### PR TITLE
Prepare hive image for log4j2

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -71,6 +71,7 @@ products = [
             {
                 'product': '2.3.9',
                 'hadoop': '2.10.1',
+                'jackson_dataformat_xml': '2.7.9',
                 'aws_java_sdk_bundle': '1.11.271',
                 'azure_storage': '7.0.1',
                 'azure_keyvault_core': '1.0.0',
@@ -78,6 +79,7 @@ products = [
             {
                 'product': '3.1.3',
                 'hadoop': '3.3.3',
+                'jackson_dataformat_xml': '2.12.3',
                 'aws_java_sdk_bundle': '1.11.1026',
                 'azure_storage': '7.0.1',
                 'azure_keyvault_core': '1.0.0',

--- a/hive/CHANGELOG.md
+++ b/hive/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [hive2.3.9-stackable0.8.0] [hive3.1.3-stackable0.4.0] - 2023-01-23
+## [Unreleased]
 
 ### Added
 

--- a/hive/CHANGELOG.md
+++ b/hive/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [hive2.3.9-stackable0.8.0] [hive3.1.3-stackable0.4.0] - 2023-01-23
+
+### Added
+
+- Added `jackson-dataformat-xml-2.7.9.jar` (2.3.9) and `jackson-dataformat-xml-2.12.3.jar` (3.1.3) for XmlFormat conversion for logging ([#293]).
+
+[#293]: https://github.com/stackabletech/docker-images/pull/293
+
 ## [hive2.3.9-stackable0.7.0] [hive3.1.3-stackable0.3.0] - 2023-01-16
 
 ### Changed

--- a/hive/Dockerfile
+++ b/hive/Dockerfile
@@ -63,7 +63,21 @@ RUN curl https://repo.stackable.tech/repository/packages/jmx-exporter/jmx_promet
     -o /stackable/jmx/jmx_prometheus_javaagent-0.16.1.jar && \
     chmod -x /stackable/jmx/jmx_prometheus_javaagent-0.16.1.jar
 
+# Download logging
+RUN curl https://repo1.maven.org/maven2/org/slf4j/slf4j-api/2.0.6/slf4j-api-2.0.6.jar \
+    -o /stackable/hive/lib/slf4j-api-2.0.6.jar && \
+    chmod -x /stackable/hive/lib/slf4j-api-2.0.6.jar && \
+    curl https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/2.0.6/slf4j-simple-2.0.6.jar \
+    -o /stackable/hive/lib/slf4j-simple-2.0.6.jar && \
+    chmod -x /stackable/hive/lib/slf4j-simple-2.0.6.jar
+
+# for XmlLayout
+RUN curl https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-xml/2.12.0/jackson-dataformat-xml-2.12.0.jar \
+    -o /stackable/hive/lib/jackson-dataformat-xml-2.12.0.jar && \
+    chmod -x /stackable/hive/lib/jackson-dataformat-xml-2.12.0.jar
+
 ENV HADOOP_HOME=/stackable/hadoop
+ENV HIVE_HOME=/stackable/hive
 
 # ===
 # Mitigation for CVE-2021-44228 (Log4Shell)

--- a/hive/Dockerfile
+++ b/hive/Dockerfile
@@ -2,6 +2,7 @@ FROM docker.stackable.tech/stackable/java-base:11-stackable0.3.0@sha256:5c7f9e72
 
 ARG PRODUCT
 ARG HADOOP
+ARG JACKSON_DATAFORMAT_XML
 ARG AWS_JAVA_SDK_BUNDLE
 ARG AZURE_STORAGE
 ARG AZURE_KEYVAULT_CORE
@@ -65,9 +66,9 @@ RUN curl https://repo.stackable.tech/repository/packages/jmx-exporter/jmx_promet
 
 # Logging
 RUN rm /stackable/hive/lib/log4j-slf4j-impl* && \
-    curl https://repo.stackable.tech/repository/packages/hive-jackson-dataformat-xml/${PRODUCT}/jackson-dataformat-xml-2.12.0.jar \
-    -o /stackable/hive/lib/jackson-dataformat-xml-2.12.0.jar && \
-    chmod -x /stackable/hive/lib/jackson-dataformat-xml-2.12.0.jar
+    curl https://repo.stackable.tech/repository/packages/hive-jackson-dataformat-xml/${PRODUCT}/jackson-dataformat-xml-${JACKSON_DATAFORMAT_XML}.jar \
+    -o /stackable/hive/lib/jackson-dataformat-xml-${JACKSON_DATAFORMAT_XML}.jar && \
+    chmod -x /stackable/hive/lib/jackson-dataformat-xml-${JACKSON_DATAFORMAT_XML}.jar
 
 ENV HADOOP_HOME=/stackable/hadoop
 ENV HIVE_HOME=/stackable/hive

--- a/hive/Dockerfile
+++ b/hive/Dockerfile
@@ -63,16 +63,9 @@ RUN curl https://repo.stackable.tech/repository/packages/jmx-exporter/jmx_promet
     -o /stackable/jmx/jmx_prometheus_javaagent-0.16.1.jar && \
     chmod -x /stackable/jmx/jmx_prometheus_javaagent-0.16.1.jar
 
-# Download logging
-RUN curl https://repo1.maven.org/maven2/org/slf4j/slf4j-api/2.0.6/slf4j-api-2.0.6.jar \
-    -o /stackable/hive/lib/slf4j-api-2.0.6.jar && \
-    chmod -x /stackable/hive/lib/slf4j-api-2.0.6.jar && \
-    curl https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/2.0.6/slf4j-simple-2.0.6.jar \
-    -o /stackable/hive/lib/slf4j-simple-2.0.6.jar && \
-    chmod -x /stackable/hive/lib/slf4j-simple-2.0.6.jar
-
-# for XmlLayout
-RUN curl https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-xml/2.12.0/jackson-dataformat-xml-2.12.0.jar \
+# Logging
+RUN rm /stackable/hive/lib/log4j-slf4j-impl* && \
+    curl https://repo.stackable.tech/repository/packages/hive-jackson-dataformat-xml/${PRODUCT}/jackson-dataformat-xml-2.12.0.jar \
     -o /stackable/hive/lib/jackson-dataformat-xml-2.12.0.jar && \
     chmod -x /stackable/hive/lib/jackson-dataformat-xml-2.12.0.jar
 


### PR DESCRIPTION
Added `jackson-dataformat-xml-x.x.x.jar` for Hive 2.3.9 and 3.1.3 log4j2 XmlFormat.

Do not merge before release 23.1 is done!