### PR TITLE
Add Python package pydruid to Superset image

### DIFF
--- a/superset/CHANGELOG.md
+++ b/superset/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [superset-stackable2.1.0] - 2022-05-04
+
+### Added
+
+- Python package pydruid added ([#110]).
+
+[#110]: https://github.com/stackabletech/docker-images/pull/110
+
 ## [superset-stackable2.0.1] - 2022-05-03
 
 ### Fixed

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -35,6 +35,7 @@ RUN microdnf update \
         gevent \
         psycopg2-binary \
         statsd \
+        pydruid \
         python-ldap
 
 # Final image


### PR DESCRIPTION
Add Python package pydruid to Superset image

This package contains a database driver which is necessary for Superset to connect to Apache Druid.