### PR TITLE
fix: add tzdata to superset image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - opa: add new version upload script ([#471]).
 - spark: added versions 3.4.1, 3.5.0 ([#475]).
 - superset: add new version 2.1.1, 3.0.1 ([#482], [#489]).
+- superset: add tzdata library as ubi-minimal has removed it ([#499]).
 - trino: removed support for versions 428 ([#487]).
 - zookeeper: add version 3.8.3 ([#470]).
 - zookeeper: add upload script ([#470]).
@@ -105,6 +106,7 @@ All notable changes to this project will be documented in this file.
 [#494]: https://github.com/stackabletech/docker-images/pull/494
 [#497]: https://github.com/stackabletech/docker-images/pull/497
 [#498]: https://github.com/stackabletech/docker-images/pull/498
+[#499]: https://github.com/stackabletech/docker-images/pull/499
 
 ## [23.7.0] - 2023-07-14
 

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -46,6 +46,10 @@ RUN microdnf update \
         pydruid \
         python-ldap \
         trino[sqlalchemy] \
+        # Redhat has removed `tzdata` from the ubi-minimal images: see https://bugzilla.redhat.com/show_bug.cgi?id=2223028.
+        # Superset relies on ZoneInfo (https://docs.python.org/3/library/zoneinfo.html#data-sources) to resolve time zones, and this is done
+        # by searching first under `TZPATH` (which is empty due to the point above) or for the tzdata python package.
+        # That package is therefore added here (airflow has tzdata in its list of dependencies, but superset does not).
         tzdata \
     && pip install \
         --no-cache-dir \

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -46,6 +46,7 @@ RUN microdnf update \
         pydruid \
         python-ldap \
         trino[sqlalchemy] \
+        tzdata \
     && pip install \
         --no-cache-dir \
         --upgrade \


### PR DESCRIPTION
# Description

- Redhat has removed `tzdata` from the ubi-minimal images. See [here](https://www.reddit.com/r/redhat/comments/12maj9w/ubi_feedback/) and [here](https://bugzilla.redhat.com/show_bug.cgi?id=2223028). 
- Superset relies on [ZoneInfo](https://docs.python.org/3/library/zoneinfo.html#data-sources) to resolve time zones, and this is done by searching first under `TZPATH` (which is empty due to the point above) or for the tzdata python package.
- That package is added in this PR (airflow already has tzdata in its list of dependencies). 


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Does your change affect an SBOM? Make sure to update all SBOMs
```
