### PR TITLE
Disable Java's DNS cache

### DIFF
--- a/java-base/Dockerfile
+++ b/java-base/Dockerfile
@@ -23,4 +23,7 @@ COPY java-base/licenses /licenses
 
 ENV JAVA_HOME=/usr/lib/jvm/jre-${PRODUCT}
 
-RUN echo "networkaddress.cache.ttl=5" >> $_SECURITY_PATH
+# Some uses (such as Kerberos or TLS client hostname verification) requires
+# up-to-date reverse DNS information, especially when workloads migrate
+# between Nodes and/or switch Pod IPs
+RUN echo "networkaddress.cache.ttl=0\nnetworkaddress.cache.negative.ttl=0" >> $_SECURITY_PATH

--- a/java-base/Dockerfile
+++ b/java-base/Dockerfile
@@ -26,4 +26,4 @@ ENV JAVA_HOME=/usr/lib/jvm/jre-${PRODUCT}
 # Some uses (such as Kerberos or TLS client hostname verification) requires
 # up-to-date reverse DNS information, especially when workloads migrate
 # between Nodes and/or switch Pod IPs
-RUN echo "networkaddress.cache.ttl=0\nnetworkaddress.cache.negative.ttl=0" >> $_SECURITY_PATH
+RUN printf "networkaddress.cache.ttl=0\nnetworkaddress.cache.negative.ttl=0\n" >> $_SECURITY_PATH

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -16,7 +16,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN microdnf update && \
     microdnf install tar gzip zip && \
-    microdnf install shadow-utils && \
+    microdnf install shadow-utils openssl && \
     microdnf clean all
 
 COPY zookeeper/stackable /stackable


### PR DESCRIPTION
This will be an issue for Kerberos, and has also caused problems for ZooKeeper's quorum TLS mode, which validates reverse DNS for ensemble peers.