### PR TITLE
hbase-image: add support for 2.4.9

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -12,7 +12,7 @@ products = [
     },
     {
         'name': 'hbase',
-        'versions': ['2.4.6', '2.4.8'],
+        'versions': ['2.4.6', '2.4.8', '2.4.9'],
     },
     {
         'name': 'hive',

--- a/hbase/CHANGELOG.md
+++ b/hbase/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- HBase 2.4.9 added ([#XXX]).
+- HBase 2.4.9 added ([#57]).
 
 
-[#XXX]: https://github.com/stackabletech/docker-images/pull/XXX
+[#57]: https://github.com/stackabletech/docker-images/pull/57

--- a/hbase/CHANGELOG.md
+++ b/hbase/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## [hbase-stackable0.3.0] - 2022-02-22
+
+### Added
+
+- HBase 2.4.9 added ([#XXX]).
+
+
+[#XXX]: https://github.com/stackabletech/docker-images/pull/XXX


### PR DESCRIPTION
- Add HBase 2.4.9
- Add changelog
- Linked to: https://github.com/stackabletech/hbase-operator/issues/120
