### PR TITLE
Set version label in Superset image

### DIFF
--- a/superset/CHANGELOG.md
+++ b/superset/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## [superset-stackable2.0.0] - 2022-04-28
+## [superset-stackable2.0.1] - 2022-05-03
+
+### Fixed
+
+- Version label set ([#108]).
+
+[#108]: https://github.com/stackabletech/docker-images/pull/108
+
+## [superset-stackable2.0.0] - 2022-05-02
 
 ### Changed
 

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -41,6 +41,7 @@ RUN microdnf update \
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 
+ARG PRODUCT
 ARG PYTHON
 ARG RELEASE=1
 


### PR DESCRIPTION
Set version label in Superset image

The version label was empty due to a missing `ARG` instruction in the Dockerfile.