### PR TITLE
Remove Superset configuration

### DIFF
--- a/.github/workflows/reviewdog.yaml
+++ b/.github/workflows/reviewdog.yaml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # tag=v3.0.0
-      - uses: reviewdog/action-markdownlint@cde85f41b4dd6196b9997b677bbb1640f0e693c3 # renovate: tag=v0.3
+      - uses: reviewdog/action-markdownlint@80ee585e1abc8c910891110289a9abbb52bd35df # tag=v0.5.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -65,6 +65,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # tag=v3.0.0
-      - uses: reviewdog/action-yamllint@21974b17ac095af86ed938bcc1eb59ce08432b97 # renovate: tag=v1.4.0
+      - uses: reviewdog/action-yamllint@efeccedfc67c3b74c89e233cd61c8133784b82e0 # tag=v1.5.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/superset/CHANGELOG.md
+++ b/superset/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [superset-stackable0.4.0] - unreleased
+
+### Removed
+
+- Custom Superset configuration removed.
+
 ## [superset-stackable0.3.0] - 2022-02-21
 
 ### Added

--- a/superset/CHANGELOG.md
+++ b/superset/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## [superset-stackable0.4.0] - unreleased
+## [superset-stackable0.4.0] - 2022-04-14
 
 ### Removed
 
-- Custom Superset configuration removed.
+- Custom Superset configuration removed ([#85]).
+
+[#85]: https://github.com/stackabletech/docker-images/pull/85
 
 ## [superset-stackable0.3.0] - 2022-02-21
 

--- a/superset/CHANGELOG.md
+++ b/superset/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## [superset-stackable0.4.0] - 2022-04-14
+## [superset-stackable1.0.0] - 2022-04-14
 
 ### Removed
 
-- Custom Superset configuration removed ([#85]).
+- BREAKING: Custom Superset configuration removed ([#85]).
 
 [#85]: https://github.com/stackabletech/docker-images/pull/85
 

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -15,5 +15,3 @@ RUN apt update &&\
 USER superset
 
 RUN pip install statsd python-ldap
-
-COPY superset/stackable/superset_config.py /app/pythonpath/

--- a/superset/stackable/superset_config.py
+++ b/superset/stackable/superset_config.py
@@ -1,6 +1,0 @@
-import os
-from superset.stats_logger import StatsdStatsLogger
-
-SECRET_KEY = os.environ.get("SECRET_KEY")
-SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")
-STATS_LOGGER = StatsdStatsLogger(host='0.0.0.0', port=9125)


### PR DESCRIPTION
Static Superset configuration removed because it is now provided in a config map.

see stackabletech/superset-operator#173