### PR TITLE
trino: Added Trino version 395 (using Java 17)

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -208,7 +208,7 @@ products = [
             {
                 'product': '395',
                 'java': '17',
-                'opa_authorizer': '0.1.0'
+                'opa_authorizer': 'stackable0.1.0'
             },
         ],
     },

--- a/conf.py
+++ b/conf.py
@@ -87,6 +87,10 @@ products = [
                 'product': '11',
                 '_security_path': '/usr/lib/jvm/jre-11/conf/security/java.security',
             },
+            {
+                'product': '17',
+                '_security_path': '/usr/lib/jvm/jre-17/conf/security/java.security',
+            },
         ],
     },
     {
@@ -185,10 +189,17 @@ products = [
         'versions': [
             {
                 'product': '377',
-                'opa_authorizer': '0.1.0'
+                'java': '11',
+                'opa_authorizer': '0.1.0',
             },
             {
                 'product': '387',
+                'java': '11',
+                'opa_authorizer': '0.1.0'
+            },
+            {
+                'product': '395',
+                'java': '17',
                 'opa_authorizer': '0.1.0'
             },
         ],

--- a/trino/CHANGELOG.md
+++ b/trino/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
 ## [395-stackable0.1.0] - 2022-09-15
 
 ### Added

--- a/trino/CHANGELOG.md
+++ b/trino/CHANGELOG.md
@@ -1,0 +1,7 @@
+## [395-stackable0.1.0] - 2022-09-15
+
+### Added
+
+- Added Trino version 395 (using Java 17) ([#172]).
+
+[#172]: https://github.com/stackabletech/docker-images/pull/172

--- a/trino/CHANGELOG.md
+++ b/trino/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 ### Added
 
-- Added Trino version 395 (using Java 17) ([#172]).
+- Added Trino version 395 (using Java 17) ([#173]).
 
-[#172]: https://github.com/stackabletech/docker-images/pull/172
+[#173]: https://github.com/stackabletech/docker-images/pull/173

--- a/trino/Dockerfile
+++ b/trino/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker.stackable.tech/stackable/java-base:11-stackable0
+ARG JAVA
+FROM docker.stackable.tech/stackable/java-base:${JAVA}-stackable0
 
 ARG PRODUCT
 ARG OPA_AUTHORIZER


### PR DESCRIPTION
Fixes https://github.com/stackabletech/trino-operator/issues/288

To build run
`python3 build_product_images.py -p java-base -i 0 -v 17 -a linux/amd64`
and
`python3 build_product_images.py -p trino -i 0.99.0 -v 395 -a linux/amd64`

- [x] Integration tests passed