### PR TITLE
New hadoop versions 3.2.4, 3.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 - java-base: Add needed tzdata-java package ([#425]).
 - testing-tools: Add java, tzdata-java, unzip ([#464], [#465], [#466]).
 
+- hadoop: added support for 3.2.4, 3.3.6 ([#478]).
+
 ### Changed
 
 - Extract image tools their own [repository](https://github.com/stackabletech/image-tools) ([#437])
@@ -27,12 +29,16 @@ All notable changes to this project will be documented in this file.
 - airflow: Updated statsd-exporter to 0.24, this was accidentally moved to a very old version previously (0.3.0) ([#431]).
 - airflow: Added wrapper script to allow the triggering of pre/post hook actions ([#435]).
 
+- hadoop: bumped jmx-exporter version to 0.20.0 ([#478]).
+
 ### Removed
 
 - airflow: Remove unused environment variable `AIRFLOW_UID` ([#429]).
 - java-base: Remove hard-coded JVM security properties containing DNS cache settings. Going forward operators will configure DNS cache settings ([#433])
 - pyspark-k8s: The PySpark image has been removed completely. Python is now installed with the Spark image ([#436])
 - Removed all product specific changelogs and updated the root file ([#440])
+
+hadoop: removed support for 3.3.1, 3.3.3 ([#478]).
 
 [#400]: https://github.com/stackabletech/docker-images/pull/400
 [#419]: https://github.com/stackabletech/docker-images/pull/419
@@ -49,6 +55,7 @@ All notable changes to this project will be documented in this file.
 [#464]: https://github.com/stackabletech/docker-images/pull/464
 [#465]: https://github.com/stackabletech/docker-images/pull/465
 [#466]: https://github.com/stackabletech/docker-images/pull/466
+[#478]: https://github.com/stackabletech/docker-images/pull/478
 
 ## [23.7.0] - 2023-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,8 @@ All notable changes to this project will be documented in this file.
 - testing-tools: Add java, tzdata-java, unzip ([#464], [#465], [#466]).
 
 - hadoop: added support for 3.2.4, 3.3.6 ([#478]).
-
 - opa: add version 0.57.0 ([#471]).
 - opa: add new version upload script ([#471]).
-
 - zookeeper: add version 3.8.3 ([#470]).
 - zookeeper: add upload script ([#470]).
 
@@ -34,7 +32,6 @@ All notable changes to this project will be documented in this file.
 - airflow: Updated git-sync to 3.6.8 ([#431]).
 - airflow: Updated statsd-exporter to 0.24, this was accidentally moved to a very old version previously (0.3.0) ([#431]).
 - airflow: Added wrapper script to allow the triggering of pre/post hook actions ([#435]).
-
 - hadoop: bumped jmx-exporter version to 0.20.0 ([#478]).
 - zookeeper: bumped jmx-exporter version to 0.20.0 ([#470]).
 

--- a/conf.py
+++ b/conf.py
@@ -82,10 +82,10 @@ products = [
     {
         "name": "hadoop",
         "versions": [
-            {"product": "3.2.2", "java-base": "11", "jmx_exporter": "0.19.0"},
-            {"product": "3.3.1", "java-base": "11", "jmx_exporter": "0.19.0"},
-            {"product": "3.3.3", "java-base": "11", "jmx_exporter": "0.19.0"},
-            {"product": "3.3.4", "java-base": "11", "jmx_exporter": "0.19.0"},
+            {"product": "3.2.2", "java-base": "11", "jmx_exporter": "0.20.0"},
+            {"product": "3.2.4", "java-base": "11", "jmx_exporter": "0.20.0"},
+            {"product": "3.3.4", "java-base": "11", "jmx_exporter": "0.20.0"},
+            {"product": "3.3.6", "java-base": "11", "jmx_exporter": "0.20.0"},
         ],
     },
     {

--- a/hadoop/Dockerfile
+++ b/hadoop/Dockerfile
@@ -123,8 +123,7 @@ RUN microdnf update && \
     microdnf install \
     fuse \
     fuse-libs \
-    krb5-workstation \
-    openssl && \
+    krb5-workstation && \
     microdnf clean all && \
     rm -rf /var/cache/yum
 


### PR DESCRIPTION
# Description

- added support for 3.2.4, 3.3.6
- removed support for 3.3.1, 3.3.3
- bumped jmx-exporter version to 0.20.0

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Does your change affect an SBOM? Make sure to update all SBOMs
```
