### PR TITLE
Prepare NiFi image for logging

### DIFF
--- a/nifi/CHANGELOG.md
+++ b/nifi/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## [nifi1.15.3-stackable???] [nifi1.16.3-stackable???] [nifi1.18.0-stackable???] - 2023-??-??
+
+### Changed
+
+- Upgraded to the base image java-base:11-stackable0.3.0. The java-base image
+  contains a layer which provides Vector. The creation of the stackable user
+  and group happens in the stackable-base layer and is therefore removed from
+  this image ([#xxx]).
+
+[#xxx]: https://github.com/stackabletech/docker-images/pull/xxx

--- a/nifi/CHANGELOG.md
+++ b/nifi/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## [nifi1.15.3-stackable???] [nifi1.16.3-stackable???] [nifi1.18.0-stackable???] - 2023-??-??
+## [Unreleased]
 
 ### Changed
 
 - Upgraded to the base image java-base:11-stackable0.3.0. The java-base image
   contains a layer which provides Vector. The creation of the stackable user
   and group happens in the stackable-base layer and is therefore removed from
-  this image ([#xxx]).
+  this image ([#297]).
 
-[#xxx]: https://github.com/stackabletech/docker-images/pull/xxx
+[#297]: https://github.com/stackabletech/docker-images/pull/297

--- a/nifi/Dockerfile
+++ b/nifi/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.stackable.tech/stackable/java-base:11-stackable0.2.2@sha256:7929833412c331fc23cde0e23ca730d652c0be61a8a69c8a82b2af937a3fbd4e
+FROM docker.stackable.tech/stackable/java-base:11-stackable0.3.0@sha256:5c7f9e7274bd68ea264138b13504efa16fb22ee1122e7d12af32f343eb93c837
 
 ARG PRODUCT
 ARG RELEASE
@@ -15,13 +15,11 @@ LABEL name="Apache NiFi" \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN microdnf update && \
-    microdnf install tar gzip zip openssl libxslt-devel libxml2-devel gcc shadow-utils && \
+    microdnf install tar gzip zip openssl libxslt-devel libxml2-devel gcc && \
     microdnf install python3-devel python3-pip python3-setuptools && \
     microdnf clean all
 
 RUN pip3 install --no-cache-dir nipyapi==0.19.1
-RUN groupadd -r stackable --gid=1000 && \
-    useradd -r -g stackable --uid=1000 stackable
 
 USER stackable
 WORKDIR /stackable


### PR DESCRIPTION
- Use vector base image
- Removed shadow-utils (in vector base image)
- Removed user and group add

Do not merge before release 23.1 is done!