### PR TITLE
Remove hard-coded hadoop version for Hive. Leftover from #149

### DIFF
--- a/hive/Dockerfile
+++ b/hive/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.stackable.tech/stackable/java-base:11-stackable0
 
 ARG PRODUCT
-ARG HADOOP=2.10.1
+ARG HADOOP
 ARG RELEASE="1"
 
 LABEL name="Apache Hive" \


### PR DESCRIPTION
I think we need to remove this as well