### PR TITLE
Add kubectl to testing-tools image

### DIFF
--- a/testing-tools/Dockerfile
+++ b/testing-tools/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && \
         curl \
         gzip \
         jq \
+        kubernetes-client \
         libssl-dev \
         libxml2-dev \
         libxslt1-dev \


### PR DESCRIPTION
# Description

Add kubectl to testing-tools image

kubectl will be used in the integration tests of the listener-operator to query the ingress addresses from the status of the Listeners.

This change was intentionally not added to the changelog because the testing-tools image is not released together with the Stackable Data Platform.
 
## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [x] Changes are OpenShift compatible
```
