### PR TITLE
feat(airflow): Add s3fs python package, needed for pandas S3 access

### DIFF
--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -26,7 +26,8 @@ RUN microdnf update \
         && python3 -m venv --system-site-packages /stackable/app \
         && source /stackable/app/bin/activate \
         && pip install --no-cache-dir --upgrade pip \
-        && pip install --no-cache-dir apache-airflow[${AIRFLOW_EXTRAS}]==${PRODUCT} --constraint /tmp/constraints.txt
+        && pip install --no-cache-dir apache-airflow[${AIRFLOW_EXTRAS}]==${PRODUCT} --constraint /tmp/constraints.txt \
+        && pip install --no-cache-dir s3fs
 
 FROM prom/statsd-exporter:0.3.0@sha256:a9c27602d6f6b86527657922b6a87c12789f7f9b39a90f1513e8c665c941f26a as statsd-exporter
 FROM docker.stackable.tech/stackable/git-sync:v3.6.4 as gitsync-image
@@ -76,7 +77,7 @@ RUN mkdir -pv ${AIRFLOW_HOME} && \
 RUN chown --recursive stackable:stackable ${AIRFLOW_HOME}
 
 # according to arch, copy binary to the name "tini"
-RUN curl -o /usr/bin/tini https://repo.stackable.tech/repository/packages/tini/tini-$(arch) 
+RUN curl -o /usr/bin/tini https://repo.stackable.tech/repository/packages/tini/tini-$(arch)
 
 COPY airflow/stackable/utils/entrypoint.sh /entrypoint
 COPY --from=statsd-exporter --chown=stackable:stackable /bin/statsd_exporter /stackable/statsd_exporter

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -77,7 +77,7 @@ RUN mkdir -pv ${AIRFLOW_HOME} && \
 RUN chown --recursive stackable:stackable ${AIRFLOW_HOME}
 
 # according to arch, copy binary to the name "tini"
-RUN curl -o /usr/bin/tini https://repo.stackable.tech/repository/packages/tini/tini-$(arch)
+RUN curl -o /usr/bin/tini "https://repo.stackable.tech/repository/packages/tini/tini-$(arch)"
 
 COPY airflow/stackable/utils/entrypoint.sh /entrypoint
 COPY --from=statsd-exporter --chown=stackable:stackable /bin/statsd_exporter /stackable/statsd_exporter

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -27,6 +27,7 @@ RUN microdnf update \
         && source /stackable/app/bin/activate \
         && pip install --no-cache-dir --upgrade pip \
         && pip install --no-cache-dir apache-airflow[${AIRFLOW_EXTRAS}]==${PRODUCT} --constraint /tmp/constraints.txt \
+        # Needed for pandas S3 integration to e.g. write and read csv and parquet files to/from S3
         && pip install --no-cache-dir s3fs
 
 FROM prom/statsd-exporter:0.3.0@sha256:a9c27602d6f6b86527657922b6a87c12789f7f9b39a90f1513e8c665c941f26a as statsd-exporter


### PR DESCRIPTION
# Description

*Please add a description here.*


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Does your change affect an SBOM? Make sure to update all SBOMs
```


This enables us to e.g.
```
    @task
    def write_repos_to_s3(df: pandas.DataFrame):
        staging_table_name =''.join(random.choice(string.ascii_lowercase) for i in range(32))
        df.to_parquet(
            f"s3://{S3_BUCKET}/staging/github/{staging_table_name}/repos.parquet",
            storage_options={
                "key": S3_ACCESS_KEY_ID,
                "secret": S3_SECRET_ACCESS_KEY,
                "client_kwargs": {'endpoint_url': S3_ENDPOINT}
            }
        )
        return staging_table_name
```