### PR TITLE
Parameterize the base image tag of the Superset dockerfile

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -63,7 +63,12 @@ products = [
     },
     {
         'name': 'superset',
-        'versions': ['1.3.2'],
+        'versions': [
+            {
+                'product': '1.3.2',
+                '_base_image_tag': '9515ba68dc560307758774d1618c885e379d2011',
+            },
+        ],
     },
     {
         'name': 'trino',

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -1,14 +1,11 @@
-#
 # We use the official Superset image here instead of building our own from scratch
 # to avoid having to deal with python dependencies and Nexus integration. We might
 # change this in the future.
-#
-# 2021.11.02: The image tag below has the same digest as the 'latest' tag at the
-#             time of writing this Dockerfile.
-#
-FROM apache/superset:9515ba68dc560307758774d1618c885e379d2011
-LABEL maintainer="Stackable GmbH"
 
 ARG PRODUCT
+ARG _BASE_IMAGE_TAG
+
+FROM apache/superset:$_BASE_IMAGE_TAG
+LABEL maintainer="Stackable GmbH"
 
 COPY superset/stackable/superset_config.py /app/pythonpath/


### PR DESCRIPTION
The base image tag for the Superset dockerfile is now parameterized and must be set in the configuration file for every Superset version.

The Stackable Superset image uses the official Superset image as base. The official images are not tagged properly. They use commit hashes as tags. The base image tag is not a dependency (like a Python or Scala version), so it should not be appended to the image tag. This is solved by prefixing the version item containing the base image tag with an underscore. Version items prefixed with an underscore are now only available as build arguments in the Dockerfile but not recognized as dependencies.

Closes #35 