### PR TITLE
Update java base image to latest ubi8 tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,14 @@ All notable changes to this project will be documented in this file.
 - Added labels for openshift requirements and licenses for all images ([#95]).
 - Added `RELEASE` ARG for all images ([#95]).
 
+### Changed
+
+- Updated base images to latest ubi8 tag 8.6-990 ([#248]).
+
 ### Removed
 
 - Prometheus image, NodeExporter image, Antora ([#95]).
+- Retired Java 1.8.0 support ([#248]).
 
 [#95]: https://github.com/stackabletech/docker-images/pull/95
+[#248]: https://github.com/stackabletech/docker-images/pull/248

--- a/conf.py
+++ b/conf.py
@@ -88,10 +88,6 @@ products = [
         'name': 'java-base',
         'versions': [
             {
-                'product': '1.8.0',
-                '_security_path': '/usr/lib/jvm/jre-1.8.0/lib/security/java.security',
-            },
-            {
                 'product': '11',
                 '_security_path': '/usr/lib/jvm/jre-11/conf/security/java.security',
             },

--- a/java-base/Dockerfile
+++ b/java-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6@sha256:e58664de16551db29fb0eaaeb3c4a44eaf95ad89a5b2399a1107041c4f2d6d34
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6@sha256:c6184bf1780638e3d1032030cf6381e40627ed66410405daad6543fa4dbf8fed
 
 ARG PRODUCT
 ARG RELEASE="1"


### PR DESCRIPTION
Removed Java 1.8.0 support since no other products are using it.