### PR TITLE
java-base image for 1.8.0 and 11

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -46,7 +46,7 @@ products = [
             {
                 'product': '1.8.0',
                 '_security_path': '/usr/lib/jvm/jre-1.8.0/lib/security/java.security',
-             },
+            },
             {
                 'product': '11',
                 '_security_path': '/usr/lib/jvm/jre-11/conf/security/java.security',

--- a/conf.py
+++ b/conf.py
@@ -41,6 +41,19 @@ products = [
         'versions': ['2.3.9'],
     },
     {
+        'name': 'java-base',
+        'versions': [
+            {
+                'product': '1.8.0',
+                '_security_path': '/usr/lib/jvm/jre-1.8.0/lib/security/java.security',
+             },
+            {
+                'product': '11',
+                '_security_path': '/usr/lib/jvm/jre-11/conf/security/java.security',
+            },
+        ],
+    },
+    {
         'name': 'kafka',
         'versions': [
             {

--- a/java-base/Dockerfile
+++ b/java-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 LABEL maintainer="Stackable GmbH"
 
 # https://github.com/hadolint/hadolint/wiki/DL4006

--- a/java-base/Dockerfile
+++ b/java-base/Dockerfile
@@ -1,0 +1,16 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+LABEL maintainer="Stackable GmbH"
+
+# https://github.com/hadolint/hadolint/wiki/DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG PRODUCT
+ARG _SECURITY_PATH
+
+RUN microdnf update && \
+    microdnf install java-${PRODUCT}-openjdk-headless --nodocs && \
+    microdnf clean all
+
+ENV JAVA_HOME=/usr/lib/jvm/jre-${PRODUCT}
+
+RUN echo "networkaddress.cache.ttl=5" >> $_SECURITY_PATH


### PR DESCRIPTION
Adds a Java base image (currently for 1.8.0 and 11) to be used in the operator images depending on java.

precondition for https://github.com/stackabletech/docker-images/issues/79