### PR TITLE
Adds installation of openssl and bcrypt to tools image.

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -5,8 +5,13 @@ LABEL maintainer="Stackable GmbH"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN microdnf update && \
-    microdnf install tar gzip zip shadow-utils curl && \
+    microdnf install tar gzip zip shadow-utils curl openssl && \
     microdnf clean all
+
+# The bcrypt tool is needed by NiFi to locally encrypt the admin password that is mounted as a secret in cleartext
+RUN curl -L https://github.com/bitnami/bcrypt-cli/releases/download/v1.0.2/bcrypt-linux-amd64.tar.gz | tar -xzC . && \
+    mv bcrypt-linux-amd64 /bin/bcrypt && \
+    chmod +x /bin/bcrypt
 
 RUN groupadd -r stackable --gid=1000 && \
     useradd -r -g stackable --uid=1000 stackable && \

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="Stackable GmbH"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN microdnf update && \
+    microdnf install java-11-openjdk-headless --nodocs && \
     microdnf install tar gzip zip shadow-utils curl openssl && \
     microdnf clean all
 


### PR DESCRIPTION
During the init phase of NiFi pods two additional tools are required to prepare the envionment:
- OpenSSL to prepare the keystore used for TLS
- bcrypt which is used to encrypt the admin password from a secret and insert it into the config file

As bcrypt tool I have chosen https://github.com/bitnami/bcrypt-cli mostly because it does not require python, node or any other heavyweight dependency.

I contemplated writing our own tool in Rust which would have been something like 50 lines, but saw no real benefit in this.