### PR TITLE
Patch repo ubi 8 appstream and base os

### DIFF
--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5 as airflow-build-image
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-941 as airflow-build-image
 
 ARG PRODUCT
 ARG PYTHON

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:37b1bbdc042d32573738c72e4e0f0592b4198a5de1c3a3f32515d29ba4605488 AS airflow-build-image
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 AS airflow-build-image
 
 ARG PRODUCT
 ARG PYTHON
@@ -26,7 +26,7 @@ RUN microdnf update \
         && pip install --no-cache-dir --upgrade pip \
         && pip install --no-cache-dir apache-airflow[${AIRFLOW_EXTRAS}]==${PRODUCT} --constraint /tmp/constraints.txt
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5 as airflow-main-image
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 as airflow-main-image
 
 ARG PRODUCT
 ARG PYTHON

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-941 as airflow-build-image
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:37b1bbdc042d32573738c72e4e0f0592b4198a5de1c3a3f32515d29ba4605488 as airflow-build-image
 
 ARG PRODUCT
 ARG PYTHON

--- a/java-base/Dockerfile
+++ b/java-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-941
 
 ARG PRODUCT
 ARG RELEASE="1"

--- a/java-base/Dockerfile
+++ b/java-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:37b1bbdc042d32573738c72e4e0f0592b4198a5de1c3a3f32515d29ba4605488
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 
 ARG PRODUCT
 ARG RELEASE="1"

--- a/java-base/Dockerfile
+++ b/java-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-941
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:37b1bbdc042d32573738c72e4e0f0592b4198a5de1c3a3f32515d29ba4605488
 
 ARG PRODUCT
 ARG RELEASE="1"

--- a/opa/Dockerfile
+++ b/opa/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:37b1bbdc042d32573738c72e4e0f0592b4198a5de1c3a3f32515d29ba4605488 AS builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 AS builder
 
 ARG PRODUCT
 ARG RELEASE="1"

--- a/opa/Dockerfile
+++ b/opa/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal AS builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-941 AS builder
 
 ARG PRODUCT
 ARG RELEASE="1"

--- a/opa/Dockerfile
+++ b/opa/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-941 AS builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:37b1bbdc042d32573738c72e4e0f0592b4198a5de1c3a3f32515d29ba4605488 AS builder
 
 ARG PRODUCT
 ARG RELEASE="1"

--- a/pyspark-k8s/Dockerfile
+++ b/pyspark-k8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-941 AS builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:37b1bbdc042d32573738c72e4e0f0592b4198a5de1c3a3f32515d29ba4605488 AS builder
 
 ARG PRODUCT
 ARG HADOOP

--- a/pyspark-k8s/Dockerfile
+++ b/pyspark-k8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:37b1bbdc042d32573738c72e4e0f0592b4198a5de1c3a3f32515d29ba4605488 AS builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 AS builder
 
 ARG PRODUCT
 ARG PYTHON

--- a/pyspark-k8s/Dockerfile
+++ b/pyspark-k8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal AS builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-941 AS builder
 
 ARG PRODUCT
 ARG HADOOP

--- a/spark-k8s/Dockerfile
+++ b/spark-k8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-941 AS builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:37b1bbdc042d32573738c72e4e0f0592b4198a5de1c3a3f32515d29ba4605488 AS builder
 
 ARG PRODUCT
 ARG HADOOP

--- a/spark-k8s/Dockerfile
+++ b/spark-k8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal AS builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-941 AS builder
 
 ARG PRODUCT
 ARG HADOOP

--- a/spark-k8s/Dockerfile
+++ b/spark-k8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:37b1bbdc042d32573738c72e4e0f0592b4198a5de1c3a3f32515d29ba4605488 AS builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 AS builder
 
 ARG PRODUCT
 ARG HADOOP_SHORT_VERSION

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-941 as builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:37b1bbdc042d32573738c72e4e0f0592b4198a5de1c3a3f32515d29ba4605488 as builder
 
 ARG PRODUCT
 ARG PYTHON

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:37b1bbdc042d32573738c72e4e0f0592b4198a5de1c3a3f32515d29ba4605488 AS builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 AS builder
 
 ARG PRODUCT
 ARG PYTHON
@@ -58,7 +58,7 @@ RUN cat /tmp/patches/* | patch \
 
 # Final image
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 
 ARG PRODUCT
 ARG PYTHON

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5 as builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-941 as builder
 
 ARG PRODUCT
 ARG PYTHON

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:37b1bbdc042d32573738c72e4e0f0592b4198a5de1c3a3f32515d29ba4605488 AS builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 AS builder
 
 ARG PRODUCT
 ARG RELEASE="1"

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal AS builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-941 AS builder
 
 ARG PRODUCT
 ARG RELEASE="1"

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-941 AS builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:37b1bbdc042d32573738c72e4e0f0592b4198a5de1c3a3f32515d29ba4605488 AS builder
 
 ARG PRODUCT
 ARG RELEASE="1"

--- a/ubi8-rust-builder/Dockerfile
+++ b/ubi8-rust-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal AS builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-941 AS builder
 LABEL maintainer="Stackable GmbH"
 
 # https://github.com/hadolint/hadolint/wiki/DL4006

--- a/ubi8-rust-builder/Dockerfile
+++ b/ubi8-rust-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:37b1bbdc042d32573738c72e4e0f0592b4198a5de1c3a3f32515d29ba4605488 AS builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 AS builder
 LABEL maintainer="Stackable GmbH"
 
 # https://github.com/hadolint/hadolint/wiki/DL4006

--- a/ubi8-rust-builder/Dockerfile
+++ b/ubi8-rust-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-941 AS builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:37b1bbdc042d32573738c72e4e0f0592b4198a5de1c3a3f32515d29ba4605488 AS builder
 LABEL maintainer="Stackable GmbH"
 
 # https://github.com/hadolint/hadolint/wiki/DL4006

--- a/ubi8-rust-builder/Dockerfile
+++ b/ubi8-rust-builder/Dockerfile
@@ -5,9 +5,9 @@ LABEL maintainer="Stackable GmbH"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Update image and install everything needed for Rustup & Rust
-RUN microdnf update --disablerepo=* --enablerepo=ubi-8-appstream --enablerepo=ubi-8-baseos --enablerepo=ubi-8-baseos -y \
+RUN microdnf update --disablerepo=* --enablerepo=ubi-8-appstream-rpms --enablerepo=ubi-8-baseos-rpms --enablerepo=ubi-8-baseos -y \
   && rm -rf /var/cache/yum \
-  && microdnf install --disablerepo=* --enablerepo=ubi-8-appstream --enablerepo=ubi-8-baseos curl findutils gcc gcc-c++ make cmake openssl-devel pkg-config systemd-devel unzip -y \
+  && microdnf install --disablerepo=* --enablerepo=ubi-8-appstream-rpms --enablerepo=ubi-8-baseos-rpms curl findutils gcc gcc-c++ make cmake openssl-devel pkg-config systemd-devel unzip -y \
   && rm -rf /var/cache/yum
 
 WORKDIR /opt/protoc


### PR DESCRIPTION
Pin all versions with digests, checkout why renovate is not pinning digests on it's own. Until then we should have a solution and pin the current version to protect us from sudden changes.