### PR TITLE
Fix path substitution in the hbck2 script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - hadoop: Add all necessary components to the image to mount HDFS using FUSE ([#400])
-- hbase: Add hbase-operator-tools ([#497]).
+- hbase: Add hbase-operator-tools ([#497], [#498]).
 - java-base: Add needed tzdata-java package ([#425]).
 - testing-tools: Add java, tzdata-java, unzip ([#464], [#465], [#466]).
 
@@ -104,6 +104,7 @@ All notable changes to this project will be documented in this file.
 [#489]: https://github.com/stackabletech/docker-images/pull/489
 [#494]: https://github.com/stackabletech/docker-images/pull/494
 [#497]: https://github.com/stackabletech/docker-images/pull/497
+[#498]: https://github.com/stackabletech/docker-images/pull/498
 
 ## [23.7.0] - 2023-07-14
 

--- a/hbase/Dockerfile
+++ b/hbase/Dockerfile
@@ -15,8 +15,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # zip required for the log4shell stuff
 RUN microdnf update && \
     microdnf install \
-    # The GNU gettext utilities contain the envsubst program which \
-    # substitutes the values of environment variables. \
+    # The GNU gettext utilities contain the envsubst program which
+    # substitutes the values of environment variables.
     gettext \
     git \
     gzip \
@@ -61,10 +61,10 @@ RUN curl --fail -L "https://repo.stackable.tech/repository/packages/hbase-operat
     rm -rf /stackable/hbase-operator-tools-${HBASE_OPERATOR_TOOLS}-src
 
 # Resolve paths in bin/hbck2
-RUN # The variable names are intentionally passed to envsubst in single-quotes, \
-    # so that they are not expanded. Disable the according ShellCheck rule: \
-    # shellcheck disable=SC2016 \
-    mv bin/hbck2 bin/hbck2.env && \
+RUN mv bin/hbck2 bin/hbck2.env && \
+    # The variable names are intentionally passed to envsubst in single-quotes,
+    # so that they are not expanded. Disabling ShellCheck rules in a Dockerfile
+    # does not work, so please ignore the according warning (SC2016).
     envsubst '${PRODUCT}:${HBASE_OPERATOR_TOOLS}' < bin/hbck2.env > bin/hbck2 && \
     chmod +x bin/hbck2 && \
     rm bin/hbck2.env


### PR DESCRIPTION
# Description

The ShellCheck comment turned the whole `RUN` argument into a comment and the paths in the hbck2 script were not substituted. This was the reason why no ShellCheck warning was emitted. Disabling the ShellCheck warning does not work in a Dockerfile, because there can be no separate line in the command which disables the ShellCheck, and inline comments with `` `# ...` `` and `$(: ...)` are not recognized by ShellCheck.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [x] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] All packages should have (if available) signatures/hashes verified
- [x] Does your change affect an SBOM? Make sure to update all SBOMs
```
