### PR TITLE
hbase: include hadoop native libs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -46,22 +46,27 @@ products = [
             {
                 'product': '2.4.6',
                 'phoenix': '2.4-5.1.2',
+                'hadoop': '3.3.4',
             },
             {
                 'product': '2.4.8',
                 'phoenix': '2.4-5.1.2',
+                'hadoop': '3.3.4',
             },
             {
                 'product': '2.4.9',
                 'phoenix': '2.4-5.1.2',
+                'hadoop': '3.3.4',
             },
             {
                 'product': '2.4.11',
                 'phoenix': '2.4-5.1.2',
+                'hadoop': '3.3.4',
             },
             {
                 'product': '2.4.12',
                 'phoenix': '2.4-5.1.2',
+                'hadoop': '3.3.4',
             },
         ]
     },

--- a/hbase/CHANGELOG.md
+++ b/hbase/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
-## [hbase2.4.6-stackable0.7.0] [hbase2.4.8-stackable0.7.0] [hbase2.4.9-stackable0.7.0] [hbase2.4.11-stackable0.7.0] [hbase2.4.12-stackable0.2.0] - 2022-08-01
+## [hbase2.4.6-stackable0.8.0] [hbase2.4.8-stackable0.8.0] [hbase2.4.9-stackable0.8.0] [hbase2.4.11-stackable0.8.0] [hbase2.4.12-stackable0.3.0] - 2022-10-21
 
 ### Added
 
 - Phoenix support added ([#157]).
+- Hadoop native libs added for compression support ([#])
 
+[#157]: https://github.com/stackabletech/docker-images/pull/157
 [#157]: https://github.com/stackabletech/docker-images/pull/157
 
 ## [hbase-stackable0.4.0] - 2022-03-22

--- a/hbase/CHANGELOG.md
+++ b/hbase/CHANGELOG.md
@@ -5,10 +5,10 @@
 ### Added
 
 - Phoenix support added ([#157]).
-- Hadoop native libs added for compression support ([#])
+- Hadoop native libs added for compression support ([#230])
 
 [#157]: https://github.com/stackabletech/docker-images/pull/157
-[#157]: https://github.com/stackabletech/docker-images/pull/157
+[#230]: https://github.com/stackabletech/docker-images/pull/230
 
 ## [hbase-stackable0.4.0] - 2022-03-22
 

--- a/hbase/Dockerfile
+++ b/hbase/Dockerfile
@@ -2,6 +2,7 @@ FROM docker.stackable.tech/stackable/java-base:11-stackable0@sha256:fd428a260606
 
 ARG PRODUCT
 ARG PHOENIX
+ARG HADOOP
 ARG RELEASE="1"
 
 LABEL name="Apache HBase" \
@@ -45,7 +46,11 @@ RUN curl -L https://repo.stackable.tech/repository/packages/hbase/hbase-${PRODUC
     ln -s /stackable/phoenix-hbase-${PHOENIX}-bin /stackable/phoenix && \
     ln -s /stackable/phoenix/phoenix-server-hbase-${PHOENIX}.jar /stackable/hbase/lib/phoenix-server-hbase-${PHOENIX}.jar
 
+RUN curl -L https://repo.stackable.tech/repository/packages/hadoop/hadoop-${HADOOP}.tar.gz | tar -xzC . && \
+    ln -s /stackable/hadoop-${HADOOP} /stackable/hadoop
+
 ENV HBASE_CONF_DIR=/stackable/hbase/conf
+ENV HBASE_LIBRARY_PATH=/stackable/hadoop-${HADOOP}/lib/native
 
 # ===
 # Mitigation for CVE-2021-44228 (Log4Shell)


### PR DESCRIPTION
Add hadoop native libs to image to so that compression (lz4, bzip2) can be applied to tables.
Don't merge - this is for compression tests only at the moment.

##### TODOs
- hadoop version is currently hard-coded as the latestone (3.3.4). Do we want to add this to the argument matrix, or are the native libs static enough for it not to matter?
- currently this adds the whole hadoop install, which makes the image really large. Only the native libs should be added.