### PR TITLE
Add opa-bundle-builder to opa image

### DIFF
--- a/opa/Dockerfile
+++ b/opa/Dockerfile
@@ -1,4 +1,22 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6@sha256:c5ffdf5938d73283cec018f2adf59f0ed9f8c376d93e415a27b16c3c6aad6f45 AS builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6@sha256:c5ffdf5938d73283cec018f2adf59f0ed9f8c376d93e415a27b16c3c6aad6f45 AS opa-bundle-builder
+LABEL maintainer="Stackable GmbH"
+
+# https://github.com/hadolint/hadolint/wiki/DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Update image and install everything needed for Rustup & Rust
+RUN microdnf update --disablerepo=* --enablerepo=ubi-8-appstream-rpms --enablerepo=ubi-8-baseos-rpms -y \
+  && rm -rf /var/cache/yum \
+  && microdnf install --disablerepo=* --enablerepo=ubi-8-appstream-rpms --enablerepo=ubi-8-baseos-rpms curl findutils gcc gcc-c++ git make cmake openssl-devel pkg-config systemd-devel unzip -y \
+  && rm -rf /var/cache/yum
+
+WORKDIR /
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN git clone --depth 1 --branch 1.0.0 https://github.com/stackabletech/opa-bundle-builder
+RUN cd ./opa-bundle-builder && . $HOME/.cargo/env && cargo build --release
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6@sha256:c5ffdf5938d73283cec018f2adf59f0ed9f8c376d93e415a27b16c3c6aad6f45
 
 ARG PRODUCT
 ARG RELEASE="1"
@@ -20,6 +38,7 @@ RUN microdnf update && \
     microdnf clean all
 
 COPY opa/licenses /licenses
+COPY --from=opa-bundle-builder /opa-bundle-builder/target/release/stackable-opa-bundle-builder /stackable/opa-bundle-builder
 
 WORKDIR /stackable/opa
 RUN groupadd -r stackable --gid=1000 && \


### PR DESCRIPTION
The opa-bundle-builder repo is cloned an build as release. The executable is copied into the OPA image.