### PR TITLE
Build images using docker buildx bake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Updated java base image to latest ubi8 tag 8.6-994 ([#249]).
 - Updated all java-base images to stackable0.2.2 ([#250]).
 - Updated all ubi8 base images to latest (8.6-994) ([#250]).
+- Updated all internal images to rebuild their base images on demand ([#321]).
 
 ### Removed
 
@@ -24,3 +25,4 @@ All notable changes to this project will be documented in this file.
 [#248]: https://github.com/stackabletech/docker-images/pull/248
 [#249]: https://github.com/stackabletech/docker-images/pull/249
 [#250]: https://github.com/stackabletech/docker-images/pull/250
+[#321]: https://github.com/stackabletech/docker-images/pull/321

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker.stackable.tech/stackable/vector:0.26.0-stackable1.1.0@sha256:a0555b112329409669e33ebfb4044b332ade5a8286cf6506e34f2608c66c05d4 AS airflow-build-image
+# syntax=docker/dockerfile:1
+FROM stackable/image/vector AS airflow-build-image
 
 ARG PRODUCT
 ARG PYTHON
@@ -28,7 +29,7 @@ RUN microdnf update \
         && pip install --no-cache-dir apache-airflow[${AIRFLOW_EXTRAS}]==${PRODUCT} --constraint /tmp/constraints.txt
 
 FROM prom/statsd-exporter:0.3.0@sha256:a9c27602d6f6b86527657922b6a87c12789f7f9b39a90f1513e8c665c941f26a as statsd-exporter
-FROM docker.stackable.tech/stackable/vector:0.26.0-stackable23.4.0-rc1@sha256:a0555b112329409669e33ebfb4044b332ade5a8286cf6506e34f2608c66c05d4 AS airflow-main-image
+FROM stackable/image/vector AS airflow-main-image
 
 ARG PRODUCT
 ARG PYTHON

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -139,9 +139,9 @@ def generate_bakefile(args: Namespace):
     """
     targets = {}
     groups = {}
-    products = {product["name"]: product for product in conf.products}
-    product_names = list(products.keys())
-    for product_name, product in products.items():
+    product_names = [product["name"] for product in conf.products]
+    for product in conf.products:
+        product_name = product["name"]
         product_targets = {}
         for version_dict in product.get("versions"):
             product_targets.update(bakefile_product_version_targets(args, product_name, version_dict, product_names))

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -139,13 +139,12 @@ def generate_bakefile(args: Namespace):
     """
     targets = {}
     groups = {}
-    contexts = {}
     products = {product["name"]: product for product in conf.products}
     product_names = list(products.keys())
     for product_name, product in products.items():
         product_targets = {}
         for version_dict in product.get("versions"):
-            product_targets.update(bakefile_product_version_targets(args, product_name, version_dict, contexts, product_names))
+            product_targets.update(bakefile_product_version_targets(args, product_name, version_dict, product_names))
         groups[product_name] = {
             "targets": list(product_targets.keys()),
         }
@@ -166,7 +165,7 @@ def bakefile_target_name_for_product_version(product_name: str, version: str) ->
     return f"{ product_name }-{ version.replace('.', '_') }"
 
 
-def bakefile_product_version_targets(args: Namespace, product_name: str, versions: Dict[str, str], contexts: Dict[str, str], product_names: List[str]):
+def bakefile_product_version_targets(args: Namespace, product_name: str, versions: Dict[str, str], product_names: List[str]):
     """
     Creates Bakefile targets defining how to build a given product version.
 

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -22,10 +22,13 @@ To also push the image to a remote registry, add the the `--push` argument.
 
 NOTE: Pushing images to a remote registry assumes you have performed a `docker login` beforehand.
 
-Some images build on top of others. These images are used as base images and might need to be built first:
+Some images build on top of others. These images are used as base images and will be built first:
     1. java-base
     2. ubi8-rust-builder
     3. tools
+
+If a key in products[_].versions matches another product definition then it is assumed that it is a dependency,
+and that product will be built first. It can then be used as a base layer using the format `stackable/image/{product}`.
 """
 from os.path import isdir
 from typing import List, Dict

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -130,6 +130,7 @@ def build_image_tags(image_name: str, image_version: str, product_version: str) 
         f"{image_name}:{product_version}-stackable{image_version}",
     ]
 
+
 def generate_bakefile(args: Namespace):
     """
     Generates a Bakefile (https://docs.docker.com/build/bake/file-definition/) describing how to build the whole image graph.
@@ -157,11 +158,13 @@ def generate_bakefile(args: Namespace):
         "group": groups,
     }
 
+
 def bakefile_target_name_for_product_version(product_name: str, version: str) -> str:
     """
     Creates a normalized Bakefile target name for a given (product, version) combination.
     """
     return f"{ product_name }-{ version.replace('.', '_') }"
+
 
 def bakefile_product_version_targets(args: Namespace, product_name: str, versions: Dict[str, str], contexts: Dict[str, str], product_names: List[str]):
     """
@@ -209,12 +212,13 @@ def build_and_publish_image(args: Namespace, product_name: str, bakefile) -> Lis
             "bake",
             "--file",
             "-",
-            *([] if product_name == None else [product_name]),
+            *([] if product_name is None else [product_name]),
             *target_mode,
         ],
         "stdin": json.dumps(bakefile),
     }
     return [command]
+
 
 def run_commands(dry, commands):
     """

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -189,7 +189,7 @@ def bakefile_product_version_targets(args: Namespace, product_name: str, version
     }
 
 
-def build_and_publish_image(args: Namespace, product_name: str, bakefile) -> List[List[str]]:
+def build_and_publish_image(args: Namespace, product_name: str, bakefile):
     """
     Returns a list of commands that need to be run in order to build and
     publish product images.

--- a/build_product_images.py
+++ b/build_product_images.py
@@ -149,6 +149,9 @@ def generate_bakefile(args: Namespace):
             "targets": list(product_targets.keys()),
         }
         targets.update(product_targets)
+    groups["default"] = {
+        "targets": list(groups.keys()),
+    }
     return {
         "target": targets,
         "group": groups,
@@ -206,7 +209,7 @@ def build_and_publish_image(args: Namespace, product_name: str, bakefile) -> Lis
             "bake",
             "--file",
             "-",
-            product_name,
+            *([] if product_name == None else [product_name]),
             *target_mode,
         ],
         "stdin": json.dumps(bakefile),
@@ -266,13 +269,8 @@ def main():
         create_virtual_environment(args)
 
     try:
-        for product in conf.products:
-            product_name = product.get("name")
-            if args.product is not None and (product_name != args.product):
-                continue
-
-            commands = build_and_publish_image(args, product_name, bakefile)
-            run_commands(args.dry, commands)
+        commands = build_and_publish_image(args, args.product, bakefile)
+        run_commands(args.dry, commands)
     finally:
         if len(args.architecture) > 1:
             remove_virtual_environment(args)

--- a/conf.py
+++ b/conf.py
@@ -33,39 +33,51 @@ products = [
         'versions': [
             {
                 'product': '0.23.0',
+                'java-base': '11',
                 'authorizer': '0.2.0',
             },
             {
                 'product': '24.0.0',
+                'java-base': '11',
                 'authorizer': '0.4.0',
             }
         ]
     },
     {
         'name': 'hadoop',
-        'versions': [{'product': '3.2.2'}, {'product': '3.3.1'}, {'product': '3.3.3'}, {'product': '3.3.4'}],
+        'versions': [
+            {'product': '3.2.2', 'java-base': '11'},
+            {'product': '3.3.1', 'java-base': '11'},
+            {'product': '3.3.3', 'java-base': '11'},
+            {'product': '3.3.4', 'java-base': '11'},
+        ],
     },
     {
         'name': 'hbase',
         'versions': [
             {
                 'product': '2.4.6',
+                'java-base': '11',
                 'phoenix': '2.4-5.1.2',
             },
             {
                 'product': '2.4.8',
+                'java-base': '11',
                 'phoenix': '2.4-5.1.2',
             },
             {
                 'product': '2.4.9',
+                'java-base': '11',
                 'phoenix': '2.4-5.1.2',
             },
             {
                 'product': '2.4.11',
+                'java-base': '11',
                 'phoenix': '2.4-5.1.2',
             },
             {
                 'product': '2.4.12',
+                'java-base': '11',
                 'phoenix': '2.4-5.1.2',
             },
         ]
@@ -84,6 +96,7 @@ products = [
             # },
             {
                 'product': '3.1.3',
+                'java-base': '11',
                 'hadoop': '3.3.3',
                 'jackson_dataformat_xml': '2.12.3',
                 'aws_java_sdk_bundle': '1.11.1026',
@@ -112,26 +125,31 @@ products = [
         'versions': [
             {
                 'product': '2.7.1',
+                'java-base': '11',
                 'scala': '2.13',
                 'opa_authorizer': '1.4.0',
             },
             {
                 'product': '2.8.1',
+                'java-base': '11',
                 'scala': '2.13',
                 'opa_authorizer': '1.4.0',
             },
             {
                 'product': '3.1.0',
+                'java-base': '11',
                 'scala': '2.13',
                 'opa_authorizer': '1.4.0',
             },
             {
                 'product': '3.2.0',
+                'java-base': '11',
                 'scala': '2.13',
                 'opa_authorizer': '1.4.0',
             },
             {
                 'product': '3.3.1',
+                'java-base': '11',
                 'scala': '2.13',
                 'opa_authorizer': '1.4.0',
             },
@@ -143,23 +161,34 @@ products = [
     },
     {
         'name': 'nifi',
-        'versions': [{'product': '1.15.3'}, {'product': '1.16.3'}, {'product': '1.18.0'}],
+        'versions': [
+            {'product': '1.15.3', 'java-base': '11'},
+            {'product': '1.16.3', 'java-base': '11'},
+            {'product': '1.18.0', 'java-base': '11'},
+        ],
     },
     {
         'name': 'opa',
-        'versions': [{'product': '0.27.1'}, {'product': '0.28.0'}, {'product': '0.37.2'}, {'product': '0.41.0'},
-                     {'product': '0.45.0'}],
+        'versions': [
+            {'product': '0.27.1', 'stackable-base': '1.0.0'},
+            {'product': '0.28.0', 'stackable-base': '1.0.0'},
+            {'product': '0.37.2', 'stackable-base': '1.0.0'},
+            {'product': '0.41.0', 'stackable-base': '1.0.0'},
+            {'product': '0.45.0', 'stackable-base': '1.0.0'},
+        ],
     },
     {
         'name': 'pyspark-k8s',
         'versions': [
             {
                 'product': '3.2.1',
+                'stackable-base': '1.0.0',
                 'python': '39',
                 'hadoop_short_version': '3.2',
             },
             {
                 'product': '3.3.0',
+                'stackable-base': '1.0.0',
                 'python': '39',
                 'hadoop_short_version': '3',
                 'hadoop_long_version': '3.3.3',
@@ -174,10 +203,12 @@ products = [
         'versions': [
             {
                 'product': '3.2.1',
+                'stackable-base': '1.0.0',
                 'hadoop_short_version': '3.2',
             },
             {
                 'product': '3.3.0',
+                'stackable-base': '1.0.0',
                 'hadoop_short_version': '3',
                 'hadoop_long_version': '3.3.3',
                 'aws_java_sdk_bundle': '1.11.1026',
@@ -195,14 +226,17 @@ products = [
         'versions': [
             {
                 'product': '1.3.2',
+                'stackable-base': '1.0.0',
                 'python': '3.8',
             },
             {
                 'product': '1.4.1',
+                'stackable-base': '1.0.0',
                 'python': '3.9',
             },
             {
                 'product': '1.5.1',
+                'stackable-base': '1.0.0',
                 'python': '3.8',
             },
         ],
@@ -212,44 +246,40 @@ products = [
         'versions': [
             {
                 'product': '377',
-                'java': '11',
-                'java_base_image_sha256': '7929833412c331fc23cde0e23ca730d652c0be61a8a69c8a82b2af937a3fbd4e',
+                'java-base': '11',
                 'opa_authorizer': '0.1.0',
             },
             {
                 'product': '387',
-                'java': '11',
-                'java_base_image_sha256': '7929833412c331fc23cde0e23ca730d652c0be61a8a69c8a82b2af937a3fbd4e',
+                'java-base': '11',
                 'opa_authorizer': '0.1.0'
             },
             {
                 'product': '395',
-                'java': '17',
-                'java_base_image_sha256': '2b8d60d1ab50d56240cb6286d6bc377410442afbfc3292d81be5674bc0b51724',
+                'java-base': '17',
                 'opa_authorizer': 'stackable0.1.0'
             },
             {
                 'product': '396',
-                'java': '17',
-                'java_base_image_sha256': '2b8d60d1ab50d56240cb6286d6bc377410442afbfc3292d81be5674bc0b51724',
+                'java-base': '17',
                 'opa_authorizer': 'stackable0.1.0'
             },
             {
                 'product': '403',
-                'java': '17',
-                'java_base_image_sha256': '2b8d60d1ab50d56240cb6286d6bc377410442afbfc3292d81be5674bc0b51724',
+                'java-base': '17',
                 'opa_authorizer': 'stackable0.1.0'
             },
         ],
     },
     {
         'name': 'tools',
-        'versions': [{'product': '0.2.0'}],
+        'versions': [{'product': '0.2.0', 'stackable-base': '1.0.0'}],
     },
-    {
-        'name': 'testing-tools',
-        'versions': [{'product': '0.1.0'}],
-    },
+    # Build is broken
+    # {
+    #     'name': 'testing-tools',
+    #     'versions': [{'product': '0.1.0'}],
+    # },
     {
         # ZooKeeper must be at least 3.5.0
         'name': 'zookeeper',

--- a/conf.py
+++ b/conf.py
@@ -85,19 +85,19 @@ products = [
     {
         'name': 'hive',
         'versions': [
-            # Hadoop 2.10.1 is no longer supported
-            # {
-            #     'product': '2.3.9',
-            #     'hadoop': '2.10.1',
-            #     'jackson_dataformat_xml': '2.7.9',
-            #     'aws_java_sdk_bundle': '1.11.271',
-            #     'azure_storage': '7.0.1',
-            #     'azure_keyvault_core': '1.0.0',
-            # },
+            {
+                'product': '2.3.9',
+                'java-base': '11',
+                'hadoop_libs': '2.10.1',
+                'jackson_dataformat_xml': '2.7.9',
+                'aws_java_sdk_bundle': '1.11.271',
+                'azure_storage': '7.0.1',
+                'azure_keyvault_core': '1.0.0',
+            },
             {
                 'product': '3.1.3',
                 'java-base': '11',
-                'hadoop': '3.3.3',
+                'hadoop_libs': '3.3.3',
                 'jackson_dataformat_xml': '2.12.3',
                 'aws_java_sdk_bundle': '1.11.1026',
                 'azure_storage': '7.0.1',

--- a/conf.py
+++ b/conf.py
@@ -9,18 +9,22 @@ products = [
             {
                 'product': '2.2.3',
                 'python': '38',
+                'vector': '0.26.0',
             },
             {
                 'product': '2.2.4',
                 'python': '39',
+                'vector': '0.26.0',
             },
             {
                 'product': '2.2.5',
                 'python': '39',
+                'vector': '0.26.0',
             },
             {
                 'product': '2.4.1',
                 'python': '39',
+                'vector': '0.26.0',
             },
         ]
     },

--- a/conf.py
+++ b/conf.py
@@ -73,14 +73,15 @@ products = [
     {
         'name': 'hive',
         'versions': [
-            {
-                'product': '2.3.9',
-                'hadoop': '2.10.1',
-                'jackson_dataformat_xml': '2.7.9',
-                'aws_java_sdk_bundle': '1.11.271',
-                'azure_storage': '7.0.1',
-                'azure_keyvault_core': '1.0.0',
-            },
+            # Hadoop 2.10.1 is no longer supported
+            # {
+            #     'product': '2.3.9',
+            #     'hadoop': '2.10.1',
+            #     'jackson_dataformat_xml': '2.7.9',
+            #     'aws_java_sdk_bundle': '1.11.271',
+            #     'azure_storage': '7.0.1',
+            #     'azure_keyvault_core': '1.0.0',
+            # },
             {
                 'product': '3.1.3',
                 'hadoop': '3.3.3',

--- a/conf.py
+++ b/conf.py
@@ -1,6 +1,15 @@
 """
 Application images will be created for products and associated versions configured here.
 """
+
+java_base_11 = {
+    'name': 'java-base',
+    'versions': {
+        'product': '11',
+        '_security_path': '/usr/lib/jvm/jre-11/conf/security/java.security',
+    },
+}
+
 products = [
     {
         'name': 'airflow',
@@ -246,5 +255,6 @@ products = [
         # ZooKeeper must be at least 3.5.0
         'name': 'zookeeper',
         'versions': [{'product': '3.5.8'}, {'product': '3.6.3'}, {'product': '3.7.0'}, {'product': '3.8.0'}],
+        'dependencies': [java_base_11],
     },
 ]

--- a/conf.py
+++ b/conf.py
@@ -2,14 +2,6 @@
 Application images will be created for products and associated versions configured here.
 """
 
-java_base_11 = {
-    'name': 'java-base',
-    'versions': {
-        'product': '11',
-        '_security_path': '/usr/lib/jvm/jre-11/conf/security/java.security',
-    },
-}
-
 products = [
     {
         'name': 'airflow',
@@ -100,10 +92,12 @@ products = [
         'versions': [
             {
                 'product': '11',
+                'vector': '0.26.0',
                 '_security_path': '/usr/lib/jvm/jre-11/conf/security/java.security',
             },
             {
                 'product': '17',
+                'vector': '0.26.0',
                 '_security_path': '/usr/lib/jvm/jre-17/conf/security/java.security',
             },
         ],
@@ -140,7 +134,7 @@ products = [
     },
     {
         'name': 'vector',
-        'versions': ['0.26.0'],
+        'versions': [{'product': '0.26.0', 'stackable-base': '1.0.0'}],
     },
     {
         'name': 'nifi',
@@ -189,7 +183,7 @@ products = [
     },
     {
         'name': 'stackable-base',
-        'versions': ['1.0.0'],
+        'versions': [{'product': '1.0.0'}],
     },
     {
         'name': 'superset',
@@ -254,7 +248,11 @@ products = [
     {
         # ZooKeeper must be at least 3.5.0
         'name': 'zookeeper',
-        'versions': [{'product': '3.5.8'}, {'product': '3.6.3'}, {'product': '3.7.0'}, {'product': '3.8.0'}],
-        'dependencies': [java_base_11],
+        'versions': [
+            {'product': '3.5.8', 'java-base': '11'},
+            {'product': '3.6.3', 'java-base': '11'},
+            {'product': '3.7.0', 'java-base': '11'},
+            {'product': '3.8.0', 'java-base': '11'},
+        ],
     },
 ]

--- a/druid/Dockerfile
+++ b/druid/Dockerfile
@@ -1,6 +1,7 @@
+# syntax=docker/dockerfile:1
 # druid < 0.23 druid only fully supports java 8
 # druid >= 0.23 is java 11 ready
-FROM docker.stackable.tech/stackable/java-base:11-stackable0.2.2@sha256:7929833412c331fc23cde0e23ca730d652c0be61a8a69c8a82b2af937a3fbd4e
+FROM stackable/image/java-base
 
 ARG PRODUCT
 ARG AUTHORIZER
@@ -20,9 +21,6 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN microdnf update && \
     microdnf install findutils openssl tar gzip zip shadow-utils && \
     microdnf clean all
-
-RUN groupadd -r stackable --gid=1000 && \
-    useradd -r -g stackable --uid=1000 stackable
 
 USER stackable
 WORKDIR /stackable

--- a/hadoop/Dockerfile
+++ b/hadoop/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker.stackable.tech/stackable/java-base:11-stackable0.3.0@sha256:5c7f9e7274bd68ea264138b13504efa16fb22ee1122e7d12af32f343eb93c837
+# syntax=docker/dockerfile:1
+FROM stackable/image/java-base
 
 ARG PRODUCT
 ARG RELEASE

--- a/hbase/Dockerfile
+++ b/hbase/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker.stackable.tech/stackable/java-base:11-stackable0.3.0@sha256:5c7f9e7274bd68ea264138b13504efa16fb22ee1122e7d12af32f343eb93c837
+# syntax=docker/dockerfile:1
+FROM stackable/image/java-base
 
 ARG PRODUCT
 ARG PHOENIX

--- a/hive/Dockerfile
+++ b/hive/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker.stackable.tech/stackable/java-base:11-stackable0.3.0@sha256:5c7f9e7274bd68ea264138b13504efa16fb22ee1122e7d12af32f343eb93c837
+# syntax=docker/dockerfile:1
+FROM stackable/image/java-base
 
 ARG PRODUCT
 ARG HADOOP

--- a/hive/Dockerfile
+++ b/hive/Dockerfile
@@ -2,7 +2,7 @@
 FROM stackable/image/java-base
 
 ARG PRODUCT
-ARG HADOOP
+ARG HADOOP_LIBS
 ARG JACKSON_DATAFORMAT_XML
 ARG AWS_JAVA_SDK_BUNDLE
 ARG AZURE_STORAGE
@@ -33,14 +33,14 @@ WORKDIR /stackable
 # Download hive and hadoop
 RUN curl -L https://repo.stackable.tech/repository/packages/hive/apache-hive-${PRODUCT}-bin.tar.gz | tar -xzC . && \
     ln -s /stackable/apache-hive-${PRODUCT}-bin/apache-hive-${PRODUCT}-bin /stackable/hive && \
-    ln -s /stackable/apache-hive-${PRODUCT}-bin/hadoop-${HADOOP} /stackable/hadoop && \
+    ln -s /stackable/apache-hive-${PRODUCT}-bin/hadoop-${HADOOP_LIBS} /stackable/hadoop && \
     # Force to overwrite the existing 'start-metastore'
     ln -sf /stackable/bin/start-metastore /stackable/hive/bin/start-metastore
 
 # Download aws module for Hadoop (support for s3a://)
-RUN curl -L https://repo.stackable.tech/repository/packages/aws/hadoop-aws-${HADOOP}.jar \
-    -o /stackable/hive/lib/hadoop-aws-${HADOOP}.jar && \
-    chmod -x /stackable/hive/lib/hadoop-aws-${HADOOP}.jar
+RUN curl -L https://repo.stackable.tech/repository/packages/aws/hadoop-aws-${HADOOP_LIBS}.jar \
+    -o /stackable/hive/lib/hadoop-aws-${HADOOP_LIBS}.jar && \
+    chmod -x /stackable/hive/lib/hadoop-aws-${HADOOP_LIBS}.jar
 
 # Download aws sdk bundle containing all the needed S3 Classes for hadoop-aws. Must match version hadoop-aws was compiled against
 RUN curl -L https://repo.stackable.tech/repository/packages/aws/aws-java-sdk-bundle-${AWS_JAVA_SDK_BUNDLE}.jar \
@@ -48,9 +48,9 @@ RUN curl -L https://repo.stackable.tech/repository/packages/aws/aws-java-sdk-bun
     chmod -x /stackable/hive/lib/aws-java-sdk-bundle-${AWS_JAVA_SDK_BUNDLE}.jar
 
 # Download azure module for Hadoop (support for abfs://)
-RUN curl -L https://repo.stackable.tech/repository/packages/aws/hadoop-azure-${HADOOP}.jar \
-    -o /stackable/hive/lib/hadoop-azure-${HADOOP}.jar && \
-    chmod -x /stackable/hive/lib/hadoop-azure-${HADOOP}.jar
+RUN curl -L https://repo.stackable.tech/repository/packages/aws/hadoop-azure-${HADOOP_LIBS}.jar \
+    -o /stackable/hive/lib/hadoop-azure-${HADOOP_LIBS}.jar && \
+    chmod -x /stackable/hive/lib/hadoop-azure-${HADOOP_LIBS}.jar
 
 # Download azure libs containing all the needed ABFS Classes for hadoop-azure. Must match version hadoop-azure was compiled against
 RUN curl -L https://repo.stackable.tech/repository/packages/azure/azure-storage-${AZURE_STORAGE}.jar \

--- a/java-base/Dockerfile
+++ b/java-base/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker.stackable.tech/stackable/vector:0.26.0-stackable1.0.0@sha256:4be0d98ca353b3ddb54212ced702504d58995b2b75fbfa07fe001fd992513692
+# syntax=docker/dockerfile:1
+FROM stackable/image/vector
 
 ARG PRODUCT
 ARG RELEASE="1"

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker.stackable.tech/stackable/java-base:11-stackable0.3.0@sha256:5c7f9e7274bd68ea264138b13504efa16fb22ee1122e7d12af32f343eb93c837 AS builder
+# syntax=docker/dockerfile:1
+FROM stackable/image/java-base AS builder
 
 RUN microdnf install -y zlib-devel openssl-devel cyrus-sasl-devel libcurl-devel && \
     microdnf install -y tar which wget zlib gcc-c++ make cmake && \
@@ -10,7 +11,7 @@ RUN curl -L -O https://github.com/edenhill/kcat/archive/refs/tags/1.7.0.tar.gz \
     && cd kcat-1.7.0 \
     && ./bootstrap.sh
 
-FROM docker.stackable.tech/stackable/java-base:11-stackable0.3.0@sha256:5c7f9e7274bd68ea264138b13504efa16fb22ee1122e7d12af32f343eb93c837
+FROM stackable/image/java-base
 
 ARG PRODUCT
 ARG SCALA

--- a/nifi/Dockerfile
+++ b/nifi/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker.stackable.tech/stackable/java-base:11-stackable0.3.0@sha256:5c7f9e7274bd68ea264138b13504efa16fb22ee1122e7d12af32f343eb93c837
+# syntax=docker/dockerfile:1
+FROM stackable/image/java-base
 
 ARG PRODUCT
 ARG RELEASE

--- a/opa/Dockerfile
+++ b/opa/Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6@sha256:c5ffdf5938d73283cec018f2adf59f0ed9f8c376d93e415a27b16c3c6aad6f45 AS opa-bundle-builder
+# syntax=docker/dockerfile:1
+FROM stackable/image/stackable-base AS opa-bundle-builder
 
 # https://github.com/hadolint/hadolint/wiki/DL4006
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -15,7 +16,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN git clone --depth 1 --branch 1.0.0 https://github.com/stackabletech/opa-bundle-builder
 RUN cd ./opa-bundle-builder && . $HOME/.cargo/env && cargo build --release
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6@sha256:c5ffdf5938d73283cec018f2adf59f0ed9f8c376d93e415a27b16c3c6aad6f45
+FROM stackable/image/stackable-base
 
 ARG PRODUCT
 ARG RELEASE
@@ -37,9 +38,6 @@ RUN microdnf update && \
     microdnf clean all
 
 COPY opa/licenses /licenses
-
-RUN groupadd -r stackable --gid=1000 && \
-    useradd -r -g stackable --uid=1000 stackable
 
 USER stackable
 WORKDIR /stackable/opa

--- a/pyspark-k8s/Dockerfile
+++ b/pyspark-k8s/Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6@sha256:c5ffdf5938d73283cec018f2adf59f0ed9f8c376d93e415a27b16c3c6aad6f45 AS builder
+# syntax=docker/dockerfile:1
+FROM stackable/image/stackable-base
 
 ARG PRODUCT
 ARG PYTHON
@@ -48,9 +49,7 @@ COPY spark-k8s/licenses /licenses
 
 RUN chmod +x /usr/bin/tini
 
-RUN groupadd -r stackable --gid=1000 && \
-    useradd -r -g stackable --uid=1000 -d /stackable stackable && \
-    chown -R stackable:stackable /stackable
+RUN chown -R stackable:stackable /stackable
 
 USER stackable
 

--- a/spark-k8s/Dockerfile
+++ b/spark-k8s/Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6@sha256:c5ffdf5938d73283cec018f2adf59f0ed9f8c376d93e415a27b16c3c6aad6f45 AS builder
+# syntax=docker/dockerfile:1
+FROM stackable/image/stackable-base
 
 ARG PRODUCT
 ARG HADOOP_SHORT_VERSION
@@ -41,9 +42,7 @@ COPY spark-k8s/licenses /licenses
   
 RUN  chmod +x /usr/bin/tini
 
-RUN groupadd -r stackable --gid=1000 && \
-    useradd -r -g stackable --uid=1000 -d /stackable stackable && \
-    chown -R stackable:stackable /stackable
+RUN chown -R stackable:stackable /stackable
 
 USER stackable
 

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -1,6 +1,7 @@
-# Build stage
+# syntax=docker/dockerfile:1
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6@sha256:c5ffdf5938d73283cec018f2adf59f0ed9f8c376d93e415a27b16c3c6aad6f45 AS builder
+# Build stage
+FROM stackable/image/stackable-base AS builder
 
 ARG PRODUCT
 ARG PYTHON
@@ -60,7 +61,7 @@ RUN cat /tmp/patches/* | patch \
 FROM prom/statsd-exporter:0.3.0@sha256:a9c27602d6f6b86527657922b6a87c12789f7f9b39a90f1513e8c665c941f26a as statsd-exporter
 
 # Final image
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6@sha256:e58664de16551db29fb0eaaeb3c4a44eaf95ad89a5b2399a1107041c4f2d6d34
+FROM stackable/image/stackable-base
 
 ARG PRODUCT
 ARG PYTHON
@@ -91,9 +92,7 @@ RUN microdnf update \
         openssl-pkcs11 \
         python${PYTHON//./} \
         shadow-utils \
-    && microdnf clean all \
-    && groupadd --gid 1000 stackable \
-    && useradd --uid 1000 --gid stackable --home-dir ${HOME} stackable
+    && microdnf clean all
 
 COPY superset/licenses /licenses
 COPY --from=statsd-exporter /bin/statsd_exporter /stackable/statsd_exporter

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6@sha256:c5ffdf5938d73283cec018f2adf59f0ed9f8c376d93e415a27b16c3c6aad6f45 AS builder
+# syntax=docker/dockerfile:1
+FROM stackable/image/stackable-base
 
 ARG PRODUCT
 ARG RELEASE
@@ -22,16 +23,9 @@ RUN microdnf update && \
                      gcc libxslt-devel libxml2-devel && \
     microdnf clean all
 
-# The bcrypt tool is needed by NiFi to locally encrypt the admin password that is mounted as a secret in cleartext
-COPY tools/bin/stackable-bcrypt-1.0-SNAPSHOT-jar-with-dependencies.jar /bin/stackable-bcrypt.jar
-# add all python scripts
-COPY tools/python /stackable/python
 COPY tools/licenses /licenses
 
-RUN pip3 install --no-cache-dir -r /stackable/python/requirements.txt && \
-    groupadd -r stackable --gid=1000 && \
-    useradd -r -g stackable --uid=1000 stackable && \
-    chown -R stackable:stackable /stackable
+RUN chown -R stackable:stackable /stackable
 
 USER stackable
 

--- a/trino/Dockerfile
+++ b/trino/Dockerfile
@@ -1,6 +1,5 @@
-ARG JAVA
-ARG JAVA_BASE_IMAGE_SHA256
-FROM docker.stackable.tech/stackable/java-base:${JAVA}-stackable0.2.2@sha256:${JAVA_BASE_IMAGE_SHA256}
+# syntax=docker/dockerfile:1
+FROM stackable/image/java-base
 
 ARG PRODUCT
 ARG OPA_AUTHORIZER
@@ -21,9 +20,6 @@ RUN microdnf update && \
     microdnf install tar gzip zip python3 openssl shadow-utils && \
     microdnf clean all && \
     alternatives --set python /usr/bin/python3
-
-RUN groupadd -r stackable --gid=1000 && \
-    useradd -r -g stackable --uid=1000 stackable
 
 USER stackable
 WORKDIR /stackable

--- a/vector/Dockerfile
+++ b/vector/Dockerfile
@@ -1,6 +1,7 @@
-# Build stage
+# syntax=docker/dockerfile:1
 
-FROM docker.stackable.tech/stackable/stackable-base:1.0.0-stackable1.0.0@sha256:18a6434eea00c911aaa3dec773e642933bbbfefa953153553998d16b54f349ad AS builder
+# Build stage
+FROM stackable/image/stackable-base AS builder
 
 ARG PRODUCT
 
@@ -21,7 +22,7 @@ RUN microdnf update && \
 
 # Final image
 
-FROM docker.stackable.tech/stackable/stackable-base:1.0.0-stackable1.0.0@sha256:18a6434eea00c911aaa3dec773e642933bbbfefa953153553998d16b54f349ad
+FROM stackable/image/stackable-base
 
 # https://github.com/hadolint/hadolint/wiki/DL4006
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker.stackable.tech/stackable/java-base:11-stackable0.3.0@sha256:5c7f9e7274bd68ea264138b13504efa16fb22ee1122e7d12af32f343eb93c837
+# syntax=docker/dockerfile:1
+FROM java-base
 
 ARG PRODUCT
 ARG RELEASE

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM java-base
+FROM stackable/image/java-base
 
 ARG PRODUCT
 ARG RELEASE


### PR DESCRIPTION
This PR changes the build workflow to generate a Bakefile (https://docs.docker.com/build/bake/), which is then passed to a single `docker buildx` call. This allows us to refer to other Dockerfiles in the tree directly, rather than having to build every step in the dependency chain manually, updating all the image references in between.

Additionally, this lets Docker build and push multiple the whole tree in parallel, rather than building the images one by one.

~~Currently Airflow and Zookeeper (and their dependencies) have been updated to take advantage of local dependencies. Other images may not work without updating to the `docker/dockerfile:1` syntax.~~ All images have now been updated.