### PR TITLE
feat(trino 428): Switch to patched storage connector

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -330,7 +330,7 @@ products = [
         "name": "trino",
         "versions": [
             {"product": "414", "java-base": "17", "opa_authorizer": "stackable0.2.0", "jmx_exporter": "0.20.0", "storage_connector": "414"},
-            {"product": "428", "java-base": "17", "opa_authorizer": "stackable0.3.0", "jmx_exporter": "0.20.0", "storage_connector": "428"},
+            {"product": "428", "java-base": "17", "opa_authorizer": "stackable0.3.0", "jmx_exporter": "0.20.0", "storage_connector": "428-jackson"},
         ],
     },
     {


### PR DESCRIPTION
# Description

So far we pulled in [trino-storage](https://github.com/snowlift/trino-storage) from https://github.com/snowlift/trino-storage/releases/tag/v428.
This PR switched to a version with backports made in https://github.com/snowlift/trino-storage/pull/244, https://github.com/snowlift/trino-storage/pull/241 and https://github.com/snowlift/trino-storage/pull/240, as they are needed for a customer.

trino-storage 432 contains the fixes, so long-term we can get rid of a patched version again. 

CC @Maleware @soenkeliebau @maltesander  

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Does your change affect an SBOM? Make sure to update all SBOMs
```
