### PR TITLE
wrap entrypoint script to trigger pre/post hook commands

### DIFF
--- a/airflow/CHANGELOG.md
+++ b/airflow/CHANGELOG.md
@@ -7,9 +7,11 @@
 - Updated Vector to 0.31 ([#429]).
 - Updated git-sync to 3.6.8 ([#431]).
 - Updated statsd-exporter to 0.24, this was accidentally moved to a very old version previously (0.3.0) ([#431]).
+- Added wrapper script to allow the triggering of pre/post hook actions ([#435]).
 
 [#429]: https://github.com/stackabletech/docker-images/pull/429
 [#431]: https://github.com/stackabletech/docker-images/pull/431
+[#435]: https://github.com/stackabletech/docker-images/pull/435
 
 ## [23.7.0]
 

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -90,8 +90,10 @@ RUN chown --recursive stackable:stackable ${AIRFLOW_HOME}
 # Get the correct `tini` binary for our architecture.
 # It is used as an init alternative in the entrypoint
 RUN curl --fail -o /usr/bin/tini "https://repo.stackable.tech/repository/packages/tini/tini-${TINI}-$(arch)"
-COPY airflow/stackable/utils/entrypoint.sh /entrypoint
-RUN chmod a+x /entrypoint && \
+COPY airflow/stackable/utils/entrypoint.sh /entrypoint.sh
+COPY airflow/stackable/utils/run-airflow.sh /run-airflow.sh
+RUN chmod a+x /entrypoint.sh && \
+    chmod a+x /run-airflow.sh && \
     chmod +x /usr/bin/tini
 
 COPY --from=statsd-exporter --chown=stackable:stackable /bin/statsd_exporter /stackable/statsd_exporter
@@ -101,5 +103,5 @@ COPY --from=gitsync-image --chown=stackable:stackable /git-sync /stackable/git-s
 USER stackable
 WORKDIR /stackable
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/entrypoint"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/run-airflow.sh"]
 CMD []

--- a/airflow/stackable/utils/run-airflow.sh
+++ b/airflow/stackable/utils/run-airflow.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+eval "$_STACKABLE_PRE_HOOK"
+
+/entrypoint.sh "$@"
+result=$?
+
+eval "$_STACKABLE_POST_HOOK"
+
+exit $result

--- a/airflow/stackable/utils/run-airflow.sh
+++ b/airflow/stackable/utils/run-airflow.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-
+# This wrapper script allows commands that are embedded in environment variables
+# to be invoked to carry out actions when the main container is complete.
+# N.B. for airflow services (scheduler, webserver, worker) this will not be relevant
+# as the service has to be terminated, but for pods spawned and terminated by the 
+# kubernetes executor this allows us to stop other containers, such as vector.
 eval "$_STACKABLE_PRE_HOOK"
 
 /entrypoint.sh "$@"


### PR DESCRIPTION
# Description

As per spark-k8s, the entrypoint script is wrapped in a runner script that evaluates/triggers the vector shutdown command via an environment variable (if set).


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
```
