### PR TITLE
Logging

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -129,7 +129,7 @@ products = [
     },
     {
         'name': 'vector',
-        'versions': ['0.25.1'],
+        'versions': ['0.26.0'],
     },
     {
         'name': 'nifi',

--- a/conf.py
+++ b/conf.py
@@ -128,6 +128,10 @@ products = [
         ]
     },
     {
+        'name': 'vector',
+        'versions': ['0.25.1'],
+    },
+    {
         'name': 'nifi',
         'versions': ['1.15.0', '1.15.1', '1.15.2', '1.15.3', '1.16.0', '1.16.1', '1.16.2', '1.16.3', '1.18.0'],
     },
@@ -183,6 +187,10 @@ products = [
                 'azure_keyvault_core': '1.0.0',
             },
         ]
+    },
+    {
+        'name': 'stackable-base',
+        'versions': ['1.0.0'],
     },
     {
         'name': 'superset',

--- a/java-base/CHANGELOG.md
+++ b/java-base/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## [java-base-stackable0.3.0] - 2022-12-12
+
+### Changed
+
+- Base image ubi-minimal:8.6 replaced with vector:0.26.0-stackable1.0.0 which
+  contains Vector ([#268]).
+
+[#268]: https://github.com/stackabletech/docker-images/pull/268

--- a/java-base/Dockerfile
+++ b/java-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.stackable.tech/sandbox/logging/vector:0.25.1-stackable1.0.0@sha256:5da88737b547318d8ce0402c55f3ea6e204a14fe7ab68e4e1c923cdb9edd32f7
+FROM docker.stackable.tech/stackable/vector:0.25.1-stackable1.0.0@sha256:5da88737b547318d8ce0402c55f3ea6e204a14fe7ab68e4e1c923cdb9edd32f7
 
 ARG PRODUCT
 ARG RELEASE="1"

--- a/java-base/Dockerfile
+++ b/java-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6@sha256:c5ffdf5938d73283cec018f2adf59f0ed9f8c376d93e415a27b16c3c6aad6f45
+FROM docker.stackable.tech/sandbox/logging/vector:0.25.1-stackable1.0.0@sha256:5da88737b547318d8ce0402c55f3ea6e204a14fe7ab68e4e1c923cdb9edd32f7
 
 ARG PRODUCT
 ARG RELEASE="1"

--- a/java-base/Dockerfile
+++ b/java-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.stackable.tech/stackable/vector:0.26.0-stackable1.0.0@sha256:44a5f4e40cc755044665edf38a19e9670bcadaf3f1ab7e35e049de9d3d2cc69d
+FROM docker.stackable.tech/stackable/vector:0.26.0-stackable1.0.0@sha256:fcc7a5e1e69753a7bb1dd0525f1dbc7a73b19c65595aa3db0e6c632941fa81e1
 
 ARG PRODUCT
 ARG RELEASE="1"

--- a/java-base/Dockerfile
+++ b/java-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.stackable.tech/stackable/vector:0.25.1-stackable1.0.0@sha256:5da88737b547318d8ce0402c55f3ea6e204a14fe7ab68e4e1c923cdb9edd32f7
+FROM docker.stackable.tech/stackable/vector:0.26.0-stackable1.0.0@sha256:44a5f4e40cc755044665edf38a19e9670bcadaf3f1ab7e35e049de9d3d2cc69d
 
 ARG PRODUCT
 ARG RELEASE="1"

--- a/stackable-base/CHANGELOG.md
+++ b/stackable-base/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [stackable-base-stackable1.0.0] - 2022-12-12
+
+### Added
+
+- Image stackable-base added which is based on the ubi-minimal:8.6 image. This
+  image creates the stackable user and group and the working directory
+  /stackable ([#268]).
+
+[#268]: https://github.com/stackabletech/docker-images/pull/268

--- a/stackable-base/Dockerfile
+++ b/stackable-base/Dockerfile
@@ -1,0 +1,13 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6@sha256:c5ffdf5938d73283cec018f2adf59f0ed9f8c376d93e415a27b16c3c6aad6f45
+
+# intentionally unused
+ARG PRODUCT
+
+RUN microdnf update && \
+    microdnf --assumeyes install shadow-utils && \
+    groupadd --gid 1000 --system stackable && \
+    useradd --gid stackable --uid 1000 --system stackable && \
+    mkdir /stackable && \
+    chown stackable:stackable /stackable && \
+    microdnf remove shadow-utils && \
+    microdnf clean all

--- a/stackable-base/Dockerfile
+++ b/stackable-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6@sha256:c5ffdf5938d73283cec018f2adf59f0ed9f8c376d93e415a27b16c3c6aad6f45
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6@sha256:33931dce809712888d1a8061bfa676963f517daca993984afed3251bc1fb5987
 
 # intentionally unused
 ARG PRODUCT

--- a/vector/CHANGELOG.md
+++ b/vector/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## [vector-stackable1.0.0] - 2022-12-12
+
+### Added
+
+- Image vector added which installs Vector and is based on the stackable-base
+  image. ([#268]).
+
+[#268]: https://github.com/stackabletech/docker-images/pull/268

--- a/vector/Dockerfile
+++ b/vector/Dockerfile
@@ -1,0 +1,26 @@
+# Build stage
+
+FROM docker.stackable.tech/sandbox/logging/stackable-base:1.0.0-stackable1.0.0@sha256:4b3fb8784196867eb8884b0528e859f3969e54ebf1403b33780f15ee02e88d0d AS builder
+
+ARG PRODUCT
+
+# https://github.com/hadolint/hadolint/wiki/DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN microdnf update && \
+    microdnf --assumeyes install gzip-1.9 tar-2:1.30 && \
+    microdnf clean all && \
+    curl "https://repo.stackable.tech/repository/packages/vector/vector-${PRODUCT}-$(arch)-unknown-linux-gnu.tar.gz" | \
+    tar x -o -z -C /opt && \
+    mkdir --parents /build/licenses && \
+    cp "/opt/vector-$(arch)-unknown-linux-gnu/LICENSE" /build/licenses/VECTOR_LICENSE && \
+    mkdir --parents /build/stackable/vector/ && \
+    cp --recursive "/opt/vector-$(arch)-unknown-linux-gnu/bin/" /build/stackable/vector/ && \
+    mkdir --parents /build/stackable/vector/var && \
+    chown --recursive stackable:stackable /build/stackable/
+
+# Final image
+
+FROM docker.stackable.tech/sandbox/logging/stackable-base:1.0.0-stackable1.0.0@sha256:4b3fb8784196867eb8884b0528e859f3969e54ebf1403b33780f15ee02e88d0d
+
+COPY --from=builder /build /

--- a/vector/Dockerfile
+++ b/vector/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage
 
-FROM docker.stackable.tech/stackable/stackable-base:1.0.0-stackable1.0.0@sha256:4b3fb8784196867eb8884b0528e859f3969e54ebf1403b33780f15ee02e88d0d AS builder
+FROM docker.stackable.tech/stackable/stackable-base:1.0.0-stackable1.0.0@sha256:566607cbbfc78be4004dd4ecd06a2673788b56eaa3c330e3e2953902c5b6b94c AS builder
 
 ARG PRODUCT
 
@@ -21,6 +21,6 @@ RUN microdnf update && \
 
 # Final image
 
-FROM docker.stackable.tech/stackable/stackable-base:1.0.0-stackable1.0.0@sha256:4b3fb8784196867eb8884b0528e859f3969e54ebf1403b33780f15ee02e88d0d
+FROM docker.stackable.tech/stackable/stackable-base:1.0.0-stackable1.0.0@sha256:566607cbbfc78be4004dd4ecd06a2673788b56eaa3c330e3e2953902c5b6b94c
 
 COPY --from=builder /build /

--- a/vector/Dockerfile
+++ b/vector/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage
 
-FROM docker.stackable.tech/sandbox/logging/stackable-base:1.0.0-stackable1.0.0@sha256:4b3fb8784196867eb8884b0528e859f3969e54ebf1403b33780f15ee02e88d0d AS builder
+FROM docker.stackable.tech/stackable/stackable-base:1.0.0-stackable1.0.0@sha256:4b3fb8784196867eb8884b0528e859f3969e54ebf1403b33780f15ee02e88d0d AS builder
 
 ARG PRODUCT
 
@@ -21,6 +21,6 @@ RUN microdnf update && \
 
 # Final image
 
-FROM docker.stackable.tech/sandbox/logging/stackable-base:1.0.0-stackable1.0.0@sha256:4b3fb8784196867eb8884b0528e859f3969e54ebf1403b33780f15ee02e88d0d
+FROM docker.stackable.tech/stackable/stackable-base:1.0.0-stackable1.0.0@sha256:4b3fb8784196867eb8884b0528e859f3969e54ebf1403b33780f15ee02e88d0d
 
 COPY --from=builder /build /

--- a/zookeeper/CHANGELOG.md
+++ b/zookeeper/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [zookeeper-stackable0.9.0] - 2022-12-12
+
+### Changed
+
+- Upgraded to the base image java-base:11-stackable0.3.0. The java-base image
+  contains a layer which provides Vector. The creation of the stackable user
+  and group happens in the stackable-base layer and is therefore removed from
+  this image ([#268]).
+
+[#268]: https://github.com/stackabletech/docker-images/pull/268
+
 ## [zookeeper-stackable0.7.1] - 2022-06-02
 
 ### Changed

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.stackable.tech/stackable/java-base:11-stackable0.2.2@sha256:7929833412c331fc23cde0e23ca730d652c0be61a8a69c8a82b2af937a3fbd4e
+FROM docker.stackable.tech/sandbox/logging/java-base:11-stackable0.3.0@sha256:4e47b9dd91d5ce5c7b8be9561b3efcf108106fe71ec9b97976a647d7025c14fd
 
 ARG PRODUCT
 ARG RELEASE="1"
@@ -16,15 +16,11 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN microdnf update && \
     microdnf install tar gzip zip && \
-    microdnf install shadow-utils openssl && \
+    microdnf install openssl && \
     microdnf clean all
 
-COPY zookeeper/stackable /stackable
+COPY --chown=stackable:stackable zookeeper/stackable /stackable
 COPY zookeeper/licenses /licenses
-
-RUN groupadd -r stackable --gid=1000 && \
-    useradd -r -g stackable --uid=1000 stackable && \
-    chown -R stackable:stackable /stackable
 
 USER stackable
 WORKDIR /stackable

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.stackable.tech/stackable/java-base:11-stackable0.3.0@sha256:4e47b9dd91d5ce5c7b8be9561b3efcf108106fe71ec9b97976a647d7025c14fd
+FROM docker.stackable.tech/stackable/java-base:11-stackable0.3.0@sha256:7161eff7fb57ce18e458da5ec7846d98f2492ecba3b22b044cb36f85d169def0
 
 ARG PRODUCT
 ARG RELEASE="1"

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.stackable.tech/stackable/java-base:11-stackable0.3.0@sha256:7161eff7fb57ce18e458da5ec7846d98f2492ecba3b22b044cb36f85d169def0
+FROM docker.stackable.tech/stackable/java-base:11-stackable0.3.0@sha256:52d7306c2f031840562fc007ce1b586e4dc59c33a3dd55cc8e963a857a1159a4
 
 ARG PRODUCT
 ARG RELEASE="1"

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.stackable.tech/sandbox/logging/java-base:11-stackable0.3.0@sha256:4e47b9dd91d5ce5c7b8be9561b3efcf108106fe71ec9b97976a647d7025c14fd
+FROM docker.stackable.tech/stackable/java-base:11-stackable0.3.0@sha256:4e47b9dd91d5ce5c7b8be9561b3efcf108106fe71ec9b97976a647d7025c14fd
 
 ARG PRODUCT
 ARG RELEASE="1"


### PR DESCRIPTION
Add stackable-base and vector images and base the zookeeper image onto them.

A java-based product image now consists of the layers `ubi-minimal`, `stackable-base`, `vector`, and the product image itself.

These extended images are used for the log aggregation (stackabletech/issues#295).