### PR TITLE
Revert all base image version (17 -> 11) merged with PR 226

### DIFF
--- a/hadoop/Dockerfile
+++ b/hadoop/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.stackable.tech/stackable/java-base:17-stackable0.2.2@sha256:2b8d60d1ab50d56240cb6286d6bc377410442afbfc3292d81be5674bc0b51724
+FROM docker.stackable.tech/stackable/java-base:11-stackable0.2.2@sha256:7929833412c331fc23cde0e23ca730d652c0be61a8a69c8a82b2af937a3fbd4e
 
 ARG PRODUCT
 ARG RELEASE="1"

--- a/hbase/Dockerfile
+++ b/hbase/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.stackable.tech/stackable/java-base:17-stackable0.2.2@sha256:2b8d60d1ab50d56240cb6286d6bc377410442afbfc3292d81be5674bc0b51724
+FROM docker.stackable.tech/stackable/java-base:11-stackable0.2.2@sha256:7929833412c331fc23cde0e23ca730d652c0be61a8a69c8a82b2af937a3fbd4e
 
 ARG PRODUCT
 ARG PHOENIX

--- a/hive/Dockerfile
+++ b/hive/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.stackable.tech/stackable/java-base:17-stackable0.2.2@sha256:2b8d60d1ab50d56240cb6286d6bc377410442afbfc3292d81be5674bc0b51724
+FROM docker.stackable.tech/stackable/java-base:11-stackable0.2.2@sha256:7929833412c331fc23cde0e23ca730d652c0be61a8a69c8a82b2af937a3fbd4e
 
 ARG PRODUCT
 ARG HADOOP

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.stackable.tech/stackable/java-base:17-stackable0.2.2@sha256:2b8d60d1ab50d56240cb6286d6bc377410442afbfc3292d81be5674bc0b51724
+FROM docker.stackable.tech/stackable/java-base:11-stackable0.2.2@sha256:7929833412c331fc23cde0e23ca730d652c0be61a8a69c8a82b2af937a3fbd4e
 
 ARG PRODUCT
 ARG SCALA

--- a/nifi/Dockerfile
+++ b/nifi/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.stackable.tech/stackable/java-base:17-stackable0.2.2@sha256:2b8d60d1ab50d56240cb6286d6bc377410442afbfc3292d81be5674bc0b51724
+FROM docker.stackable.tech/stackable/java-base:11-stackable0.2.2@sha256:7929833412c331fc23cde0e23ca730d652c0be61a8a69c8a82b2af937a3fbd4e
 
 ARG PRODUCT
 ARG RELEASE="1"

--- a/spark/Dockerfile
+++ b/spark/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.stackable.tech/stackable/java-base:17-stackable0.2.2@sha256:2b8d60d1ab50d56240cb6286d6bc377410442afbfc3292d81be5674bc0b51724
+FROM docker.stackable.tech/stackable/java-base:11-stackable0.2.2@sha256:7929833412c331fc23cde0e23ca730d652c0be61a8a69c8a82b2af937a3fbd4e
 
 ARG PRODUCT
 ARG HADOOP

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.stackable.tech/stackable/java-base:17-stackable0.2.2@sha256:2b8d60d1ab50d56240cb6286d6bc377410442afbfc3292d81be5674bc0b51724
+FROM docker.stackable.tech/stackable/java-base:11-stackable0.2.2@sha256:7929833412c331fc23cde0e23ca730d652c0be61a8a69c8a82b2af937a3fbd4e
 
 ARG PRODUCT
 ARG RELEASE="1"


### PR DESCRIPTION
I thought only Druid had to be reverted in https://github.com/stackabletech/docker-images/pull/234, but Hadoop etc is affected as well. So now just reverting the PR https://github.com/stackabletech/docker-images/pull/226 completely.
