### PR TITLE
Enable statsd logging in Superset

### DIFF
--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -8,4 +8,6 @@ ARG _BASE_IMAGE_TAG
 FROM apache/superset:$_BASE_IMAGE_TAG
 LABEL maintainer="Stackable GmbH"
 
+RUN pip install statsd
+
 COPY superset/stackable/superset_config.py /app/pythonpath/

--- a/superset/stackable/superset_config.py
+++ b/superset/stackable/superset_config.py
@@ -1,4 +1,6 @@
 import os
+from superset.stats_logger import StatsdStatsLogger
 
 SECRET_KEY = os.environ.get("SECRET_KEY")
 SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")
+STATS_LOGGER = StatsdStatsLogger(host='0.0.0.0', port=9125)


### PR DESCRIPTION
Enable statsd logging in Superset.

This is needed for stackabletech/superset-operator#128.