### PR TITLE
trino: Bump opa-authorizer version for Trino 414

### DIFF
--- a/image_tools/conf.py
+++ b/image_tools/conf.py
@@ -398,7 +398,7 @@ products = [
             {"product": "395", "java-base": "17", "opa_authorizer": "stackable0.1.0", "jmx_exporter": "0.16.1"},
             {"product": "396", "java-base": "17", "opa_authorizer": "stackable0.1.0", "jmx_exporter": "0.16.1"},
             {"product": "403", "java-base": "17", "opa_authorizer": "stackable0.1.0", "jmx_exporter": "0.16.1"},
-            {"product": "414", "java-base": "17", "opa_authorizer": "stackable0.1.0", "jmx_exporter": "0.18.0"},
+            {"product": "414", "java-base": "17", "opa_authorizer": "stackable0.2.0", "jmx_exporter": "0.18.0"},
         ],
     },
     {


### PR DESCRIPTION
So we get https://github.com/stackabletech/trino-opa-authorizer/issues/24 in