### PR TITLE
Remove openssl from zookeeper image

### DIFF
--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -16,7 +16,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN microdnf update && \
     microdnf install tar gzip zip && \
-    microdnf install shadow-utils openssl && \
+    microdnf install shadow-utils && \
     microdnf clean all
 
 COPY zookeeper/stackable /stackable


### PR DESCRIPTION
https://github.com/stackabletech/zookeeper-operator/pull/533 uses the tools image for the initcontainer, therefore openssl is no longer needed here.