### PR TITLE
Fix broken Superset image 23.4.0-rc1

### DIFF
--- a/superset/CHANGELOG.md
+++ b/superset/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- setuptools pinned to version 66.1.1 because newer versions are not
+  compatible with the supported Superset versions. With version 67.0.0,
+  the requirements of Superset cannot be parsed anymore (see also
+  https://github.com/pypa/setuptools/pull/3790) [(#307)].
+
+[#307]: https://github.com/stackabletech/docker-images/pull/307
+
 ## [superset1.5.1-stackable0.2.0] - 2022-07-13
 
 - Add Trino sqlalchemy library ([#153]).

--- a/superset/CHANGELOG.md
+++ b/superset/CHANGELOG.md
@@ -7,7 +7,7 @@
 - setuptools pinned to version 66.1.1 because newer versions are not
   compatible with the supported Superset versions. With version 67.0.0,
   the requirements of Superset cannot be parsed anymore (see also
-  https://github.com/pypa/setuptools/pull/3790) [(#307)].
+  <https://github.com/pypa/setuptools/pull/3790>) ([#307]).
 
 [#307]: https://github.com/stackabletech/docker-images/pull/307
 

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -27,7 +27,7 @@ RUN microdnf update \
     && pip install \
         --no-cache-dir \
         --upgrade \
-        setuptools \
+        setuptools==66.1.1 \
         pip \
     && pip install \
         --no-cache-dir \


### PR DESCRIPTION
setuptools pinned to version 66.1.1.

The setuptools version 67.0.0 and newer are not compatible with the supported Superset versions because parsing of the requirements is more strict and fails in Superset (see also pypa/setuptools#3790).

This fixes the following error when starting Superset:

```
Traceback (most recent call last):
  File "/stackable/app/lib64/python3.8/site-packages/pkg_resources/__init__.py", line 3030, in _dep_map
    return self.__dep_map
  File "/stackable/app/lib64/python3.8/site-packages/pkg_resources/__init__.py", line 2826, in __getattr__
    raise AttributeError(attr)
AttributeError: _DistInfoDistribution__dep_map

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/stackable/app/lib64/python3.8/site-packages/pkg_resources/_vendor/packaging/requirements.py", line 35, in __init__
    parsed = parse_requirement(requirement_string)
  File "/stackable/app/lib64/python3.8/site-packages/pkg_resources/_vendor/packaging/_parser.py", line 64, in parse_requirement
    return _parse_requirement(Tokenizer(source, rules=DEFAULT_RULES))
  File "/stackable/app/lib64/python3.8/site-packages/pkg_resources/_vendor/packaging/_parser.py", line 82, in _parse_requirement
    url, specifier, marker = _parse_requirement_details(tokenizer)
  File "/stackable/app/lib64/python3.8/site-packages/pkg_resources/_vendor/packaging/_parser.py", line 120, in _parse_requirement_details
    specifier = _parse_specifier(tokenizer)
  File "/stackable/app/lib64/python3.8/site-packages/pkg_resources/_vendor/packaging/_parser.py", line 209, in _parse_specifier
    tokenizer.consume("WS")
  File "/usr/lib64/python3.8/contextlib.py", line 120, in __exit__
    next(self.gen)
  File "/stackable/app/lib64/python3.8/site-packages/pkg_resources/_vendor/packaging/_tokenizer.py", line 183, in enclosing_tokens
    self.raise_syntax_error(
  File "/stackable/app/lib64/python3.8/site-packages/pkg_resources/_vendor/packaging/_tokenizer.py", line 163, in raise_syntax_error
    raise ParserSyntaxError(
pkg_resources.extern.packaging._tokenizer.ParserSyntaxError: Expected closing RIGHT_PARENTHESIS
    pytz (>dev)
         ~^

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/stackable/app/bin/superset", line 33, in <module>
    sys.exit(load_entry_point('apache-superset==1.5.1', 'console_scripts', 'superset')())
  File "/stackable/app/bin/superset", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/lib64/python3.8/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/usr/lib64/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/stackable/app/lib64/python3.8/site-packages/superset/cli/main.py", line 28, in <module>
    from superset.cli.lib import normalize_token
  File "/stackable/app/lib64/python3.8/site-packages/superset/cli/lib.py", line 20, in <module>
    from superset import config
  File "/stackable/app/lib64/python3.8/site-packages/superset/config.py", line 35, in <module>
    import pkg_resources
  File "/stackable/app/lib64/python3.8/site-packages/pkg_resources/__init__.py", line 3249, in <module>
    def _initialize_master_working_set():
  File "/stackable/app/lib64/python3.8/site-packages/pkg_resources/__init__.py", line 3223, in _call_aside
    f(*args, **kwargs)
  File "/stackable/app/lib64/python3.8/site-packages/pkg_resources/__init__.py", line 3261, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/stackable/app/lib64/python3.8/site-packages/pkg_resources/__init__.py", line 617, in _build_master
    ws.require(__requires__)
  File "/stackable/app/lib64/python3.8/site-packages/pkg_resources/__init__.py", line 956, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/stackable/app/lib64/python3.8/site-packages/pkg_resources/__init__.py", line 820, in resolve
    new_requirements = dist.requires(req.extras)[::-1]
  File "/stackable/app/lib64/python3.8/site-packages/pkg_resources/__init__.py", line 2746, in requires
    dm = self._dep_map
  File "/stackable/app/lib64/python3.8/site-packages/pkg_resources/__init__.py", line 3032, in _dep_map
    self.__dep_map = self._compute_dependencies()
  File "/stackable/app/lib64/python3.8/site-packages/pkg_resources/__init__.py", line 3042, in _compute_dependencies
    reqs.extend(parse_requirements(req))
  File "/stackable/app/lib64/python3.8/site-packages/pkg_resources/__init__.py", line 3095, in __init__
    super(Requirement, self).__init__(requirement_string)
  File "/stackable/app/lib64/python3.8/site-packages/pkg_resources/_vendor/packaging/requirements.py", line 37, in __init__
    raise InvalidRequirement(str(e)) from e
pkg_resources.extern.packaging.requirements.InvalidRequirement: Expected closing RIGHT_PARENTHESIS
    pytz (>dev)
         ~^
```