### PR TITLE
Remove dependency versions from Docker image tags

### DIFF
--- a/build_product_images.py
+++ b/build_product_images.py
@@ -52,38 +52,19 @@ def build_image_tags(image_name, image_version, product_version):
     """
     Returns a list of --tag command line arguments that are used by the
     docker build command.
-    Each image is tagged with three tags as follows:
-        1. <product>-<dependency1>-<dependency2>...-<image>
-        2. <product>-<dependency1>-<dependency2>...-<platform>
-        3. <product>-<platform>
-
-    Product version items starting with an underscore are not appended as
-    dependencies.
+    Each image is tagged with two tags as follows:
+        1. <product>-<image>
+        2. <product>-<platform>
     """
-    result = []
 
     platform_version = re.search(r'^\d+', image_version)[0]
-
     if isinstance(product_version, dict):
-        dep_versions = [f'{key}{value}' for key, value in product_version.items() if key != "product" and not key.startswith('_')]
-        image_tag = "-".join([product_version['product'], *dep_versions, f'stackable{image_version}'])
-        platform_tag = "-".join([product_version['product'], *dep_versions, f'stackable{platform_version}'])
-        latest_tag = "-".join([product_version['product'], f'stackable{platform_version}'])
+        product_version = product_version['product']
 
-        result.extend([
-            '-t', f'{image_name}:{image_tag}',
-            '-t', f'{image_name}:{platform_tag}',
-            '-t', f'{image_name}:{latest_tag}'
-            ])
-
-    elif isinstance(product_version, str):
-        result.extend([
-            '-t', f'{image_name}:{product_version}-stackable{image_version}',
-            '-t', f'{image_name}:{product_version}-stackable{platform_version}'])
-    else:
-        raise ValueError(f'Unsupported version object: {product_version}')
-
-    return result
+    return [
+        '-t', f'{image_name}:{product_version}-stackable{image_version}',
+        '-t', f'{image_name}:{product_version}-stackable{platform_version}',
+    ]
 
 def build_and_publish_image(args, products):
     """


### PR DESCRIPTION
This is tracked as part of the image/platform version anyway, and was a weird detail to require users to configure manually.

We could keep building the dep-tagged images as well as a fallback, but this doesn't seem worthwhile when they were never used anyway.

This applies to many of the ADR018 PRs already created, such as https://github.com/stackabletech/druid-operator/pull/238 and https://github.com/stackabletech/airflow-operator/pull/106.