### PR TITLE
Nifi new version 1.23.2

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -207,11 +207,8 @@ products = [
     {
         "name": "nifi",
         "versions": [
-            {"product": "1.15.3", "java-base": "11"},
-            {"product": "1.16.3", "java-base": "11"},
-            {"product": "1.18.0", "java-base": "11"},
-            {"product": "1.20.0", "java-base": "11"},
             {"product": "1.21.0", "java-base": "11"},
+            {"product": "1.23.2", "java-base": "11"},
         ],
     },
     {

--- a/nifi/Dockerfile
+++ b/nifi/Dockerfile
@@ -16,7 +16,7 @@ LABEL name="Apache NiFi" \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN microdnf update && \
-    microdnf install tar gzip zip libxslt-devel libxml2-devel gcc && \
+    microdnf install tar gzip zip unzip libxslt-devel libxml2-devel gcc && \
     microdnf install python3-devel python3-pip python3-setuptools && \
     microdnf clean all
 
@@ -31,7 +31,10 @@ COPY --chown=stackable:stackable nifi/stackable /stackable
 COPY --chown=stackable:stackable nifi/licenses /licenses
 COPY --chown=stackable:stackable nifi/python /stackable/python
 
-RUN curl -L https://repo.stackable.tech/repository/packages/nifi/nifi-${PRODUCT}-bin.tar.gz | tar -xzC . && \
+# zip is different than tar and cannot be just piped, therefore the intermediate save and remove step to unzip
+RUN curl --fail -L https://repo.stackable.tech/repository/packages/nifi/nifi-${PRODUCT}-bin.zip -o /stackable/nifi-${PRODUCT}-bin.zip && \
+    unzip /stackable/nifi-${PRODUCT}-bin.zip && \
+    rm /stackable/nifi-${PRODUCT}-bin.zip && \
     ln -s /stackable/nifi-${PRODUCT} /stackable/nifi
 
 # ===

--- a/nifi/Dockerfile
+++ b/nifi/Dockerfile
@@ -16,7 +16,7 @@ LABEL name="Apache NiFi" \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN microdnf update && \
-    microdnf install tar gzip zip openssl libxslt-devel libxml2-devel gcc && \
+    microdnf install tar gzip zip libxslt-devel libxml2-devel gcc && \
     microdnf install python3-devel python3-pip python3-setuptools && \
     microdnf clean all
 

--- a/nifi/upload_new_nifi_version.sh
+++ b/nifi/upload_new_nifi_version.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+VERSION=${1:?"Missing version number argument (arg 1)"}
+NEXUS_USER=${2:?"Missing Nexus username argument (arg 2)"}
+
+read -r -s -p "Nexus Password: " NEXUS_PASSWORD
+echo ""
+
+# https://stackoverflow.com/questions/4632028/how-to-create-a-temporary-directory
+# Find the directory name of the script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# the temp directory used, within $DIR
+WORK_DIR=$(mktemp -d -p "$DIR")
+
+# check if tmp dir was created
+if [[ ! "$WORK_DIR" || ! -d "$WORK_DIR" ]]; then
+  echo "Could not create temp dir"
+  exit 1
+fi
+
+# deletes the temp directory
+function cleanup {
+  rm -rf "$WORK_DIR"
+}
+
+# register the cleanup function to be called on the EXIT signal
+trap cleanup EXIT
+
+cd "$WORK_DIR" || exit
+
+bin_file="nifi-$VERSION-bin.zip"
+download_url="https://archive.apache.org/dist/nifi/${VERSION}"
+
+echo "Downloading Nifi (this can take a while, it is intentionally downloading from a slow mirror that contains all old versions)"
+curl --fail -LOs "${download_url}/${bin_file}"
+curl --fail -LOs "${download_url}/${bin_file}.asc"
+curl --fail -LOs "${download_url}/${bin_file}.sha512"
+
+# It is probably redundant to check both the checksum and the signature but it's cheap and why not
+echo "Validating SHA512 Checksums"
+if ! (sha512sum "$bin_file" | cut -d ' ' -f 1 | diff - "$bin_file.sha512"); then
+  echo "ERROR: One of the SHA512 sums does not match"
+  exit 1
+fi
+
+echo "Validating signatures"
+echo '--> NOTE: Make sure you have downloaded and added the KEYS file (https://archive.apache.org/dist/nifi/common/KEYS) to GPG: https://www.apache.org/info/verification.html'
+
+if ! (gpg --verify "$bin_file.asc" "$bin_file" 2> /dev/null); then
+  echo "ERROR: One of the signatures could not be verified"
+  exit 1
+fi
+
+echo "Uploading everything to Nexus"
+EXIT_STATUS=0
+curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${bin_file}" 'https://repo.stackable.tech/repository/packages/nifi/' || EXIT_STATUS=$?
+curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${bin_file}.asc" 'https://repo.stackable.tech/repository/packages/nifi/' || EXIT_STATUS=$?
+curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${bin_file}.sha512" 'https://repo.stackable.tech/repository/packages/nifi/' || EXIT_STATUS=$?
+
+if [ $EXIT_STATUS -ne 0 ]; then
+  echo "ERROR: Upload failed"
+  exit 1
+fi
+
+echo "Successfully uploaded version $VERSION of Nifi to Nexus"
+echo "https://repo.stackable.tech/service/rest/repository/browse/packages/nifi/"


### PR DESCRIPTION
# Description

- added nifi 1.23.2
- removed 1.15.x, 1.16.x, 1.18.x, 1.20.x
- removed openssl
- now using nifi original zip file instead of converting to tar.gz to keep sha and signature aligned


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Does your change affect an SBOM? Make sure to update all SBOMs
```
