### PR TITLE
Enable log aggregation in HBase

### DIFF
--- a/hbase/CHANGELOG.md
+++ b/hbase/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [hbase2.4.6-stackable0.9.0] [hbase2.4.8-stackable0.9.0] [hbase2.4.9-stackable0.9.0] [hbase2.4.11-stackable0.9.0] [hbase2.4.12-stackable0.4.0] - 2022-12-21
+
+### Changed
+
+- Upgraded to the base image java-base:11-stackable0.3.0. The java-base image
+  contains a layer which provides Vector. The creation of the stackable user
+  and group happens in the stackable-base layer and is therefore removed from
+  this image ([#283]).
+
+[#283]: https://github.com/stackabletech/docker-images/pull/283
+
 ## [hbase2.4.6-stackable0.7.0] [hbase2.4.8-stackable0.7.0] [hbase2.4.9-stackable0.7.0] [hbase2.4.11-stackable0.7.0] [hbase2.4.12-stackable0.2.0] - 2022-08-01
 
 ### Added

--- a/hbase/Dockerfile
+++ b/hbase/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.stackable.tech/stackable/java-base:11-stackable0.2.2@sha256:7929833412c331fc23cde0e23ca730d652c0be61a8a69c8a82b2af937a3fbd4e
+FROM docker.stackable.tech/stackable/java-base:11-stackable0.3.0@sha256:5c7f9e7274bd68ea264138b13504efa16fb22ee1122e7d12af32f343eb93c837
 
 ARG PRODUCT
 ARG PHOENIX
@@ -17,7 +17,6 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN microdnf update && \
     microdnf install tar gzip zip && \
-    microdnf install shadow-utils && \
     microdnf install python3 python3-pip && \
     microdnf clean all
 
@@ -26,12 +25,8 @@ RUN ln -s /usr/bin/python3 /usr/bin/python && \
 
 ENV HOME=/stackable
 
-COPY hbase/stackable /stackable
+COPY --chown=stackable:stackable hbase/stackable /stackable
 COPY hbase/licenses /licenses
-
-RUN groupadd -r stackable --gid=1000 && \
-    useradd -r -g stackable --uid=1000 -d /stackable stackable && \
-    chown -R stackable:stackable /stackable
 
 USER stackable
 WORKDIR /stackable


### PR DESCRIPTION
Use java-base:11-stackable0.3.0 which contains Vector, as base image for HBase.