### PR TITLE
Support Trino v414

### DIFF
--- a/image_tools/conf.py
+++ b/image_tools/conf.py
@@ -327,15 +327,12 @@ products = [
     {
         "name": "trino",
         "versions": [
-            {
-                "product": "377",
-                "java-base": "11",
-                "opa_authorizer": "0.1.0",
-            },
-            {"product": "387", "java-base": "11", "opa_authorizer": "0.1.0"},
-            {"product": "395", "java-base": "17", "opa_authorizer": "stackable0.1.0"},
-            {"product": "396", "java-base": "17", "opa_authorizer": "stackable0.1.0"},
-            {"product": "403", "java-base": "17", "opa_authorizer": "stackable0.1.0"},
+            {"product": "377", "java-base": "11", "opa_authorizer": "0.1.0", "jmx_exporter": "0.16.1"},
+            {"product": "387", "java-base": "11", "opa_authorizer": "0.1.0", "jmx_exporter": "0.16.1"},
+            {"product": "395", "java-base": "17", "opa_authorizer": "stackable0.1.0", "jmx_exporter": "0.16.1"},
+            {"product": "396", "java-base": "17", "opa_authorizer": "stackable0.1.0", "jmx_exporter": "0.16.1"},
+            {"product": "403", "java-base": "17", "opa_authorizer": "stackable0.1.0", "jmx_exporter": "0.16.1"},
+            {"product": "414", "java-base": "17", "opa_authorizer": "stackable0.1.0", "jmx_exporter": "0.18.0"},
         ],
     },
     {

--- a/trino/CHANGELOG.md
+++ b/trino/CHANGELOG.md
@@ -1,8 +1,21 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
 ## [Unreleased]
 
-All notable changes to this project will be documented in this file.
+## [414] - 2023-04-26
+
+### Added
+
+- Added Trino version 414 ([#367]).
+- Make soft link for `jmx-exporter` e.g. `jmx_prometheus_javaagent-<version>.jar` -> `jmx_prometheus_javaagent.jar` ([#367]).
+
+### Changed
+
+- Make `jmx-exporter` configurable in `conf.py` ([#367]).
+
+[#367]: https://github.com/stackabletech/docker-images/pull/367
 
 ## [396-stackable0.1.0] - 2022-09-16
 

--- a/trino/Dockerfile
+++ b/trino/Dockerfile
@@ -3,6 +3,7 @@ FROM stackable/image/java-base
 
 ARG PRODUCT
 ARG OPA_AUTHORIZER
+ARG JMX_EXPORTER
 ARG RELEASE
 
 LABEL name="Trino" \
@@ -17,7 +18,7 @@ LABEL name="Trino" \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN microdnf update && \
-    microdnf install tar gzip zip python3 openssl shadow-utils && \
+    microdnf install tar gzip zip python3 openssl && \
     microdnf clean all && \
     alternatives --set python /usr/bin/python3
 
@@ -30,9 +31,10 @@ COPY --chown=stackable:stackable trino/licenses /licenses
 RUN curl -L https://repo.stackable.tech/repository/packages/trino-server/trino-server-${PRODUCT}.tar.gz | tar -xzC . && \
     ln -s /stackable/trino-server-${PRODUCT} /stackable/trino-server
 
-RUN curl https://repo.stackable.tech/repository/packages/jmx-exporter/jmx_prometheus_javaagent-0.16.1.jar \
-    -o /stackable/jmx/jmx_prometheus_javaagent-0.16.1.jar && \
-    chmod -x /stackable/jmx/jmx_prometheus_javaagent-0.16.1.jar
+RUN curl https://repo.stackable.tech/repository/packages/jmx-exporter/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar \
+    -o /stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar && \
+    chmod -x /stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar && \
+    ln -s /stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar /stackable/jmx/jmx_prometheus_javaagent.jar
 
 RUN curl -L https://repo.stackable.tech/repository/packages/trino-opa-authorizer/trino-opa-authorizer-${PRODUCT}-${OPA_AUTHORIZER}.tar.gz | tar -xzC /stackable/trino-server/plugin
 


### PR DESCRIPTION
- Added Trino version 414
- Make soft link for `jmx-exporter` e.g. `jmx_prometheus_javaagent-<version>.jar` -> `jmx_prometheus_javaagent.jar`
- Make `jmx-exporter` configurable in `conf.py`