### PR TITLE
Cross-platform building

### DIFF
--- a/.github/workflows/product_images.yml
+++ b/.github/workflows/product_images.yml
@@ -108,6 +108,7 @@ jobs:
         shell: bash
         run: python build_product_images.py -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a linux/amd64 -u
 
+      -
         name: Build and push images (multi arch)
         shell: bash
         run: python build_product_images.py -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION"  -o stackable-experimental -a linux/amd64 -u

--- a/.github/workflows/product_images.yml
+++ b/.github/workflows/product_images.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   reject_illegal_tags:
-    if: ${{ github.event.intputs.product }} = ''
+    if: ${{ github.event_name == 'push' }}
     name: Check if tag adheres to format 'productx.y.z-stackablea.b.c'
     runs-on: ubuntu-latest
     outputs:
@@ -42,7 +42,7 @@ jobs:
           [[ "$TAGNAME" =~ ^kafka|zookeeper|nifi|druid|opa|hive|hbase|hadoop|trino|airflow|superset|spark-k8s|pyspark-k8s|tools|.+-stackable\d+\.\d+\.\d+ ]] && echo "${TAGNAME}" valid || exit 255
 
   parse_tag:
-    if: ${{ github.event.intputs.product }} = ''
+    if: ${{ github.event_name == 'push' }}
     name: Extract product, version and imageversion from tag name
     runs-on: ubuntu-latest
     needs:
@@ -121,11 +121,11 @@ jobs:
       -
         name: Build and push images
         shell: bash
-        if: ${{ github.event.intputs.product }} = ''
+        if: ${{ github.event_name == 'push' }}
         run: python build_product_images.py -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a linux/arm64 linux/amd64 -u
 
       -
         name: Build and push images on dispatch
         shell: bash
-        if: ${{ github.event.intputs.tags }} != ''
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: python build_product_images.py -p ${{ github.event.inputs.product }} -v ${{ github.event.inputs.product-version }} -i ${{ github.event.inputs.image-version }} -o ${{ github.event.inputs.organization }} -a linux/arm64 linux/amd64 -u

--- a/.github/workflows/product_images.yml
+++ b/.github/workflows/product_images.yml
@@ -102,7 +102,7 @@ jobs:
         name: Build and push images (amd64)
         shell: bash
         run: python build_product_images.py -u -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a amd64
- 
+
       -
         name: Build and push images (arm64)
         shell: bash

--- a/.github/workflows/product_images.yml
+++ b/.github/workflows/product_images.yml
@@ -102,7 +102,8 @@ jobs:
         name: Build and push images (amd64)
         shell: bash
         run: python build_product_images.py -u -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a amd64
-        
+      
+      -
         name: Build and push images (arm64)
         shell: bash
         run: python build_product_images.py -u -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a arm64

--- a/.github/workflows/product_images.yml
+++ b/.github/workflows/product_images.yml
@@ -1,3 +1,4 @@
+---
 name: Product images
 
 on:
@@ -103,6 +104,10 @@ jobs:
           password: ${{ secrets.NEXUS_PASSWORD }}
 
       -
-        name: Build and push images
+        name: Build and push images (single arch)
         shell: bash
-        run: python build_product_images.py -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a linux/arm64 linux/amd64 -u
+        run: python build_product_images.py -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a linux/amd64 -u
+
+        name: Build and push images (multi arch)
+        shell: bash
+        run: python build_product_images.py -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION"  -o stackable-experimental -a linux/amd64 -u

--- a/.github/workflows/product_images.yml
+++ b/.github/workflows/product_images.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   reject_illegal_tags:
-    if: ${{ github.event.intputs.product }} = '' 
+    if: ${{ github.event.intputs.product }} = ''
     name: Check if tag adheres to format 'productx.y.z-stackablea.b.c'
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/product_images.yml
+++ b/.github/workflows/product_images.yml
@@ -102,4 +102,3 @@ jobs:
         name: Build and push images
         shell: bash
         run: python build_product_images.py -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -m
-

--- a/.github/workflows/product_images.yml
+++ b/.github/workflows/product_images.yml
@@ -81,6 +81,10 @@ jobs:
         uses: actions/checkout@v3
 
       -
+        name: Set up QEMU for multiarch builds
+        uses: docker/setup-qemu-action@v2
+
+      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 

--- a/.github/workflows/product_images.yml
+++ b/.github/workflows/product_images.yml
@@ -101,4 +101,4 @@ jobs:
       -
         name: Build and push images
         shell: bash
-        run: python build_product_images.py -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a linux/arm64,linux/amd64 -u -m
+        run: python build_product_images.py -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a linux/arm64 linux/amd64 -u

--- a/.github/workflows/product_images.yml
+++ b/.github/workflows/product_images.yml
@@ -99,8 +99,10 @@ jobs:
           password: ${{ secrets.NEXUS_PASSWORD }}
 
       -
-        name: Build and push images
+        name: Build and push images (amd64)
         shell: bash
-        run: |
-          python build_product_images.py -u -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a amd64
-          python build_product_images.py -u -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a arm64
+        run: python build_product_images.py -u -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a amd64
+        
+        name: Build and push images (arm64)
+        shell: bash
+        run: python build_product_images.py -u -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a arm64

--- a/.github/workflows/product_images.yml
+++ b/.github/workflows/product_images.yml
@@ -102,7 +102,7 @@ jobs:
         name: Build and push images (amd64)
         shell: bash
         run: python build_product_images.py -u -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a amd64
-      
+ 
       -
         name: Build and push images (arm64)
         shell: bash

--- a/.github/workflows/product_images.yml
+++ b/.github/workflows/product_images.yml
@@ -111,4 +111,4 @@ jobs:
       -
         name: Build and push images (multi arch)
         shell: bash
-        run: python build_product_images.py -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION"  -o stackable-experimental -a linux/amd64 -u
+        run: python build_product_images.py -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION"  -o stackable-experimental -a linux/amd64 linux/arm64 -u

--- a/.github/workflows/product_images.yml
+++ b/.github/workflows/product_images.yml
@@ -101,6 +101,6 @@ jobs:
       -
         name: Build and push images
         shell: bash
-        run: | 
-          python build_product_images.py -u -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a amd64 
+        run: |
+          python build_product_images.py -u -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a amd64
           python build_product_images.py -u -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a arm64

--- a/.github/workflows/product_images.yml
+++ b/.github/workflows/product_images.yml
@@ -101,4 +101,6 @@ jobs:
       -
         name: Build and push images
         shell: bash
-        run: python build_product_images.py -u -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION"
+        run: | 
+          python build_product_images.py -u -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a amd64 
+          python build_product_images.py -u -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a arm64

--- a/.github/workflows/product_images.yml
+++ b/.github/workflows/product_images.yml
@@ -4,9 +4,24 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
+    inputs:
+      product:
+        description: 'Product to build'
+        required: true
+      product-version:
+        description: 'Productversion'
+        required: true
+      image-version:
+        description: 'Imageversion'
+        default: '0'
+      organization:
+        description: 'Organization of the image'
+        default: 'stackable'
 
 jobs:
   reject_illegal_tags:
+    if: "${{ github.event.intputs.product = '' }}"
     name: Check if tag adheres to format 'productx.y.z-stackablea.b.c'
     runs-on: ubuntu-latest
     outputs:
@@ -27,6 +42,7 @@ jobs:
           [[ "$TAGNAME" =~ ^kafka|zookeeper|nifi|druid|opa|hive|hbase|hadoop|trino|airflow|superset|spark-k8s|pyspark-k8s|tools|.+-stackable\d+\.\d+\.\d+ ]] && echo "${TAGNAME}" valid || exit 255
 
   parse_tag:
+    if: "${{ github.event.intputs.product = '' }}"
     name: Extract product, version and imageversion from tag name
     runs-on: ubuntu-latest
     needs:
@@ -105,4 +121,11 @@ jobs:
       -
         name: Build and push images
         shell: bash
+        if: "${{ github.event.intputs.product = '' }}"
         run: python build_product_images.py -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a linux/arm64 linux/amd64 -u
+
+      -
+        name: Build and push images on dispatch
+        shell: bash
+        if: "${{ github.event.intputs.tags != '' }}"
+        run: python build_product_images.py -p ${{ github.event.inputs.product }} -v ${{ github.event.inputs.product-version }} -i ${{ github.event.inputs.image-version }} -o ${{ github.event.inputs.organization }} -a linux/arm64 linux/amd64 -u

--- a/.github/workflows/product_images.yml
+++ b/.github/workflows/product_images.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   reject_illegal_tags:
-    if: "${{ github.event.intputs.product = '' }}"
+    if: ${{ github.event.intputs.product }} = '' 
     name: Check if tag adheres to format 'productx.y.z-stackablea.b.c'
     runs-on: ubuntu-latest
     outputs:
@@ -42,7 +42,7 @@ jobs:
           [[ "$TAGNAME" =~ ^kafka|zookeeper|nifi|druid|opa|hive|hbase|hadoop|trino|airflow|superset|spark-k8s|pyspark-k8s|tools|.+-stackable\d+\.\d+\.\d+ ]] && echo "${TAGNAME}" valid || exit 255
 
   parse_tag:
-    if: "${{ github.event.intputs.product = '' }}"
+    if: ${{ github.event.intputs.product }} = ''
     name: Extract product, version and imageversion from tag name
     runs-on: ubuntu-latest
     needs:
@@ -121,11 +121,11 @@ jobs:
       -
         name: Build and push images
         shell: bash
-        if: "${{ github.event.intputs.product = '' }}"
+        if: ${{ github.event.intputs.product }} = ''
         run: python build_product_images.py -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a linux/arm64 linux/amd64 -u
 
       -
         name: Build and push images on dispatch
         shell: bash
-        if: "${{ github.event.intputs.tags != '' }}"
+        if: ${{ github.event.intputs.tags }} != ''
         run: python build_product_images.py -p ${{ github.event.inputs.product }} -v ${{ github.event.inputs.product-version }} -i ${{ github.event.inputs.image-version }} -o ${{ github.event.inputs.organization }} -a linux/arm64 linux/amd64 -u

--- a/.github/workflows/product_images.yml
+++ b/.github/workflows/product_images.yml
@@ -101,4 +101,4 @@ jobs:
       -
         name: Build and push images
         shell: bash
-        run: python build_product_images.py -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -m -u
+        run: python build_product_images.py -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a linux/arm64,linux/amd64 -u -m

--- a/.github/workflows/product_images.yml
+++ b/.github/workflows/product_images.yml
@@ -99,11 +99,7 @@ jobs:
           password: ${{ secrets.NEXUS_PASSWORD }}
 
       -
-        name: Build and push images (amd64)
+        name: Build and push images
         shell: bash
-        run: python build_product_images.py -u -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a amd64
+        run: python build_product_images.py -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -m
 
-      -
-        name: Build and push images (arm64)
-        shell: bash
-        run: python build_product_images.py -u -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a arm64

--- a/.github/workflows/product_images.yml
+++ b/.github/workflows/product_images.yml
@@ -4,24 +4,9 @@ on:
   push:
     tags:
       - '*'
-  workflow_dispatch:
-    inputs:
-      product:
-        description: 'Product to build'
-        required: true
-      product-version:
-        description: 'Productversion'
-        required: true
-      image-version:
-        description: 'Imageversion'
-        default: '0'
-      organization:
-        description: 'Organization of the image'
-        default: 'stackable'
 
 jobs:
   reject_illegal_tags:
-    if: ${{ github.event_name == 'push' }}
     name: Check if tag adheres to format 'productx.y.z-stackablea.b.c'
     runs-on: ubuntu-latest
     outputs:
@@ -42,7 +27,6 @@ jobs:
           [[ "$TAGNAME" =~ ^kafka|zookeeper|nifi|druid|opa|hive|hbase|hadoop|trino|airflow|superset|spark-k8s|pyspark-k8s|tools|.+-stackable\d+\.\d+\.\d+ ]] && echo "${TAGNAME}" valid || exit 255
 
   parse_tag:
-    if: ${{ github.event_name == 'push' }}
     name: Extract product, version and imageversion from tag name
     runs-on: ubuntu-latest
     needs:
@@ -121,11 +105,4 @@ jobs:
       -
         name: Build and push images
         shell: bash
-        if: ${{ github.event_name == 'push' }}
         run: python build_product_images.py -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -a linux/arm64 linux/amd64 -u
-
-      -
-        name: Build and push images on dispatch
-        shell: bash
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: python build_product_images.py -p ${{ github.event.inputs.product }} -v ${{ github.event.inputs.product-version }} -i ${{ github.event.inputs.image-version }} -o ${{ github.event.inputs.organization }} -a linux/arm64 linux/amd64 -u

--- a/.github/workflows/product_images.yml
+++ b/.github/workflows/product_images.yml
@@ -101,4 +101,4 @@ jobs:
       -
         name: Build and push images
         shell: bash
-        run: python build_product_images.py -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -m
+        run: python build_product_images.py -p "$PRODUCT" -v "$PRODUCTVERSION" -i "$IMAGEVERSION" -m -u

--- a/.github/workflows/product_images_dispatch.yml
+++ b/.github/workflows/product_images_dispatch.yml
@@ -1,23 +1,24 @@
+---
 name: Product images workflow_dispatch
 
 on:
   workflow_dispatch:
-      inputs:
-        product:
-          description: 'Product to build'
-          required: true
-        product-version:
-          description: 'Productversion'
-          required: true
-        image-version:
-          description: 'Imageversion'
-          default: '0'
-        organization:
-          description: 'Organization of the image'
-          default: 'stackable'
-        architecture:
-          description: 'Target architecture to build, multi arch is defualt'
-          default: 'linux/arm64 linux/amd64'
+    inputs:
+      product:
+        description: 'Product to build'
+        required: true
+      product-version:
+        description: 'Productversion'
+        required: true
+      image-version:
+        description: 'Imageversion'
+        default: '0'
+      organization:
+        description: 'Organization of the image'
+        default: 'stackable'
+      architecture:
+        description: 'Target architecture to build, multi arch is defualt'
+        default: 'linux/arm64 linux/amd64'
 
 jobs:
   build:

--- a/.github/workflows/product_images_dispatch.yml
+++ b/.github/workflows/product_images_dispatch.yml
@@ -1,0 +1,58 @@
+name: Product images workflow_dispatch
+
+on:
+  workflow_dispatch:
+      inputs:
+        product:
+          description: 'Product to build'
+          required: true
+        product-version:
+          description: 'Productversion'
+          required: true
+        image-version:
+          description: 'Imageversion'
+          default: '0'
+        organization:
+          description: 'Organization of the image'
+          default: 'stackable'
+        architecture:
+          descritption: 'Target architecture to build, multi arch is defualt'
+          default: 'linux/arm64 linux/amd64'
+
+jobs:
+  build:
+    name: Build product images for ${{ github.event.inputs.product }}
+    runs-on: ubuntu-latest
+
+    steps:
+
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+
+      -
+        name: Set up QEMU for multiarch builds
+        uses: docker/setup-qemu-action@v2
+
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      -
+        name: Install python 3
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      -
+        name: Login to Stackable Nexus
+        uses: docker/login-action@v2
+        with:
+          registry: docker.stackable.tech
+          username: github
+          password: ${{ secrets.NEXUS_PASSWORD }}
+
+      -
+        name: Build and push images on dispatch
+        shell: bash
+        run: python build_product_images.py -p ${{ github.event.inputs.product }} -v ${{ github.event.inputs.product-version }} -i ${{ github.event.inputs.image-version }} -o ${{ github.event.inputs.organization }} -a ${{ github.event.inputs.architecture }} -u

--- a/.github/workflows/product_images_dispatch.yml
+++ b/.github/workflows/product_images_dispatch.yml
@@ -16,14 +16,13 @@ on:
           description: 'Organization of the image'
           default: 'stackable'
         architecture:
-          descritption: 'Target architecture to build, multi arch is defualt'
+          description: 'Target architecture to build, multi arch is defualt'
           default: 'linux/arm64 linux/amd64'
 
 jobs:
   build:
     name: Build product images for ${{ github.event.inputs.product }}
     runs-on: ubuntu-latest
-
     steps:
 
       -

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -251,7 +251,7 @@ def main():
     run_commands(args.dry, commands)
 
     if len(args.architecture) > 1:
-            remove_virtual_enviroment(args)
+        remove_virtual_enviroment(args)
 
 
 if __name__ == "__main__":

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -218,7 +218,7 @@ def remove_virtual_enviroment(args):
 
 def check_architecture_input(args):
 
-    supported_arch = ["linux/amd64","linux/arm64"]
+    supported_arch = ["linux/amd64", "linux/arm64"]
 
     for target_arch in args.architecture:
         if target_arch not in supported_arch:

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -191,7 +191,7 @@ def check_architecture_input(architecture):
 
     if architecture not in supported_arch:
         raise ValueError(
-            f"Architecture {architectures} not supported. Supported: {supported_arch}"
+            f"Architecture {architecture} not supported. Supported: {supported_arch}"
         )
     
     return architecture

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -16,7 +16,6 @@ This assumes that the following images are available for target architecture:
     1. Java-Base 11, 1.8.0
     2. ubi8-rust-builder
     3. Tools 0.2.0
-
 """
 
 import conf
@@ -108,7 +107,7 @@ def build_and_publish_image(args, product):
 
     # Multiarch builds
     if args.multiarch:
-       commands.append(
+        commands.append(
             [
                 "docker",
                 "buildx",
@@ -118,12 +117,12 @@ def build_and_publish_image(args, product):
                 "-f",
                 product["name"] + "/Dockerfile",
                 "--platform",
-                "linux/amd64,linux/arm64", 
+                "linux/amd64,linux/arm64",
                 "--push",
                 ".",
             ]
         )
-    #local builds / single architecture
+    # local builds / single architecture
     else:
         commands.append(
             [
@@ -186,6 +185,7 @@ def product_to_build(product_name, product_version, products):
     else:
         return None
 
+
 """
 In generall, the following checks weather or not dependencies are available on your local machine. This is only useful if a local repository via Docker-Desktop or
 something simular is used. However, this is not checking if a dependency of certain architecutre is existent in a repository!
@@ -200,7 +200,7 @@ def check_or_build_dependencies(args, architecture, products):
     tools = False
     java = False
     rust_builder = False
-
+    
     images = client.images.list(filters={"label": "architecture=" + architecture})
     for image in images:
         for tags in image.tags:
@@ -215,7 +215,6 @@ def check_or_build_dependencies(args, architecture, products):
                 print("Found tools image")
 
     build_dependencies(java, tools, rust_builder, args, products)
-
 
 
 def build_dependencies(java, tools, rust_builder, args, products):
@@ -261,8 +260,9 @@ def check_platform(architecture):
 
 
 def create_virtual_enviroment(args):
-   
+
     commands=[]
+
     commands.append(
         [
             "docker",
@@ -281,9 +281,9 @@ def remove_virtual_enviroment(args):
     commands=[]
     commands.append(
         [
-            "docker", 
-            "buildx", 
-            "rm", 
+            "docker",
+            "buildx",
+            "rm",
             "builder"
          ]
     )

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -61,7 +61,8 @@ def parse_args():
         type=check_architecture_input
     )
     parser.add_argument(
-        "--path",
+        "-o",
+        "--organization",
         help="Define a custom location or repository",
         default="stackable"
     )

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -97,7 +97,7 @@ def build_and_publish_image(args, product):
     image_name = f'{args.registry}/stackable/{product["name"]}'
     tags = build_image_tags(image_name, args.image_version, args.product_version)
     build_args = build_image_args(product["versions"][0])
-   
+
     commands.append(
         [
             "docker",

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -24,9 +24,10 @@ Some images build on top of others. These images are used as base images and mig
     3. tools
 """
 
-import conf
+from typing import List
 import argparse
 import subprocess
+import conf
 
 
 def parse_args():
@@ -101,7 +102,7 @@ def build_image_tags(image_name, image_version, product_version):
     ]
 
 
-def build_and_publish_image(args, product) -> list[list[str]]:
+def build_and_publish_image(args, product) -> List[List[str]]:
     """
     Returns a list of commands that need to be run in order to build and
     publish product images.
@@ -145,7 +146,7 @@ def run_commands(dry, commands):
     """
     for cmd in commands:
         if dry:
-            subprocess.run(["echo", *cmd])
+            subprocess.run(["echo", *cmd], check=True)
         else:
             subprocess.run(cmd, check=True)
 
@@ -172,8 +173,8 @@ def product_to_build(product_name, product_version, products):
             "name": product_name,
             "versions": product_to_build_version,
         }
-    else:
-        return None
+
+    return None
 
 
 def create_virtual_enviroment(args):

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -175,7 +175,7 @@ def check_or_build_dependencies(args, architecture, products):
 
     # TODO: Parse more architectures (like all) | currently buildx build is not supporting multi-platform, docker buildx create --use should solve it
     # but requires more work
-    images = client.images.list(filters={"label":"architecture="+architecture})
+    images = client.images.list(filters={"label": "architecture=" + architecture})
     for image in images:
         for tags in image.tags:
             if 'java-base' in tags:

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -195,7 +195,7 @@ def check_platform(architecture):
     """
     Checks if a desired platform is given, gives current platform if not
     """
-    if architecture is None:
+    if architecture is None or len(architecture) == 0:
         architecture = ["linux/" + platform.machine()]
 
     return architecture
@@ -232,52 +232,6 @@ def remove_virtual_enviroment(args):
     run_commands(args.dry, commands)
 
 
-def join_nodes(args):
-    """
-    Takes all nodes provided and bundels them into a builder. If only one node is given, it gets used by buildx.
-    If a node given is not in context, a virtual one with the name will be created.
-
-    If a set of nodes is not in context, they will be created virtually and used by buildx
-    """
-
-    nodes = args.node.split(',')
-
-    for node in nodes:
-        commands = []
-        if node != nodes[0]:
-            commands.append(
-                [
-                    "docker",
-                    "buildx",
-                    "create",
-                    "--name",
-                    nodes[0],
-                    "--append",
-                    node
-                ]
-            )
-            run_commands(args.dry, commands)
-
-    use_builder(args)
-
-
-def use_builder(args):
-
-    nodes = args.node.split(',')
-    commands = []
-
-    commands.append(
-        [
-            "docker",
-            "buildx",
-            "use",
-            nodes[0]
-        ]
-    )
-
-    run_commands(args.dry, commands)
-
-
 def main():
     args = parse_args()
     print("Current Platform: ", platform.machine())
@@ -285,11 +239,7 @@ def main():
     args.architecture = check_platform(args.architecture)    
 
     if len(args.architecture) > 1:
-        if args.node is None:
-            create_virtual_enviroment(args)
-
-    if args.node is not None:
-        join_nodes(args)
+            create_virtual_enviroment(args)  
 
     product = product_to_build(args.product, args.product_version, conf.products)
 
@@ -304,7 +254,6 @@ def main():
     run_commands(args.dry, commands)
 
     if len(args.architecture) > 1:
-        if args.node is None:
             remove_virtual_enviroment(args)
 
 

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -17,10 +17,9 @@ This assumes that the following images are available for target architecture:
     2. ubi8-rust-builder
     3. Tools 0.2.0
 
-For native nodes, it assumes that native node exists in docker buildx context. If node is not exisiting, a virtual one will be created. 
+For native nodes, it assumes that native node exists in docker buildx context. If node is not exisiting, a virtual one will be created.
 """
 
-from venv import create
 import conf
 import argparse
 import subprocess

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -183,10 +183,10 @@ def check_or_build_dependencies(args, architecture, products):
                 print("Found java-base image")
             if 'ubi8-rust-builder' in tags:
                 rust_builder = True
-                print("Found rust builder")
+                print("Found rust builder image")
             if 'tools' in tags:
                 tools = True
-                print("Found tools")
+                print("Found tools image")
 
     build_dependencies(java, tools, rust_builder, args, products)
 
@@ -205,20 +205,20 @@ def build_dependencies(java, tools, rust_builder, args, products):
     if not java:
         args_dummy.image_version = '0'
         args_dummy.product_version = '11'
-        print('Building dependencie to Java-Base', args_dummy.product_version)
+        print('Building dependency Java-Base', args_dummy.product_version)
 
         run_commands(args_dummy.dry, build_and_publish_image(args_dummy, product_to_build('java-base', '11', products)))
 
         args_dummy.image_version = '0'
         args_dummy.product_version = '1.8.0'
-        print('Building dependencie to Java-Base', args_dummy.product_version)
+        print('Building dependency Java-Base', args_dummy.product_version)
 
         run_commands(args_dummy.dry, build_and_publish_image(args_dummy, product_to_build('java-base', '1.8.0', products)))
 
     if not tools:
         args_dummy.image_version = '0'
         args_dummy.product_version = '0.2.0'
-        print("Building dependencie to Tools", args_dummy.product_version)
+        print("Building dependency Tools", args_dummy.product_version)
 
         run_commands(args_dummy.dry, build_and_publish_image(args_dummy, product_to_build('tools', '0.2.0', products)))
 

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -191,6 +191,7 @@ In generall, the following checks weather or not dependencies are available on y
 something simular is used. However, this is not checking if a dependency of certain architecutre is existent in a repository!
 """
 
+
 def check_or_build_dependencies(args, architecture, products):
     """
     Checks if dependencies are currently build on local system, if not they get build
@@ -200,7 +201,7 @@ def check_or_build_dependencies(args, architecture, products):
     tools = False
     java = False
     rust_builder = False
-    
+
     images = client.images.list(filters={"label": "architecture=" + architecture})
     for image in images:
         for tags in image.tags:
@@ -261,7 +262,7 @@ def check_platform(architecture):
 
 def create_virtual_enviroment(args):
 
-    commands=[]
+    commands = []
 
     commands.append(
         [
@@ -278,14 +279,14 @@ def create_virtual_enviroment(args):
 
 def remove_virtual_enviroment(args):
 
-    commands=[]
+    commands = []
     commands.append(
         [
             "docker",
             "buildx",
             "rm",
             "builder"
-         ]
+        ]
     )
     run_commands(args.dry, commands)
 

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -100,7 +100,6 @@ def build_and_publish_image(args, product):
     For local building, builder instances are supported.
     """
     commands = []
-
     image_name = f'{args.registry}/stackable/{product["name"]}'
     tags = build_image_tags(image_name, args.image_version, args.product_version)
     build_args = build_image_args(product["versions"][0])

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -51,7 +51,7 @@ def parse_args():
         help="Target platform for image, Expecting -a <platform 1> <platform 2> ... At least one argument",
         nargs="+",
         required=True,
-        type = check_architecture_input
+        type=check_architecture_input
     )
     return parser.parse_args()
 

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -7,7 +7,7 @@ Usage: build_product_images.py --help
 
 Example:
 
-    build_product_images.py --product zookeeper,kafka --image_version 0.1.0 --push
+    build_product_images.py --product zookeeper,kafka --image_version 0.1.0 -a linux/amd64 -u
 
 This will build an image for each Apache ZooKeeper and Apache Kafka version configured in conf.py
 
@@ -216,9 +216,22 @@ def remove_virtual_enviroment(args):
     run_commands(args.dry, commands)
 
 
+def check_architecture_input(args):
+
+    supported_arch = ["linux/amd64","linux/arm64"]
+
+    for target_arch in args.architecture:
+        if target_arch not in supported_arch:
+            raise ValueError(
+                f"Architecture {target_arch} not supported. Supported: {supported_arch}"
+            )
+
+
 def main():
     args = parse_args()
     print("Current Platform: ", platform.machine())
+
+    check_architecture_input(args)
 
     if len(args.architecture) > 1:
         create_virtual_enviroment(args)

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -175,9 +175,9 @@ def check_or_build_dependencies(args, architecture, products):
 
     # TODO: Parse more architectures (like all) | currently buildx build is not supporting multi-platform, docker buildx create --use should solve it
     # but requires more work
-    images=client.images.list(filters={"label":"architecture="+architecture})
-    for image in images: 
-        for tags in image.tags: 
+    images = client.images.list(filters={"label":"architecture="+architecture})
+    for image in images:
+        for tags in image.tags:
             if 'java-base' in tags:
                 java = True
                 print("Found java-base image")

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -99,7 +99,7 @@ def build_and_publish_image(args, product):
     tags = build_image_tags(image_name, args.image_version, args.product_version)
     build_args = build_image_args(product["versions"][0])
 
-    # This is a ugly hack because currently we run into the problem that java-base and tools can not be passed with --platform 
+    # This is a ugly hack because currently we run into the problem that java-base and tools can not be passed with --platform
     if product["name"] == "java-base" or product["name"] == "tools":
         cross_platform = ""
 
@@ -162,7 +162,7 @@ def product_to_build(product_name, product_version, products):
         return None
 
 
-#Checks and dependencies for cross platform compiling
+# Checks and dependencies for cross platform compiling
 def check_or_build_dependencies(args, architecture, products):
     """
     Checks if dependencies are currently build on local system, if not they get build
@@ -171,14 +171,13 @@ def check_or_build_dependencies(args, architecture, products):
     client = docker.from_env()
     tools = False
     java = False
-    rust_builder = False 
-    args_dummy = copy.deepcopy(args)
+    rust_builder = False
 
-    #TODO: Parse more architectures (like all) | currently buildx build is not supporting multi-platform, docker buildx create --use should solve it 
+    # TODO: Parse more architectures (like all) | currently buildx build is not supporting multi-platform, docker buildx create --use should solve it
     # but requires more work
     images=client.images.list(filters={"label":"architecture="+architecture})
-    for image in images:
-        for tags in image.tags:
+    for image in images: 
+        for tags in image.tags: 
             if 'java-base' in tags:
                 java = True
                 print("Found java-base image")
@@ -190,7 +189,7 @@ def check_or_build_dependencies(args, architecture, products):
                 print("Found tools")
 
     build_dependencies(java, tools, rust_builder, args, products)
- 
+
 
 def build_dependencies(java, tools, rust_builder, args, products):
     """
@@ -203,13 +202,13 @@ def build_dependencies(java, tools, rust_builder, args, products):
         print("Building rust builder")
         subprocess.run("make")
 
-    if not java: 
+    if not java:
         args_dummy.image_version = '0'
         args_dummy.product_version = '11'
         print('Building dependencie to Java-Base', args_dummy.product_version)
 
-        run_commands(args_dummy.dry ,build_and_publish_image(args_dummy, product_to_build('java-base', '11', products)))
-        
+        run_commands(args_dummy.dry, build_and_publish_image(args_dummy, product_to_build('java-base', '11', products)))
+
         args_dummy.image_version = '0'
         args_dummy.product_version = '1.8.0'
         print('Building dependencie to Java-Base', args_dummy.product_version)
@@ -221,14 +220,14 @@ def build_dependencies(java, tools, rust_builder, args, products):
         args_dummy.product_version = '0.2.0'
         print("Building dependencie to Tools", args_dummy.product_version)
 
-        run_commands(args_dummy.dry ,build_and_publish_image(args_dummy, product_to_build('tools', '0.2.0', products))) 
+        run_commands(args_dummy.dry, build_and_publish_image(args_dummy, product_to_build('tools', '0.2.0', products)))
 
 
 def check_platform(architecture):
     """
     Checks if a desired platform is given, gives current platform if not
     """
-    if architecture == None:
+    if architecture is None:
         architecture = platform.machine()
 
     return architecture
@@ -236,7 +235,7 @@ def check_platform(architecture):
 
 def main():
     args = parse_args()
-    print("Current Platform: ", platform.machine() )
+    print("Current Platform: ", platform.machine())
 
     if args.check:
         check_or_build_dependencies(args, check_platform(args.architecture), conf.products)

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -45,7 +45,7 @@ def parse_args():
     )
     parser.add_argument("-u", "--push", help="Push images", action="store_true")
     parser.add_argument("-d", "--dry", help="Dry run.", action="store_true")
-    parser.add_argument("-a", "--architecture", help="Target platform for image, Expecting -a <platform 1> <platform 2> ...", nargs='+') 
+    parser.add_argument("-a", "--architecture", help="Target platform for image, Expecting -a <platform 1> <platform 2> ...", nargs='+')
     return parser.parse_args()
 
 

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -233,7 +233,7 @@ def main():
     args = parse_args()
     print("Current Platform: ", platform.machine())
 
-    args.architecture = check_platform(args.architecture)    
+    args.architecture = check_platform(args.architecture)
 
     if len(args.architecture) > 1:
         create_virtual_enviroment(args)
@@ -251,7 +251,7 @@ def main():
     run_commands(args.dry, commands)
 
     if len(args.architecture) > 1:
-        remove_virtual_enviroment(args)
+            remove_virtual_enviroment(args)
 
 
 if __name__ == "__main__":

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 """
 Build and possibly publish product images.
-but it assumes a `docker login` has been performed before.
 
 Requirements:
 

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -13,7 +13,6 @@ This will build an image for each Apache ZooKeeper and Apache Kafka version conf
 """
 
 from cProfile import label, run
-from distutils.errors import CompileError
 import conf
 import argparse
 import subprocess

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -306,14 +306,14 @@ def use_native_node(args):
 
 def append_native_node(args):
 
-    i = 0
+    i = False
     commands = []
 
     for nodes in args.node.split(','):
         commands = []
-        if i == 0:
+        if not i:
             use_native_node(args)
-            i += 1
+            i = True
         else:
             commands.append(
                 [

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -193,7 +193,7 @@ def check_architecture_input(architecture):
         raise ValueError(
             f"Architecture {architecture} not supported. Supported: {supported_arch}"
         )
-    
+
     return architecture
 
 

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -12,7 +12,7 @@ Example:
 This will build an image for each Apache ZooKeeper and Apache Kafka version configured in conf.py
 """
 
-from cProfile import label, run
+
 import conf
 import argparse
 import subprocess

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -282,23 +282,24 @@ def create_virtual_enviroment(args):
     )
     run_commands(args.dry, commands)
 
+
 def use_native_node(args):
 
     commands = []
     nodes = args.node.split(',')
 
-    assert(len(nodes) != 0)
+    assert len(nodes) != 0
 
     commands.append(
-            [
-                "docker",
-                "buildx",
-                "create",
-                "--use",
-                "--name",
-                nodes[0]
-            ]
-        )
+        [
+            "docker",
+            "buildx",
+            "create",
+            "--use",
+            "--name",
+            nodes[0]
+        ]
+    )
 
     run_commands(args.dry, commands)
 

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -1,21 +1,28 @@
 #!/usr/bin/env python
 """
-Build and possibly publish product images. It doesn't login to any registry when publishing
+Build and possibly publish product images.
 but it assumes a `docker login` has been performed before.
+
+Requirements:
+
+- Python 3
+- Docker with buildx. Installation details here: https://github.com/docker/buildx
 
 Usage: build_product_images.py --help
 
 Example:
 
-    build_product_images.py --product zookeeper,kafka --image_version 0.1.0 -a linux/amd64 -u
+    build_product_images.py --product zookeeper --product_version 3.8.0 --image_version 0.1.0 --architecture linux/amd64
 
-This will build an image for each Apache ZooKeeper and Apache Kafka version configured in conf.py
+This will build the image `docker.stackable.tech/stackable/zookeeper:3.8.0-stackable0.1.0` for the linux/amd64 architecture.
+To also push the image to a remote registry, add the the `--push` argument.
 
-Multiarchitecture builds:
-This assumes that the following images are available for target architecture:
-    1. Java-Base 11, 1.8.0
+NOTE: Pushing images to a remote registry assumes you have performed a `docker login` beforehand.
+
+Some images build on top of others. These images are used as base images and might need to be built first:
+    1. java-base
     2. ubi8-rust-builder
-    3. Tools 0.2.0
+    3. tools
 """
 
 import conf
@@ -25,7 +32,7 @@ import subprocess
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Build and publish product images. See conf.py for details regarding product versions."
+        description="Build and publish product images. Requires docker and buildx (https://github.com/docker/buildx)."
     )
     parser.add_argument(
         "-r",
@@ -204,7 +211,7 @@ def main():
 
     if product is None:
         raise ValueError(
-            f"No products configured for product {args.product} and version {args.product_version}"
+            f"No products configured for product {args.product} and version {args.product_version}. See conf.py for available products and versions."
         )
 
     if len(args.architecture) > 1:

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -50,7 +50,6 @@ def parse_args():
     parser.add_argument("-u", "--push", help="Push images", action="store_true")
     parser.add_argument("-d", "--dry", help="Dry run.", action="store_true")
     parser.add_argument("-a", "--architecture", help="Target platform for image", nargs='*')
-    parser.add_argument("-m", "--multiarch", help="Build and publish multi-architecture images", action="store_true")
     parser.add_argument("-n", "--node", help="Create nodes to a builder. First is Master.", type=str)
     return parser.parse_args()
 

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -17,9 +17,10 @@ This assumes that the following images are available for target architecture:
     2. ubi8-rust-builder
     3. Tools 0.2.0
 
-For native nodes, it assumes that native node exists in docker context ls
+For native nodes, it assumes that native node exists in docker buildx context. If node is not exisiting, a virtual one will be created. 
 """
 
+from venv import create
 import conf
 import argparse
 import subprocess
@@ -283,50 +284,18 @@ def create_virtual_enviroment(args):
     run_commands(args.dry, commands)
 
 
-"""
-def use_native_node(args):
+def remove_virtual_enviroment(args):
 
     commands = []
-    nodes = args.node.split(',')
-
-    assert len(nodes) != 0
-
     commands.append(
         [
             "docker",
             "buildx",
-            "create",
-            "--use",
-            "--name",
-            nodes[0]
+            "rm",
+            "builder"
         ]
     )
-
     run_commands(args.dry, commands)
-
-
-def create_nodes(args):
-
-    i = False
-    commands = []
-
-    for nodes in args.node.split(','):
-        commands = []
-        if not i:
-            use_native_node(args)
-            i = True
-        else:
-            commands.append(
-                [
-                    "docker",
-                    "buildx",
-                    "create",
-                    "--name",
-                    nodes
-                ]
-            )
-            run_commands(args.dry, commands)
-"""
 
 
 def join_nodes(args):
@@ -348,10 +317,8 @@ def join_nodes(args):
                 ]
             )
             run_commands(args.dry, commands)
-            use_builder(args)
 
-        elif len(nodes) == 1:
-            use_builder(args)
+    use_builder(args)
 
 
 def use_builder(args):
@@ -363,25 +330,11 @@ def use_builder(args):
         [
             "docker",
             "buildx",
-            "use", 
+            "use",
             nodes[0]
         ]
     )
 
-    run_commands(args.dry, commands)
-
-
-def remove_virtual_enviroment(args):
-
-    commands = []
-    commands.append(
-        [
-            "docker",
-            "buildx",
-            "rm",
-            "builder"
-        ]
-    )
     run_commands(args.dry, commands)
 
 
@@ -395,10 +348,9 @@ def main():
     if args.multiarch:
         if args.node is None:
             create_virtual_enviroment(args)
-            
+
     if args.node is not None:
-        #create_nodes(args)
-        join_nodes(args) 
+        join_nodes(args)
 
     product = product_to_build(args.product, args.product_version, conf.products)
 

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -60,6 +60,11 @@ def parse_args():
         required=True,
         type=check_architecture_input
     )
+    parser.add_argument(
+        "--path",
+        help="Define a custom location or repository",
+        default="stackable"
+    )
     return parser.parse_args()
 
 
@@ -109,7 +114,7 @@ def build_and_publish_image(args, product) -> List[List[str]]:
 
     For local building, builder instances are supported.
     """
-    image_name = f'{args.registry}/stackable/{product["name"]}'
+    image_name = f'{args.registry}/{args.path}/{product["name"]}'
     tags = build_image_tags(image_name, args.image_version, args.product_version)
     build_args = build_image_args(product["versions"][0])
 

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -16,8 +16,6 @@ This assumes that the following images are available for target architecture:
     1. Java-Base 11, 1.8.0
     2. ubi8-rust-builder
     3. Tools 0.2.0
-
-For native nodes, it assumes that native node exists in docker buildx context. If node is not exisiting, a virtual one will be created.
 """
 
 import conf
@@ -47,8 +45,7 @@ def parse_args():
     )
     parser.add_argument("-u", "--push", help="Push images", action="store_true")
     parser.add_argument("-d", "--dry", help="Dry run.", action="store_true")
-    parser.add_argument("-a", "--architecture", help="Target platform for image", nargs='*')
-    parser.add_argument("-n", "--node", help="Create nodes to a builder. First is Master.", type=str)
+    parser.add_argument("-a", "--architecture", help="Target platform for image, Expecting -a <platform 1> <platform 2> ...", nargs='+') 
     return parser.parse_args()
 
 

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -123,7 +123,7 @@ def build_and_publish_image(args, product):
                 "-f",
                 product["name"] + "/Dockerfile",
                 "--platform",
-                "linux/amd64,linux/arm64",
+                args.architecture,
                 push,
                 ".",
             ]
@@ -140,7 +140,7 @@ def build_and_publish_image(args, product):
                 "-f",
                 product["name"] + "/Dockerfile",
                 "--platform",
-                "linux/" + check_platform(args.architecture),
+                check_platform(args.architecture),
                 "--load",
                 ".",
             ]
@@ -200,7 +200,7 @@ something simular is used. However, this is not checking if a dependency of cert
 
 def check_or_build_dependencies(args, architecture, products):
     """
-    Checks if dependencies are currently build on local system, if not they get build
+    Checks if dependencies are currently build on local system, if not they get build. Local usage only.
     """
 
     client = docker.from_env()
@@ -226,7 +226,7 @@ def check_or_build_dependencies(args, architecture, products):
 
 def build_dependencies(java, tools, rust_builder, args, products):
     """
-    Builds neccessary dependencies for images if not available on system
+    Builds neccessary dependencies for images if not available on system. Local usage only
     """
 
     args_dummy = copy.deepcopy(args)
@@ -261,7 +261,7 @@ def check_platform(architecture):
     Checks if a desired platform is given, gives current platform if not
     """
     if architecture is None:
-        architecture = platform.machine()
+        architecture = "linux/" + platform.machine()
 
     return architecture
 
@@ -298,6 +298,12 @@ def remove_virtual_enviroment(args):
 
 
 def join_nodes(args):
+    """
+    Takes all nodes provided and bundels them into a builder. If only one node is given, it gets used by buildx.
+    If a node given is not in context, a virtual one with the name will be created.
+
+    If a set of nodes is not in context, they will be created virtually and used by buildx
+    """
 
     nodes = args.node.split(',')
 

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -122,7 +122,7 @@ def build_and_publish_image(args, product) -> list[list[str]]:
         commands.append(
             "--push",
         )
-    if len(args.architecture) == 1:
+    if not args.push and len(args.architecture) == 1:
         commands.append(
             "--load",
         )

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -25,8 +25,6 @@ import argparse
 import subprocess
 import sys
 import platform
-import docker
-import copy
 
 
 def parse_args():
@@ -53,7 +51,6 @@ def parse_args():
     parser.add_argument("-n", "--node", help="Create nodes to a builder. First is Master.", type=str)
     return parser.parse_args()
 
-# Remove -m, rather check if -a contains more platforms, -a can be a list, check up in docu
 
 def build_image_args(version):
     """
@@ -239,7 +236,7 @@ def main():
     args.architecture = check_platform(args.architecture)    
 
     if len(args.architecture) > 1:
-            create_virtual_enviroment(args)  
+        create_virtual_enviroment(args)
 
     product = product_to_build(args.product, args.product_version, conf.products)
 
@@ -254,7 +251,7 @@ def main():
     run_commands(args.dry, commands)
 
     if len(args.architecture) > 1:
-            remove_virtual_enviroment(args)
+        remove_virtual_enviroment(args)
 
 
 if __name__ == "__main__":

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -45,7 +45,7 @@ def parse_args():
     )
     parser.add_argument("-u", "--push", help="Push images", action="store_true")
     parser.add_argument("-d", "--dry", help="Dry run.", action="store_true")
-    parser.add_argument("-a", "--architecture", help="Target platform for image, Expecting -a <platform 1> <platform 2> ...", nargs='+')
+    parser.add_argument("-a", "--architecture", help="Target platform for image, Expecting -a <platform 1> <platform 2> ... At least one argument", nargs='+', required=True)
     return parser.parse_args()
 
 
@@ -185,16 +185,6 @@ def product_to_build(product_name, product_version, products):
         return None
 
 
-def check_platform(architecture):
-    """
-    Checks if a desired platform is given, gives current platform if not
-    """
-    if architecture is None or len(architecture) == 0:
-        architecture = ["linux/" + platform.machine()]
-
-    return architecture
-
-
 def create_virtual_enviroment(args):
 
     commands = []
@@ -229,8 +219,6 @@ def remove_virtual_enviroment(args):
 def main():
     args = parse_args()
     print("Current Platform: ", platform.machine())
-
-    args.architecture = check_platform(args.architecture)
 
     if len(args.architecture) > 1:
         create_virtual_enviroment(args)

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -51,6 +51,7 @@ def parse_args():
         help="Target platform for image, Expecting -a <platform 1> <platform 2> ... At least one argument",
         nargs="+",
         required=True,
+        type = check_architecture_input
     )
     return parser.parse_args()
 
@@ -184,21 +185,20 @@ def remove_virtual_enviroment(args):
     run_commands(args.dry, commands)
 
 
-def check_architecture_input(args):
+def check_architecture_input(architecture):
 
     supported_arch = ["linux/amd64", "linux/arm64"]
 
-    for target_arch in args.architecture:
-        if target_arch not in supported_arch:
-            raise ValueError(
-                f"Architecture {target_arch} not supported. Supported: {supported_arch}"
-            )
+    if architecture not in supported_arch:
+        raise ValueError(
+            f"Architecture {architectures} not supported. Supported: {supported_arch}"
+        )
+    
+    return architecture
 
 
 def main():
     args = parse_args()
-
-    check_architecture_input(args)
 
     product = product_to_build(args.product, args.product_version, conf.products)
 

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -17,7 +17,6 @@ import conf
 import argparse
 import subprocess
 import sys
-import re
 import platform
 import docker
 import copy
@@ -109,6 +108,7 @@ def build_and_publish_image(args, product):
             product["name"] + "/Dockerfile",
             "--platform",
             "linux/" + check_platform(args.architecture),
+            "--load",
             ".",
         ]
     )
@@ -128,7 +128,6 @@ def run_commands(dry, commands):
         if dry:
             subprocess.run(["echo", *cmd])
         else:
-            print(cmd)
             ret = subprocess.run(cmd)
             if ret.returncode != 0:
                 sys.exit(1)

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -97,10 +97,8 @@ def build_and_publish_image(args, product):
     image_name = f'{args.registry}/stackable/{product["name"]}'
     tags = build_image_tags(image_name, args.image_version, args.product_version)
     build_args = build_image_args(product["versions"][0])
-
-    # This is a ugly hack because currently we run into the problem that java-base and tools can not be passed with --platform
-    if product["name"] == "java-base" or product["name"] == "tools":
-        commands.append(
+   
+    commands.append(
         [
             "docker",
             "buildx",
@@ -109,24 +107,11 @@ def build_and_publish_image(args, product):
             *tags,
             "-f",
             product["name"] + "/Dockerfile",
+            "--platform",
+            "linux/" + check_platform(args.architecture),
             ".",
         ]
     )
-    else: 
-        commands.append(
-            [
-                "docker",
-                "buildx",
-                "build",
-                *build_args,
-                *tags,
-                "-f",
-                product["name"] + "/Dockerfile",
-                "--platform",
-                check_platform(args.architecture),
-                ".",
-            ]
-        )
 
     if args.push:
         commands.append(["docker", "push", "--all-tags", image_name])
@@ -175,7 +160,6 @@ def product_to_build(product_name, product_version, products):
         return None
 
 
-# Checks and dependencies for cross platform compiling
 def check_or_build_dependencies(args, architecture, products):
     """
     Checks if dependencies are currently build on local system, if not they get build

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -100,9 +100,13 @@ def build_and_publish_image(args, product):
     For local building, builder instances are supported.
     """
     commands = []
+    push = ""
     image_name = f'{args.registry}/stackable/{product["name"]}'
     tags = build_image_tags(image_name, args.image_version, args.product_version)
     build_args = build_image_args(product["versions"][0])
+
+    if args.push:
+        push = "--push"
 
     # Multiarch builds
     if args.multiarch:
@@ -117,7 +121,7 @@ def build_and_publish_image(args, product):
                 product["name"] + "/Dockerfile",
                 "--platform",
                 "linux/amd64,linux/arm64",
-                "--push",
+                push,
                 ".",
             ]
         )


### PR DESCRIPTION
FIrst draft for cross-plattfrom compiling.

There are some braking changes for our github action. Giving the script -c will bring it back to normal but can be used with -a/--architecture arm64/amd64/... .  For our actions we can use the option -a to cross-compile. Be aware that not giving -a will result in --platform platform.machine(), so the native platform will be passed to docker. 

**Actual Issue:**
1. Java-Base and Tools can not build with --platform flag, we run into an error from redhead, feel free to try and comment your ideas. (**Solved**)
2. You can not give multiple platforms ant once like -a amd64, arm64 since buildx is not supporting multi-platform. That would be a next step if my approach is decent for now.