### PR TITLE
Rework Druid image to use a builder step and apply all around best practices

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -42,7 +42,7 @@ Prerequisites:
 * Stackable Image Tools (`pip install image-tools-stackabletech`) https://github.com/stackabletech/image-tools 
 * Docker including the `buildx` plugin: https://github.com/docker/buildx
 
-To build and push product images to the default repository, use the `build_product_images.py` like this:
+To build and push product images to the default repository, use the `bake`-tool like this:
 
     bake --product zookeeper --image 0.0.0-dev --push
 

--- a/druid/Dockerfile
+++ b/druid/Dockerfile
@@ -1,13 +1,56 @@
 # syntax=docker/dockerfile:1
+
+# TODO: Do we even support druid < 0.23 anymore?
 # druid < 0.23 druid only fully supports java 8
 # druid >= 0.23 is java 11 ready
-FROM stackable/image/java-base
+FROM stackable/image/java-base AS builder
 
 ARG PRODUCT
 ARG JACKSON_DATAFORMAT_XML
 ARG STAX2_API
 ARG WOODSTOX_CORE
 ARG AUTHORIZER
+
+RUN microdnf update && \
+    microdnf install findutils openssl tar gzip zip && \
+    microdnf clean all && \
+    rm -rf /var/cache/yum
+
+WORKDIR /stackable
+
+# https://github.com/hadolint/hadolint/wiki/DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Download & extracd Apache Druid itself
+RUN curl --fail -L https://repo.stackable.tech/repository/packages/druid/apache-druid-${PRODUCT}-bin.tar.gz | tar -xzC . && \
+    ln -s /stackable/apache-druid-${PRODUCT} /stackable/druid
+
+# Overwrite the existing 'run-druid'
+# TODO: Why? Where does this come from?
+COPY --chown=stackable:stackable druid/stackable /stackable
+RUN ln -sf /stackable/bin/run-druid /stackable/druid/bin/run-druid
+
+# Install the Prometheus emitter extension. This bundle contains the emitter and all jar dependencies.
+RUN curl --fail -L https://repo.stackable.tech/repository/packages/druid/druid-prometheus-emitter-${PRODUCT}.tar.gz | tar -xzC /stackable/druid/extensions
+
+# Install OPA authorizer extension.
+RUN curl --fail -L https://repo.stackable.tech/repository/packages/druid/druid-opa-authorizer-${AUTHORIZER}.tar.gz | tar -xzC /stackable/druid/extensions
+
+# Install jackson-dataformat-xml, stax2-api, and woodstox-core which are required for logging, and remove stax-ex.
+# TODO: Why remove stax-ex?
+RUN rm /stackable/druid/lib/stax-ex-*.jar && \
+    curl --fail -L -o /stackable/druid/lib/jackson-dataformat-xml-${JACKSON_DATAFORMAT_XML}.jar \
+        https://repo.stackable.tech/repository/packages/jackson-dataformat-xml/jackson-dataformat-xml-${JACKSON_DATAFORMAT_XML}.jar && \
+    curl --fail -L -o /stackable/druid/lib/stax2-api-${STAX2_API}.jar \
+        https://repo.stackable.tech/repository/packages/stax2-api/stax2-api-${STAX2_API}.jar && \
+    curl --fail -L -o /stackable/druid/lib/woodstox-core-${WOODSTOX_CORE}.jar \
+        https://repo.stackable.tech/repository/packages/woodstox-core/woodstox-core-${WOODSTOX_CORE}.jar
+
+
+# Final Image
+FROM stackable/image/java-base
+
+ARG PRODUCT
 ARG RELEASE
 
 LABEL name="Apache Druid" \
@@ -21,32 +64,22 @@ LABEL name="Apache Druid" \
 # https://github.com/hadolint/hadolint/wiki/DL4006
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# TODO: Not sure what openssl is required for
 RUN microdnf update && \
-    microdnf install findutils openssl tar gzip zip && \
-    microdnf clean all
+    microdnf install openssl && \
+    microdnf clean all && \
+    rm -rf /var/cache/yum
 
 USER stackable
 WORKDIR /stackable
 
-COPY --chown=stackable:stackable druid/stackable /stackable
 COPY --chown=stackable:stackable druid/licenses /licenses
 
-RUN curl -L https://repo.stackable.tech/repository/packages/druid/apache-druid-${PRODUCT}-bin.tar.gz | tar -xzC . && \
-    ln -s /stackable/apache-druid-${PRODUCT} /stackable/druid && \
-    # Force to overwrite the existing 'run-druid'
-    ln -sf /stackable/bin/run-druid /stackable/druid/bin/run-druid && \
-    # Install the Prometheus emitter extension. This bundle contains the emitter and all jar dependencies.
-    curl https://repo.stackable.tech/repository/packages/druid/druid-prometheus-emitter-${PRODUCT}.tar.gz | tar -xzC /stackable/druid/extensions && \
-    # Install OPA authorizer extension.
-    curl https://repo.stackable.tech/repository/packages/druid/druid-opa-authorizer-${AUTHORIZER}.tar.gz | tar -xzC /stackable/druid/extensions && \
-    # Install jackson-dataformat-xml, stax2-api, and woodstox-core which are required for logging, and remove stax-ex.
-    rm /stackable/druid/lib/stax-ex-*.jar && \
-    curl -L -o /stackable/druid/lib/jackson-dataformat-xml-${JACKSON_DATAFORMAT_XML}.jar \
-        https://repo.stackable.tech/repository/packages/jackson-dataformat-xml/jackson-dataformat-xml-${JACKSON_DATAFORMAT_XML}.jar && \
-    curl -L -o /stackable/druid/lib/stax2-api-${STAX2_API}.jar \
-        https://repo.stackable.tech/repository/packages/stax2-api/stax2-api-${STAX2_API}.jar && \
-    curl -L -o /stackable/druid/lib/woodstox-core-${WOODSTOX_CORE}.jar \
-        https://repo.stackable.tech/repository/packages/woodstox-core/woodstox-core-${WOODSTOX_CORE}.jar
+ENV HOME=/stackable
+ENV PATH=$PATH:$HOME/druid/binp
+
+COPY --link --chown=stackable:stackable --from=builder /stackable/apache-druid-${PRODUCT} /stackable/apache-druid-${PRODUCT}/
+RUN ln -s /stackable/apache-druid-${PRODUCT} /stackable/druid
 
 WORKDIR /stackable/druid
 CMD ["bin/run-druid", "coordinator", "conf/druid/cluster/master/coordinator-overlord/"]

--- a/druid/README.md
+++ b/druid/README.md
@@ -2,4 +2,7 @@
 
 ## Prometheus Extension
 
-We ship druid with the Prometheus Emitter extension. It is a community extension and so it is not shipped by default, [the documentation](https://druid.apache.org/docs/latest/development/extensions.html#loading-community-extensions) explains how to load community extensions.  It can be found on [maven](https://search.maven.org/artifact/org.apache.druid.extensions.contrib/prometheus-emitter), the codebase is in the official druid [github repository](https://github.com/apache/druid/tree/master/extensions-contrib/prometheus-emitter).
+We ship druid with the Prometheus Emitter extension.
+It is a community extension and so it is not shipped by default.
+[The documentation](https://druid.apache.org/docs/latest/development/extensions.html#loading-community-extensions) explains how to load community extensions.
+It can be found on [maven](https://search.maven.org/artifact/org.apache.druid.extensions.contrib/prometheus-emitter), the codebase is in the official Druid [Gitb repository](https://github.com/apache/druid/tree/master/extensions-contrib/prometheus-emitter).

--- a/druid/stackable/bin/run-druid
+++ b/druid/stackable/bin/run-druid
@@ -13,6 +13,6 @@ if [ -z "$JAVA_BIN" ]; then
   >&2 echo "Could not find java - please run ./bin/verify-java to confirm it is installed."
   exit 1
 fi
-exec "$JAVA_BIN"/java `cat "$CONFDIR"/jvm.config | xargs` \
+exec "$JAVA_BIN"/java "$(< "$CONFDIR"/jvm.config)" \
   -cp "$CONFDIR":"./lib/*" \
   org.apache.druid.cli.Main server "$WHATAMI"


### PR DESCRIPTION
# Description

This is similar to the recent PRs for Hadoop and Airflow
- It splits up building in two steps which saves a bit of space in the final image and makes the Dockerfile more readable (don't care about number of layers in intermediate builder)
- It adds `--fail` to all curl commands to fail if a download fails
- Sets environment variables


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Does your change affect an SBOM? Make sure to update all SBOMs
```
