### PR TITLE
Airflow image

### DIFF
--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -5,7 +5,10 @@
 #
 # 2022.01.20: Some components (e.g. airflow triggerer) require python 3.7+
 #
-FROM apache/airflow:2.2.3-python3.8
+ARG PRODUCT=2.2.3
+ARG PYTHON=3.8
+
+FROM apache/airflow:$PRODUCT-python$PYTHON
 LABEL maintainer="Stackable GmbH"
 
-ARG PRODUCT
+

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -1,0 +1,13 @@
+#
+# We use the official Airflow image here instead of building our own from scratch
+# to avoid having to deal with python dependencies and Nexus integration. We might
+# change this in the future.
+#
+# 2022.01.20: Some components (e.g. airflow triggerer) require python 3.7+
+#
+FROM apache/airflow:2.2.3-python3.8
+LABEL maintainer="Stackable GmbH"
+
+ARG PRODUCT
+
+COPY airflow/stackable/airflow_config.py /app/pythonpath/

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -9,5 +9,3 @@ FROM apache/airflow:2.2.3-python3.8
 LABEL maintainer="Stackable GmbH"
 
 ARG PRODUCT
-
-COPY airflow/stackable/airflow_config.py /app/pythonpath/

--- a/airflow/stackable/airflow_config.py
+++ b/airflow/stackable/airflow_config.py
@@ -1,4 +1,0 @@
-import os
-
-SECRET_KEY = os.environ.get("SECRET_KEY")
-SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")

--- a/airflow/stackable/airflow_config.py
+++ b/airflow/stackable/airflow_config.py
@@ -1,0 +1,4 @@
+import os
+
+SECRET_KEY = os.environ.get("SECRET_KEY")
+SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")

--- a/conf.py
+++ b/conf.py
@@ -75,7 +75,12 @@ products = [
     },
     {
         'name': 'airflow',
-    	'versions': ['2.2.3'],
+        'versions': [
+            {
+                'product': '2.2.3',
+                'python': '3.8',
+            },
+        ]
     },
     {
         # ZooKeeper must be at least 3.5.0

--- a/conf.py
+++ b/conf.py
@@ -74,6 +74,10 @@ products = [
         'versions': ['0.1.0'],
     },
     {
+        'name': 'airflow',
+    	'versions': ['2.2.3'],
+    },
+    {
         # ZooKeeper must be at least 3.5.0
         'name': 'zookeeper',
         'versions': ['3.5.8', '3.6.3', '3.7.0'],


### PR DESCRIPTION
- Airflow image for use with the airflow operator
- Uses a standard apache/airflow image with default versions (airflow + python) which can be overridden with the build script
- Defaults to airflow 2.2.3 and python 3.8 (some airflow components require at least python 3.7)
- Build tested locally with docker and helm