### PR TITLE
Mirror image action

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -1,0 +1,45 @@
+name: Mirror container image
+on:
+  workflow_dispatch:
+    inputs:
+      src:
+        description: 'Location of the source image (example: registry.k8s.io/git-sync/git-sync:v3.6.4)'
+        required: true
+      dst:
+        description: 'Name and tag of the destination image (example: git-sync:v3.6.4)'
+        required: true
+
+env:
+  DST_REGISTRY: oci.stackable.tech
+  DST_PROJECT: mirror
+
+jobs:
+  mirror-image:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.DST_REGISTRY }}
+          username: "robot$stackable+github-action-build"
+          password: ${{ secrets.HARBOR_ROBOT_STACKABLE_GITHUB_ACTION_BUILD_SECRET }}
+      - name: Pull image from source registry
+        run: docker pull "${{ github.event.inputs.src }}"
+      - name: Retag image
+        run: docker tag "${{ github.event.inputs.src }}" "$DST_REGISTRY/$DST_PROJECT/${{ github.event.inputs.dst }}"
+      - name: Set up Cosign
+        uses: sigstore/cosign-installer@v3.0.5
+      - name: Push image to destination registry
+        run: |
+          DOCKER_OUTPUT=$(docker push "$DST_REGISTRY/$DST_PROJECT/${{ github.event.inputs.dst }}");
+          # Obtain the digest of the pushed image from the output of `docker push`, because signing by tag is deprecated and will be removed from cosign in the future
+          REPO_DIGEST_OF_IMAGE=$(echo "$DOCKER_OUTPUT" | awk '/^\S+: digest: sha256:[0-9a-f]{64} size: [0-9]+$/ { print $3 }');
+          if [ -z "$REPO_DIGEST_OF_IMAGE" ]; then
+            echo "Could not find repo digest for container image: $DST_REGISTRY/$DST_PROJECT/${{ github.event.inputs.dst }}"
+            exit 1
+          fi
+          # This generates a signature and publishes it to the registry, next to the image
+          # Uses the keyless signing flow with Github Actions as identity provider
+          cosign sign -y $DST_REGISTRY/$DST_PROJECT/${{ github.event.inputs.dst }}@$REPO_DIGEST_OF_IMAGE


### PR DESCRIPTION
A Github Action to manually mirror an image in our OCI registry. It also signs it automatically.