### PR TITLE
Moved statsd-exporter to main image

### DIFF
--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -27,6 +27,7 @@ RUN microdnf update \
         && pip install --no-cache-dir --upgrade pip \
         && pip install --no-cache-dir apache-airflow[${AIRFLOW_EXTRAS}]==${PRODUCT} --constraint /tmp/constraints.txt
 
+FROM prom/statsd-exporter:0.3.0@sha256:a9c27602d6f6b86527657922b6a87c12789f7f9b39a90f1513e8c665c941f26a as statsd-exporter
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6@sha256:e58664de16551db29fb0eaaeb3c4a44eaf95ad89a5b2399a1107041c4f2d6d34 as airflow-main-image
 
 ARG PRODUCT
@@ -71,6 +72,7 @@ RUN mkdir -pv ${HOME} && \
 RUN curl -o /usr/bin/tini https://repo.stackable.tech/repository/packages/tini/tini-$(arch) 
 
 COPY airflow/stackable/utils/entrypoint.sh /entrypoint
+COPY --from=statsd-exporter /bin/statsd_exporter /stackable/statsd_exporter
 
 RUN chmod a+x /entrypoint && \
     chmod +x /usr/bin/tini

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -57,7 +57,7 @@ RUN cat /tmp/patches/* | patch \
     --strip=1
 
 # Final image
-
+FROM prom/statsd-exporter:0.3.0@sha256:a9c27602d6f6b86527657922b6a87c12789f7f9b39a90f1513e8c665c941f26a as statsd-exporter
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6@sha256:e58664de16551db29fb0eaaeb3c4a44eaf95ad89a5b2399a1107041c4f2d6d34
 
 ARG PRODUCT
@@ -95,6 +95,7 @@ RUN microdnf update \
 
 COPY superset/licenses /licenses
 COPY --from=builder /stackable ${HOME}
+COPY --from=statsd-exporter /bin/statsd_exporter /stackable/statsd_exporter
 
 RUN chown --recursive stackable:stackable ${HOME}
 

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -56,8 +56,10 @@ RUN cat /tmp/patches/* | patch \
     --directory=/stackable/app/lib/python${PYTHON}/site-packages \
     --strip=1
 
-# Final image
+# Get statsd-exporter
 FROM prom/statsd-exporter:0.3.0@sha256:a9c27602d6f6b86527657922b6a87c12789f7f9b39a90f1513e8c665c941f26a as statsd-exporter
+
+# Final image
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6@sha256:e58664de16551db29fb0eaaeb3c4a44eaf95ad89a5b2399a1107041c4f2d6d34
 
 ARG PRODUCT
@@ -94,10 +96,8 @@ RUN microdnf update \
     && useradd --uid 1000 --gid stackable --home-dir ${HOME} stackable
 
 COPY superset/licenses /licenses
-COPY --from=builder /stackable ${HOME}
 COPY --from=statsd-exporter /bin/statsd_exporter /stackable/statsd_exporter
-
-RUN chown --recursive stackable:stackable ${HOME}
+COPY --from=builder --chown=stackable:stackable /stackable/ ${HOME}/
 
 USER stackable
 WORKDIR ${HOME}


### PR DESCRIPTION
Now copying statsd-exporter from  its docker image to the main image for airflow and superset (hopefully multi arch compatible)

@Maleware can you confirm :) ?