### PR TITLE
Post release bump stackable-base ubi8-minimal

### DIFF
--- a/stackable-base/CHANGELOG.md
+++ b/stackable-base/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## [Unreleased]
 
-### changed
+### Changed
 
 - Update ubi-minimal base image from 8.6 to 8.7@sha256:3e1adcc31c6073d010b8043b070bd089d7bf37ee2c397c110211a6273453433f
+
+- Update ubi-minimal base image from 8.7@sha256:3e1adcc31c6073d010b8043b070bd089d7bf37ee2c397c110211a6273453433f to registry.access.redhat.com/ubi8/ubi-minimal:8.8@sha256:14b404f4181904fb5edfde1a7a6b03fe1b0bb4dad1f5c02e16f797d5eea8c0cb ([#420]).
 
 ## [stackable-base-stackable1.0.0] - 2022-12-12
 
@@ -15,3 +17,4 @@
   /stackable ([#268]).
 
 [#268]: https://github.com/stackabletech/docker-images/pull/268
+[#420]: https://github.com/stackabletech/docker-images/pull/420

--- a/stackable-base/Dockerfile
+++ b/stackable-base/Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7@sha256:3e1adcc31c6073d010b8043b070bd089d7bf37ee2c397c110211a6273453433f
+# 8.8-1014 as of 2023-07-20
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:14b404f4181904fb5edfde1a7a6b03fe1b0bb4dad1f5c02e16f797d5eea8c0cb
 
 # intentionally unused
 ARG PRODUCT

--- a/stackable-base/Dockerfile
+++ b/stackable-base/Dockerfile
@@ -1,5 +1,5 @@
 # 8.8-1014 as of 2023-07-20
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:14b404f4181904fb5edfde1a7a6b03fe1b0bb4dad1f5c02e16f797d5eea8c0cb
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8@sha256:14b404f4181904fb5edfde1a7a6b03fe1b0bb4dad1f5c02e16f797d5eea8c0cb
 
 # intentionally unused
 ARG PRODUCT


### PR DESCRIPTION
using https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8?tag=8.8-1014&push_date=1687885725000&container-tabs=overview