### PR TITLE
Adds OpenSSL and bcrypt to nifi image

### DIFF
--- a/nifi/Dockerfile
+++ b/nifi/Dockerfile
@@ -7,8 +7,13 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN microdnf update && \
     microdnf install java-11-openjdk-headless --nodocs && \
     microdnf install tar gzip zip && \
-    microdnf install shadow-utils && \
+    microdnf install shadow-utils openssl && \
     microdnf clean all
+
+# A bcrypt tool is needed to locally encrypt the admin password that is mounted as a secret into config files
+RUN curl -L https://github.com/bitnami/bcrypt-cli/releases/download/v1.0.2/bcrypt-linux-amd64.tar.gz | tar -xzC . && \
+    mv bcrypt-linux-amd64 /bin/bcrypt && \
+    chmod +x /bin/bcrypt
 
 ENV JAVA_HOME=/usr/lib/jvm/jre-11
 


### PR DESCRIPTION
During the init phase of NiFi containers two additional tools are required to prepare the envionment:
- OpenSSL to prepare the keystore used for TLS
- bcrypt which is used to encrypt the admin password from a secret and insert it into the config file

As bcrypt tool I have chosen https://github.com/bitnami/bcrypt-cli mostly because it does not require python, node or any other heavyweight dependency.

I contemplated writing our own tool in Rust which would have been something like 50 lines, but saw no real benefit in this.