### PR TITLE
Add protoc to the ubi8-rust-builder image

### DIFF
--- a/ubi8-rust-builder/Dockerfile
+++ b/ubi8-rust-builder/Dockerfile
@@ -12,7 +12,7 @@ RUN microdnf update --disablerepo=* --enablerepo=ubi-8-appstream --enablerepo=ub
 
 WORKDIR /opt/protoc
 RUN PROTOC_VERSION=21.5 \
-  && curl --location --output protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-$(arch).zip" \
+  && curl --location --output protoc.zip "https://repo.stackable.tech/repository/packages/protoc/protoc-${PROTOC_VERSION}-linux-$(arch).zip" \
   && unzip protoc.zip \
   && rm protoc.zip
 ENV PROTOC=/opt/protoc/bin/protoc

--- a/ubi8-rust-builder/Dockerfile
+++ b/ubi8-rust-builder/Dockerfile
@@ -12,7 +12,8 @@ RUN microdnf update --disablerepo=* --enablerepo=ubi-8-appstream --enablerepo=ub
 
 WORKDIR /opt/protoc
 RUN PROTOC_VERSION=21.5 \
-  && curl --location --output protoc.zip "https://repo.stackable.tech/repository/packages/protoc/protoc-${PROTOC_VERSION}-linux-$(arch).zip" \
+  ARCH=$(arch | sed 's/^arm64$/aarch_64/') \
+  && curl --location --output protoc.zip "https://repo.stackable.tech/repository/packages/protoc/protoc-${PROTOC_VERSION}-linux-${ARCH}.zip" \
   && unzip protoc.zip \
   && rm protoc.zip
 ENV PROTOC=/opt/protoc/bin/protoc

--- a/ubi8-rust-builder/Dockerfile
+++ b/ubi8-rust-builder/Dockerfile
@@ -12,7 +12,7 @@ RUN microdnf update --disablerepo=* --enablerepo=ubi-8-appstream --enablerepo=ub
 
 WORKDIR /opt/protoc
 RUN PROTOC_VERSION=21.5 \
-  ARCH=$(arch | sed 's/^arm64$/aarch_64/') \
+  ARCH=$(arch | sed 's/^aarch64$/aarch_64/') \
   && curl --location --output protoc.zip "https://repo.stackable.tech/repository/packages/protoc/protoc-${PROTOC_VERSION}-linux-${ARCH}.zip" \
   && unzip protoc.zip \
   && rm protoc.zip

--- a/ubi8-rust-builder/Dockerfile
+++ b/ubi8-rust-builder/Dockerfile
@@ -7,8 +7,16 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Update image and install everything needed for Rustup & Rust
 RUN microdnf update --disablerepo=* --enablerepo=ubi-8-appstream --enablerepo=ubi-8-baseos --enablerepo=ubi-8-baseos -y \
   && rm -rf /var/cache/yum \
-  && microdnf install --disablerepo=* --enablerepo=ubi-8-appstream --enablerepo=ubi-8-baseos curl findutils gcc gcc-c++ make cmake openssl-devel pkg-config systemd-devel -y \
+  && microdnf install --disablerepo=* --enablerepo=ubi-8-appstream --enablerepo=ubi-8-baseos curl findutils gcc gcc-c++ make cmake openssl-devel pkg-config systemd-devel unzip -y \
   && rm -rf /var/cache/yum
+
+WORKDIR /opt/protoc
+RUN PROTOC_VERSION=21.5 \
+  && curl --location --output protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-$(arch).zip" \
+  && unzip protoc.zip \
+  && rm protoc.zip
+ENV PROTOC=/opt/protoc/bin/protoc
+WORKDIR /
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
  && . $HOME/.cargo/env \


### PR DESCRIPTION
Add protoc to the ubi8-rust-builder image

The secret-operator depends on [`prost`](https://crates.io/crates/prost), a Protocol Buffers implementation for Rust. With version 0.11, `prost` will no longer provide a bundled `protoc`. Therefore `protoc` must be installed on the builder image. The Red Hat UBI 8 repositories do not provide `protoc`, so it is downloaded from the protobuf project on GitHub directly.