### PR TITLE
Revert "Update patch to upstream HBase PR"

### DIFF
--- a/hbase/stackable/patches/2.4.17/002-HBASE-25292-2.4.17.patch
+++ b/hbase/stackable/patches/2.4.17/002-HBASE-25292-2.4.17.patch
@@ -1,45 +1,85 @@
-From c4dc0ebe2236c01b3d96e5fa8a11eea396df04b6 Mon Sep 17 00:00:00 2001
-From: Sebastian Bernauer <sebastian.bernauer@stackable.de>
-Date: Fri, 10 Nov 2023 16:56:48 +0100
-Subject: [PATCH] HBASE-25292 [branch-2.4] Improve InetSocketAddress usage
- discipline
+From c5e6b4d0909693a5b9819e6b41b605c08c562778 Mon Sep 17 00:00:00 2001
+From: Andrew Purtell <apurtell@apache.org>
+Date: Sat, 28 Nov 2020 14:01:22 +0100
+Subject: [PATCH] HBASE-25292 Improve InetSocketAddress usage discipline
+ (#2669)
 
-Co-authored-by: Andrew Purtell <apurtell@apache.org>
-(cherry picked from commit f813479)
+Network identities should be bound late. Remote addresses should be
+resolved at the last possible moment, just before connect(). Network
+identity mappings can change, so our code should not inappropriately
+cache them. Otherwise we might miss a change and fail to operate normally.
+
+Revert "HBASE-14544 Allow HConnectionImpl to not refresh the dns on errors"
+Removes hbase.resolve.hostnames.on.failure and related code. We always
+resolve hostnames, as late as possible.
+
+Preserve InetSocketAddress caching per RPC connection. Avoids potential
+lookups per Call.
+
+Replace InetSocketAddress with Address where used as a map key. If we want
+to key by hostname and/or resolved address we should be explicit about it.
+Using Address chooses mapping by hostname and port only.
+
+Add metrics for potential nameservice resolution attempts, whenever an
+InetSocketAddress is instantiated for connect; and metrics for failed
+resolution, whenever InetSocketAddress#isUnresolved on the new instance
+is true.
+
+* Use ServerName directly to build a stub key
+
+* Resolve and cache ISA on a RpcChannel as late as possible, at first call
+
+* Remove now invalid unit test TestCIBadHostname
+
+We resolve DNS at the latest possible time, at first call, and do not
+resolve hostnames for creating stubs at all, so this unit test cannot
+work now.
+
+Reviewed-by: Mingliang Liu <liuml07@apache.org>
+Signed-off-by: Duo Zhang <zhangduo@apache.org>
 ---
- .../hbase/client/AsyncConnectionImpl.java     |  9 +-
- .../client/ConnectionImplementation.java      | 18 ++--
- .../hadoop/hbase/client/ConnectionUtils.java  | 28 ++----
- .../hbase/client/MetricsConnection.java       | 14 +++
- .../hadoop/hbase/ipc/AbstractRpcClient.java   | 94 ++++++++++++------
- .../hbase/ipc/BlockingRpcConnection.java      | 49 +++++++---
- .../apache/hadoop/hbase/ipc/ConnectionId.java | 10 +-
- .../hadoop/hbase/ipc/FailedServers.java       | 17 ++--
- .../org/apache/hadoop/hbase/ipc/IPCUtil.java  |  6 +-
- .../hadoop/hbase/ipc/NettyRpcConnection.java  | 37 +++++--
- .../apache/hadoop/hbase/ipc/RpcClient.java    |  8 +-
- .../hadoop/hbase/ipc/RpcConnection.java       | 17 ++--
- .../hbase/ipc/ServerTooBusyException.java     |  8 ++
- .../client/TestMasterRegistryHedgedReads.java |  6 +-
- .../hadoop/hbase/ipc/TestConnectionId.java    |  6 +-
- .../hbase/ipc/TestFailedServersLog.java       |  6 +-
- .../apache/hadoop/hbase/ipc/TestIPCUtil.java  |  4 +-
- .../hbase/ipc/TestNettyRpcConnection.java     |  4 +-
- .../org/apache/hadoop/hbase/net/Address.java  | 38 +++++++-
- .../hbase/io/hfile/MemcachedBlockCache.java   |  3 +
- .../hbase/regionserver/HRegionServer.java     | 28 +++---
- .../hbase/client/TestCIBadHostname.java       | 97 -------------------
- .../hbase/client/TestClientTimeouts.java      | 15 ++-
- .../hadoop/hbase/ipc/TestHBaseClient.java     | 10 +-
- .../apache/hadoop/hbase/zookeeper/ZKUtil.java |  7 +-
- 25 files changed, 266 insertions(+), 273 deletions(-)
+ .../hbase/client/AsyncConnectionImpl.java     |  11 +-
+ .../client/ConnectionImplementation.java      |  14 +--
+ .../hadoop/hbase/client/ConnectionUtils.java  |  28 ++---
+ .../hbase/client/MetricsConnection.java       |  16 +++
+ .../hadoop/hbase/ipc/AbstractRpcClient.java   | 116 +++++++++++-------
+ .../hbase/ipc/BlockingRpcConnection.java      |  61 +++++----
+ .../apache/hadoop/hbase/ipc/ConnectionId.java |  16 +--
+ .../hadoop/hbase/ipc/FailedServers.java       |  21 ++--
+ .../org/apache/hadoop/hbase/ipc/IPCUtil.java  |   6 +-
+ .../hadoop/hbase/ipc/NettyRpcConnection.java  |  37 ++++--
+ .../apache/hadoop/hbase/ipc/RpcClient.java    |   8 +-
+ .../hadoop/hbase/ipc/RpcConnection.java       |  17 +--
+ .../hbase/ipc/ServerTooBusyException.java     |   8 ++
+ .../client/TestMasterRegistryHedgedReads.java |   6 +-
+ .../hadoop/hbase/ipc/TestConnectionId.java    |   6 +-
+ .../hbase/ipc/TestFailedServersLog.java       |   6 +-
+ .../apache/hadoop/hbase/ipc/TestIPCUtil.java  |   4 +-
+ .../hbase/ipc/TestNettyRpcConnection.java     |   4 +-
+ .../org/apache/hadoop/hbase/net/Address.java  |  44 +++++--
+ .../hbase/io/hfile/MemcachedBlockCache.java   |   3 +
+ .../hbase/regionserver/HRegionServer.java     |  36 +++---
+ .../hbase/client/TestCIBadHostname.java       |  97 ---------------
+ .../hbase/client/TestClientTimeouts.java      |  17 ++-
+ .../hadoop/hbase/ipc/TestHBaseClient.java     |  12 +-
+ .../apache/hadoop/hbase/zookeeper/ZKUtil.java |   7 +-
+ 25 files changed, 305 insertions(+), 296 deletions(-)
  delete mode 100644 hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestCIBadHostname.java
 
 diff --git a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncConnectionImpl.java b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncConnectionImpl.java
-index 2e5d1813aa..bcd3fdaaca 100644
+index 2e5d1813aa6..2bea6abe7a7 100644
 --- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncConnectionImpl.java
 +++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncConnectionImpl.java
-@@ -77,8 +77,6 @@ class AsyncConnectionImpl implements AsyncConnection {
+@@ -28,6 +28,8 @@ import static org.apache.hadoop.hbase.client.NonceGenerator.CLIENT_NONCES_ENABLE
+ import static org.apache.hadoop.hbase.util.FutureUtils.addListener;
+ 
+ import java.io.IOException;
++import java.net.InetAddress;
++import java.net.InetSocketAddress;
+ import java.util.Optional;
+ import java.util.concurrent.CompletableFuture;
+ import java.util.concurrent.ConcurrentHashMap;
+@@ -77,8 +79,6 @@ class AsyncConnectionImpl implements AsyncConnection {
        .setUncaughtExceptionHandler(Threads.LOGGING_EXCEPTION_HANDLER).build(),
      10, TimeUnit.MILLISECONDS);
  
@@ -48,7 +88,7 @@ index 2e5d1813aa..bcd3fdaaca 100644
    private final Configuration conf;
  
    final AsyncConnectionConfiguration connConf;
-@@ -93,8 +91,6 @@ class AsyncConnectionImpl implements AsyncConnection {
+@@ -93,8 +93,6 @@ class AsyncConnectionImpl implements AsyncConnection {
  
    final RpcControllerFactory rpcControllerFactory;
  
@@ -57,7 +97,7 @@ index 2e5d1813aa..bcd3fdaaca 100644
    private final AsyncRegionLocator locator;
  
    final AsyncRpcRetryingCallerFactory callerFactory;
-@@ -137,7 +133,6 @@ class AsyncConnectionImpl implements AsyncConnection {
+@@ -137,7 +135,6 @@ class AsyncConnectionImpl implements AsyncConnection {
      }
      this.rpcClient = RpcClientFactory.createClient(conf, clusterId, metrics.orElse(null));
      this.rpcControllerFactory = RpcControllerFactory.instantiate(conf);
@@ -65,7 +105,7 @@ index 2e5d1813aa..bcd3fdaaca 100644
      this.rpcTimeout =
        (int) Math.min(Integer.MAX_VALUE, TimeUnit.NANOSECONDS.toMillis(connConf.getRpcTimeoutNs()));
      this.locator = new AsyncRegionLocator(this, RETRY_TIMER);
-@@ -258,7 +253,7 @@ class AsyncConnectionImpl implements AsyncConnection {
+@@ -258,7 +255,7 @@ class AsyncConnectionImpl implements AsyncConnection {
  
    ClientService.Interface getRegionServerStub(ServerName serverName) throws IOException {
      return ConcurrentMapUtils.computeIfAbsentEx(rsStubs,
@@ -74,7 +114,7 @@ index 2e5d1813aa..bcd3fdaaca 100644
        () -> createRegionServerStub(serverName));
    }
  
-@@ -272,7 +267,7 @@ class AsyncConnectionImpl implements AsyncConnection {
+@@ -272,7 +269,7 @@ class AsyncConnectionImpl implements AsyncConnection {
  
    AdminService.Interface getAdminStub(ServerName serverName) throws IOException {
      return ConcurrentMapUtils.computeIfAbsentEx(adminSubs,
@@ -84,7 +124,7 @@ index 2e5d1813aa..bcd3fdaaca 100644
    }
  
 diff --git a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionImplementation.java b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionImplementation.java
-index 0af0be5232..c734726179 100644
+index 1b10775721f..efc6ecbc6f7 100644
 --- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionImplementation.java
 +++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionImplementation.java
 @@ -165,9 +165,6 @@ class ConnectionImplementation implements ClusterConnection, Closeable {
@@ -105,18 +145,16 @@ index 0af0be5232..c734726179 100644
      Class<? extends ClusterStatusListener.Listener> listenerClass =
        conf.getClass(ClusterStatusListener.STATUS_LISTENER_CLASS,
          ClusterStatusListener.DEFAULT_STATUS_LISTENER_CLASS, ClusterStatusListener.Listener.class);
-@@ -511,8 +507,8 @@ class ConnectionImplementation implements ClusterConnection, Closeable {
-     if (isDeadServer(masterServer)) {
+@@ -512,7 +508,7 @@ class ConnectionImplementation implements ClusterConnection, Closeable {
        throw new RegionServerStoppedException(masterServer + " is dead.");
      }
--    String key = getStubKey(MasterProtos.HbckService.BlockingInterface.class.getName(),
+     String key = getStubKey(MasterProtos.HbckService.BlockingInterface.class.getName(),
 -      masterServer, this.hostnamesCanChange);
-+    String key =
-+      getStubKey(MasterProtos.HbckService.BlockingInterface.class.getName(), masterServer);
++      masterServer);
  
      return new HBaseHbck(
        (MasterProtos.HbckService.BlockingInterface) computeIfAbsentEx(stubs, key, () -> {
-@@ -1306,8 +1302,7 @@ class ConnectionImplementation implements ClusterConnection, Closeable {
+@@ -1301,8 +1297,7 @@ class ConnectionImplementation implements ClusterConnection, Closeable {
          throw new MasterNotRunningException(sn + " is dead.");
        }
        // Use the security info interface name as our stub key
@@ -126,7 +164,7 @@ index 0af0be5232..c734726179 100644
        MasterProtos.MasterService.BlockingInterface stub =
          (MasterProtos.MasterService.BlockingInterface) computeIfAbsentEx(stubs, key, () -> {
            BlockingRpcChannel channel = rpcClient.createBlockingRpcChannel(sn, user, rpcTimeout);
-@@ -1355,8 +1350,7 @@ class ConnectionImplementation implements ClusterConnection, Closeable {
+@@ -1350,8 +1345,7 @@ class ConnectionImplementation implements ClusterConnection, Closeable {
      if (isDeadServer(serverName)) {
        throw new RegionServerStoppedException(serverName + " is dead.");
      }
@@ -136,30 +174,28 @@ index 0af0be5232..c734726179 100644
      return (AdminProtos.AdminService.BlockingInterface) computeIfAbsentEx(stubs, key, () -> {
        BlockingRpcChannel channel =
          this.rpcClient.createBlockingRpcChannel(serverName, user, rpcTimeout);
-@@ -1370,8 +1364,8 @@ class ConnectionImplementation implements ClusterConnection, Closeable {
-     if (isDeadServer(serverName)) {
+@@ -1366,7 +1360,7 @@ class ConnectionImplementation implements ClusterConnection, Closeable {
        throw new RegionServerStoppedException(serverName + " is dead.");
      }
--    String key = getStubKey(ClientProtos.ClientService.BlockingInterface.class.getName(),
+     String key = getStubKey(ClientProtos.ClientService.BlockingInterface.class.getName(),
 -      serverName, this.hostnamesCanChange);
-+    String key =
-+      getStubKey(ClientProtos.ClientService.BlockingInterface.class.getName(), serverName);
++      serverName);
      return (ClientProtos.ClientService.BlockingInterface) computeIfAbsentEx(stubs, key, () -> {
        BlockingRpcChannel channel =
          this.rpcClient.createBlockingRpcChannel(serverName, user, rpcTimeout);
 diff --git a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionUtils.java b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionUtils.java
-index d85b4399af..a781492417 100644
+index d85b4399aff..7e19572fa59 100644
 --- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionUtils.java
 +++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionUtils.java
-@@ -24,7 +24,6 @@ import static org.apache.hadoop.hbase.util.FutureUtils.addListener;
- 
+@@ -25,6 +25,7 @@ import static org.apache.hadoop.hbase.util.FutureUtils.addListener;
  import java.io.IOException;
  import java.lang.reflect.UndeclaredThrowableException;
--import java.net.InetAddress;
+ import java.net.InetAddress;
++import java.net.InetSocketAddress;
  import java.net.UnknownHostException;
  import java.util.Arrays;
  import java.util.List;
-@@ -152,32 +151,17 @@ public final class ConnectionUtils {
+@@ -152,32 +153,17 @@ public final class ConnectionUtils {
    }
  
    /**
@@ -199,7 +235,7 @@ index d85b4399af..a781492417 100644
  
    static void checkHasFamilies(Mutation mutation) {
 diff --git a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MetricsConnection.java b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MetricsConnection.java
-index 16a13df1e6..ee9861cc3f 100644
+index 16a13df1e68..a9848a2a65c 100644
 --- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MetricsConnection.java
 +++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MetricsConnection.java
 @@ -69,6 +69,8 @@ public class MetricsConnection implements StatisticTrackable {
@@ -211,25 +247,27 @@ index 16a13df1e6..ee9861cc3f 100644
    private static final String CLIENT_SVC = ClientService.getDescriptor().getName();
  
    /** A container class for collecting details about the RPC call as it percolates. */
-@@ -293,6 +295,8 @@ public class MetricsConnection implements StatisticTrackable {
+@@ -293,6 +295,9 @@ public class MetricsConnection implements StatisticTrackable {
    protected final Timer userRegionLockWaitingTimer;
    protected final Timer userRegionLockHeldTimer;
    protected final Histogram userRegionLockQueueHist;
 +  protected final Counter nsLookups;
 +  protected final Counter nsLookupsFailed;
++
  
    // dynamic metrics
  
-@@ -360,6 +364,8 @@ public class MetricsConnection implements StatisticTrackable {
+@@ -360,6 +365,9 @@ public class MetricsConnection implements StatisticTrackable {
        registry.timer(name(this.getClass(), "userRegionLockHeldDuration", scope));
      this.userRegionLockQueueHist =
        registry.histogram(name(MetricsConnection.class, "userRegionLockQueueLength", scope));
 +    this.nsLookups = registry.counter(name(this.getClass(), NS_LOOKUPS, scope));
 +    this.nsLookupsFailed = registry.counter(name(this.getClass(), NS_LOOKUPS_FAILED, scope));
++
  
      this.reporter = JmxReporter.forRegistry(this.registry).build();
      this.reporter.start();
-@@ -564,4 +570,12 @@ public class MetricsConnection implements StatisticTrackable {
+@@ -564,4 +572,12 @@ public class MetricsConnection implements StatisticTrackable {
        CACHE_BASE + (exception == null ? UNKNOWN_EXCEPTION : exception.getClass().getSimpleName()),
        cacheDroppingExceptions, counterFactory).inc();
    }
@@ -243,7 +281,7 @@ index 16a13df1e6..ee9861cc3f 100644
 +  }
  }
 diff --git a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/AbstractRpcClient.java b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/AbstractRpcClient.java
-index 4e437909ab..29f51415dc 100644
+index 4e437909ab3..f7a041e52b8 100644
 --- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/AbstractRpcClient.java
 +++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/AbstractRpcClient.java
 @@ -36,6 +36,7 @@ import org.apache.hadoop.hbase.ServerName;
@@ -254,22 +292,29 @@ index 4e437909ab..29f51415dc 100644
  import org.apache.hadoop.hbase.security.User;
  import org.apache.hadoop.hbase.security.UserProvider;
  import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
-@@ -133,11 +134,11 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
+@@ -133,14 +134,13 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
  
    private int maxConcurrentCallsPerServer;
  
 -  private static final LoadingCache<InetSocketAddress, AtomicInteger> concurrentCounterCache =
-+  private static final LoadingCache<Address, AtomicInteger> concurrentCounterCache =
-     CacheBuilder.newBuilder().expireAfterAccess(1, TimeUnit.HOURS)
+-    CacheBuilder.newBuilder().expireAfterAccess(1, TimeUnit.HOURS)
 -      .build(new CacheLoader<InetSocketAddress, AtomicInteger>() {
-+      .build(new CacheLoader<Address, AtomicInteger>() {
-         @Override
+-        @Override
 -        public AtomicInteger load(InetSocketAddress key) throws Exception {
-+        public AtomicInteger load(Address key) throws Exception {
-           return new AtomicInteger(0);
-         }
-       });
-@@ -206,7 +207,7 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
+-          return new AtomicInteger(0);
+-        }
+-      });
++  private static final LoadingCache<Address, AtomicInteger> concurrentCounterCache =
++      CacheBuilder.newBuilder().expireAfterAccess(1, TimeUnit.HOURS).
++          build(new CacheLoader<Address, AtomicInteger>() {
++            @Override public AtomicInteger load(Address key) throws Exception {
++              return new AtomicInteger(0);
++            }
++          });
+ 
+   /**
+    * Construct an IPC client for the cluster <code>clusterId</code>
+@@ -206,7 +206,7 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
          // The connection itself will disconnect if there is no pending call for maxIdleTime.
          if (conn.getLastTouched() < closeBeforeTime && !conn.isActive()) {
            if (LOG.isTraceEnabled()) {
@@ -278,39 +323,44 @@ index 4e437909ab..29f51415dc 100644
            }
            connections.remove(conn.remoteId(), conn);
            conn.cleanupConnection();
-@@ -344,11 +345,11 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
+@@ -344,11 +344,11 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
    private T getConnection(ConnectionId remoteId) throws IOException {
      if (failedServers.isFailedServer(remoteId.getAddress())) {
        if (LOG.isDebugEnabled()) {
 -        LOG.debug("Not trying to connect to " + remoteId.address
+-          + " this server is in the failed servers list");
 +        LOG.debug("Not trying to connect to " + remoteId.getAddress()
-           + " this server is in the failed servers list");
++            + " this server is in the failed servers list");
        }
        throw new FailedServerException(
 -        "This server is in the failed servers list: " + remoteId.address);
-+        "This server is in the failed servers list: " + remoteId.getAddress());
++          "This server is in the failed servers list: " + remoteId.getAddress());
      }
      T conn;
      synchronized (connections) {
-@@ -366,7 +367,7 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
+@@ -366,8 +366,8 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
     */
    protected abstract T createConnection(ConnectionId remoteId) throws IOException;
  
 -  private void onCallFinished(Call call, HBaseRpcController hrc, InetSocketAddress addr,
+-    RpcCallback<Message> callback) {
 +  private void onCallFinished(Call call, HBaseRpcController hrc, Address addr,
-     RpcCallback<Message> callback) {
++      RpcCallback<Message> callback) {
      call.callStats.setCallTimeMs(EnvironmentEdgeManager.currentTime() - call.getStartTime());
      if (metrics != null) {
-@@ -392,7 +393,7 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
+       metrics.updateRpc(call.md, call.param, call.callStats, call.error);
+@@ -392,8 +392,8 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
    }
  
    Call callMethod(final Descriptors.MethodDescriptor md, final HBaseRpcController hrc,
 -    final Message param, Message returnType, final User ticket, final InetSocketAddress addr,
-+    final Message param, Message returnType, final User ticket, final InetSocketAddress inetAddr,
-     final RpcCallback<Message> callback) {
+-    final RpcCallback<Message> callback) {
++      final Message param, Message returnType, final User ticket,
++      final InetSocketAddress inetAddr, final RpcCallback<Message> callback) {
      final MetricsConnection.CallStats cs = MetricsConnection.newCallStats();
      cs.setStartTime(EnvironmentEdgeManager.currentTime());
-@@ -407,6 +408,7 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
+ 
+@@ -407,6 +407,7 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
        cs.setNumActionsPerServer(numActions);
      }
  
@@ -318,7 +368,7 @@ index 4e437909ab..29f51415dc 100644
      final AtomicInteger counter = concurrentCounterCache.getUnchecked(addr);
      Call call = new Call(nextCallId(), md, param, hrc.cellScanner(), returnType,
        hrc.getCallTimeout(), hrc.getPriority(), new RpcCallback<Call>() {
-@@ -431,12 +433,8 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
+@@ -431,12 +432,8 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
      return call;
    }
  
@@ -333,7 +383,7 @@ index 4e437909ab..29f51415dc 100644
    }
  
    /**
-@@ -452,8 +450,8 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
+@@ -452,8 +449,8 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
        for (T connection : connections.values()) {
          ConnectionId remoteId = connection.remoteId();
          if (
@@ -344,12 +394,12 @@ index 4e437909ab..29f51415dc 100644
          ) {
            LOG.info("The server on " + sn.toString() + " is dead - stopping the connection "
              + connection.remoteId);
-@@ -514,19 +512,25 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
+@@ -514,19 +511,25 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
  
    @Override
    public BlockingRpcChannel createBlockingRpcChannel(final ServerName sn, final User ticket,
 -    int rpcTimeout) throws UnknownHostException {
-+    int rpcTimeout) {
++      int rpcTimeout) {
      return new BlockingRpcChannelImplementation(this, createAddr(sn), ticket, rpcTimeout);
    }
  
@@ -374,31 +424,32 @@ index 4e437909ab..29f51415dc 100644
  
      protected final AbstractRpcClient<?> rpcClient;
  
-@@ -534,8 +538,8 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
+@@ -534,8 +537,8 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
  
      protected final int rpcTimeout;
  
 -    protected AbstractRpcChannel(AbstractRpcClient<?> rpcClient, InetSocketAddress addr,
 -      User ticket, int rpcTimeout) {
-+    protected AbstractRpcChannel(AbstractRpcClient<?> rpcClient, Address addr, User ticket,
-+      int rpcTimeout) {
++    protected AbstractRpcChannel(AbstractRpcClient<?> rpcClient, Address addr,
++        User ticket, int rpcTimeout) {
        this.addr = addr;
        this.rpcClient = rpcClient;
        this.ticket = ticket;
-@@ -570,16 +574,30 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
-   public static class BlockingRpcChannelImplementation extends AbstractRpcChannel
+@@ -571,15 +574,29 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
      implements BlockingRpcChannel {
  
--    protected BlockingRpcChannelImplementation(AbstractRpcClient<?> rpcClient,
+     protected BlockingRpcChannelImplementation(AbstractRpcClient<?> rpcClient,
 -      InetSocketAddress addr, User ticket, int rpcTimeout) {
-+    protected BlockingRpcChannelImplementation(AbstractRpcClient<?> rpcClient, Address addr,
-+      User ticket, int rpcTimeout) {
++        Address addr, User ticket, int rpcTimeout) {
        super(rpcClient, addr, ticket, rpcTimeout);
      }
  
      @Override
      public Message callBlockingMethod(Descriptors.MethodDescriptor md, RpcController controller,
-       Message param, Message returnType) throws ServiceException {
+-      Message param, Message returnType) throws ServiceException {
+-      return rpcClient.callBlockingMethod(md, configureRpcController(controller), param, returnType,
+-        ticket, addr);
++        Message param, Message returnType) throws ServiceException {
 +      // Look up remote address upon first call
 +      if (isa == null) {
 +        if (this.rpcClient.metrics != null) {
@@ -413,28 +464,30 @@ index 4e437909ab..29f51415dc 100644
 +          throw new ServiceException(new UnknownHostException(addr + " could not be resolved"));
 +        }
 +      }
-       return rpcClient.callBlockingMethod(md, configureRpcController(controller), param, returnType,
--        ticket, addr);
-+        ticket, isa);
++      return rpcClient.callBlockingMethod(md, configureRpcController(controller),
++        param, returnType, ticket, isa);
      }
    }
  
-@@ -588,20 +606,34 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
+@@ -588,20 +605,35 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
     */
    public static class RpcChannelImplementation extends AbstractRpcChannel implements RpcChannel {
  
 -    protected RpcChannelImplementation(AbstractRpcClient<?> rpcClient, InetSocketAddress addr,
 -      User ticket, int rpcTimeout) throws UnknownHostException {
-+    protected RpcChannelImplementation(AbstractRpcClient<?> rpcClient, Address addr, User ticket,
-+      int rpcTimeout) {
++    protected RpcChannelImplementation(AbstractRpcClient<?> rpcClient, Address addr,
++        User ticket, int rpcTimeout) {
        super(rpcClient, addr, ticket, rpcTimeout);
      }
  
      @Override
-     public void callMethod(Descriptors.MethodDescriptor md, RpcController controller, Message param,
-       Message returnType, RpcCallback<Message> done) {
-+      HBaseRpcController configuredController = configureRpcController(
-+        Preconditions.checkNotNull(controller, "RpcController can not be null for async rpc call"));
+-    public void callMethod(Descriptors.MethodDescriptor md, RpcController controller, Message param,
+-      Message returnType, RpcCallback<Message> done) {
++    public void callMethod(Descriptors.MethodDescriptor md, RpcController controller,
++        Message param, Message returnType, RpcCallback<Message> done) {
++      HBaseRpcController configuredController =
++        configureRpcController(Preconditions.checkNotNull(controller,
++          "RpcController can not be null for async rpc call"));
 +      // Look up remote address upon first call
 +      if (isa == null || isa.isUnresolved()) {
 +        if (this.rpcClient.metrics != null) {
@@ -461,7 +514,7 @@ index 4e437909ab..29f51415dc 100644
    }
  }
 diff --git a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcConnection.java b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcConnection.java
-index d789417aef..10847c0155 100644
+index 60e2502524e..c623004f131 100644
 --- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcConnection.java
 +++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcConnection.java
 @@ -32,6 +32,7 @@ import java.io.IOException;
@@ -472,7 +525,7 @@ index d789417aef..10847c0155 100644
  import java.net.Socket;
  import java.net.SocketTimeoutException;
  import java.net.UnknownHostException;
-@@ -51,6 +52,7 @@ import org.apache.hadoop.hbase.exceptions.ConnectionClosingException;
+@@ -50,6 +51,7 @@ import org.apache.hadoop.hbase.exceptions.ConnectionClosingException;
  import org.apache.hadoop.hbase.io.ByteArrayOutputStream;
  import org.apache.hadoop.hbase.ipc.HBaseRpcController.CancellationCallback;
  import org.apache.hadoop.hbase.log.HBaseMarkers;
@@ -480,22 +533,24 @@ index d789417aef..10847c0155 100644
  import org.apache.hadoop.hbase.security.HBaseSaslRpcClient;
  import org.apache.hadoop.hbase.security.SaslUtil;
  import org.apache.hadoop.hbase.security.SaslUtil.QualityOfProtection;
-@@ -216,7 +218,7 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
+@@ -207,8 +209,8 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
+      * Cleans the call not yet sent when we finish.
       */
      public void cleanup(IOException e) {
-       IOException ie =
+-      IOException ie =
 -        new ConnectionClosingException("Connection to " + remoteId.address + " is closing.");
-+        new ConnectionClosingException("Connection to " + remoteId.getAddress() + " is closing.");
++      IOException ie = new ConnectionClosingException(
++          "Connection to " + remoteId.getAddress() + " is closing.");
        for (Call call : callsToWrite) {
          call.setException(ie);
        }
-@@ -226,12 +228,9 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
+@@ -218,12 +220,9 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
  
    BlockingRpcConnection(BlockingRpcClient rpcClient, ConnectionId remoteId) throws IOException {
      super(rpcClient.conf, AbstractRpcClient.WHEEL_TIMER, remoteId, rpcClient.clusterId,
 -      rpcClient.userProvider.isHBaseSecurityEnabled(), rpcClient.codec, rpcClient.compressor);
-+      rpcClient.userProvider.isHBaseSecurityEnabled(), rpcClient.codec, rpcClient.compressor,
-+      rpcClient.metrics);
++        rpcClient.userProvider.isHBaseSecurityEnabled(), rpcClient.codec, rpcClient.compressor,
++        rpcClient.metrics);
      this.rpcClient = rpcClient;
 -    if (remoteId.getAddress().isUnresolved()) {
 -      throw new UnknownHostException("unknown host: " + remoteId.getAddress().getHostName());
@@ -504,7 +559,7 @@ index d789417aef..10847c0155 100644
      this.connectionHeaderPreamble = getConnectionHeaderPreamble();
      ConnectionHeader header = getConnectionHeader();
      ByteArrayOutputStream baos = new ByteArrayOutputStream(4 + header.getSerializedSize());
-@@ -266,7 +265,17 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
+@@ -258,7 +257,17 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
          if (this.rpcClient.localAddr != null) {
            this.socket.bind(this.rpcClient.localAddr);
          }
@@ -523,12 +578,17 @@ index d789417aef..10847c0155 100644
          this.socket.setSoTimeout(this.rpcClient.readTO);
          return;
        } catch (SocketTimeoutException toe) {
-@@ -411,8 +420,18 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
+@@ -361,12 +370,22 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
+   }
  
    private boolean setupSaslConnection(final InputStream in2, final OutputStream out2)
-     throws IOException {
+-    throws IOException {
 -    saslRpcClient = new HBaseSaslRpcClient(this.rpcClient.conf, provider, token, serverAddress,
 -      securityInfo, this.rpcClient.fallbackAllowed,
+-      this.rpcClient.conf.get("hbase.rpc.protection",
+-        QualityOfProtection.AUTHENTICATION.name().toLowerCase(Locale.ROOT)),
+-      this.rpcClient.conf.getBoolean(CRYPTO_AES_ENABLED_KEY, CRYPTO_AES_ENABLED_DEFAULT));
++      throws IOException {
 +    if (this.metrics != null) {
 +      this.metrics.incrNsLookups();
 +    }
@@ -540,21 +600,25 @@ index d789417aef..10847c0155 100644
 +      throw new UnknownHostException(remoteId.getAddress() + " could not be resolved");
 +    }
 +    saslRpcClient = new HBaseSaslRpcClient(this.rpcClient.conf, provider, token,
-+      serverAddr.getAddress(), securityInfo, this.rpcClient.fallbackAllowed,
-       this.rpcClient.conf.get("hbase.rpc.protection",
-         QualityOfProtection.AUTHENTICATION.name().toLowerCase(Locale.ROOT)),
-       this.rpcClient.conf.getBoolean(CRYPTO_AES_ENABLED_KEY, CRYPTO_AES_ENABLED_DEFAULT));
-@@ -490,16 +509,16 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
++        serverAddr.getAddress(), securityInfo, this.rpcClient.fallbackAllowed,
++        this.rpcClient.conf.get("hbase.rpc.protection",
++            QualityOfProtection.AUTHENTICATION.name().toLowerCase(Locale.ROOT)),
++        this.rpcClient.conf.getBoolean(CRYPTO_AES_ENABLED_KEY, CRYPTO_AES_ENABLED_DEFAULT));
+     return saslRpcClient.saslConnect(in2, out2);
+   }
+ 
+@@ -441,16 +460,16 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
  
      if (this.rpcClient.failedServers.isFailedServer(remoteId.getAddress())) {
        if (LOG.isDebugEnabled()) {
 -        LOG.debug("Not trying to connect to " + remoteId.address
+-          + " this server is in the failed servers list");
 +        LOG.debug("Not trying to connect to " + remoteId.getAddress()
-           + " this server is in the failed servers list");
++            + " this server is in the failed servers list");
        }
        throw new FailedServerException(
 -        "This server is in the failed servers list: " + remoteId.address);
-+        "This server is in the failed servers list: " + remoteId.getAddress());
++          "This server is in the failed servers list: " + remoteId.getAddress());
      }
  
      try {
@@ -564,7 +628,7 @@ index d789417aef..10847c0155 100644
        }
  
        short numRetries = 0;
-@@ -554,14 +573,14 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
+@@ -505,14 +524,14 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
        closeSocket();
        IOException e = ExceptionUtil.asInterrupt(t);
        if (e == null) {
@@ -581,7 +645,7 @@ index d789417aef..10847c0155 100644
          }
        }
        throw e;
-@@ -836,7 +855,7 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
+@@ -770,7 +789,7 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
      if (callSender != null) {
        callSender.interrupt();
      }
@@ -591,20 +655,21 @@ index d789417aef..10847c0155 100644
  
    @Override
 diff --git a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/ConnectionId.java b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/ConnectionId.java
-index 48aec5cc9a..6cb9cddd9f 100644
+index 48aec5cc9aa..3428ca16c74 100644
 --- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/ConnectionId.java
 +++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/ConnectionId.java
-@@ -17,8 +17,8 @@
+@@ -17,8 +17,9 @@
   */
  package org.apache.hadoop.hbase.ipc;
  
 -import java.net.InetSocketAddress;
  import java.util.Objects;
++
 +import org.apache.hadoop.hbase.net.Address;
  import org.apache.hadoop.hbase.security.User;
  import org.apache.yetus.audience.InterfaceAudience;
  
-@@ -31,9 +31,9 @@ class ConnectionId {
+@@ -31,9 +32,9 @@ class ConnectionId {
    private static final int PRIME = 16777619;
    final User ticket;
    final String serviceName;
@@ -616,7 +681,7 @@ index 48aec5cc9a..6cb9cddd9f 100644
      this.address = address;
      this.ticket = ticket;
      this.serviceName = serviceName;
-@@ -43,7 +43,7 @@ class ConnectionId {
+@@ -43,7 +44,7 @@ class ConnectionId {
      return this.serviceName;
    }
  
@@ -625,20 +690,24 @@ index 48aec5cc9a..6cb9cddd9f 100644
      return address;
    }
  
-@@ -72,7 +72,7 @@ class ConnectionId {
+@@ -72,8 +73,9 @@ class ConnectionId {
      return hashCode(ticket, serviceName, address);
    }
  
 -  public static int hashCode(User ticket, String serviceName, InetSocketAddress address) {
+-    return (address.hashCode()
+-      + PRIME * (PRIME * serviceName.hashCode() ^ (ticket == null ? 0 : ticket.hashCode())));
 +  public static int hashCode(User ticket, String serviceName, Address address) {
-     return (address.hashCode()
-       + PRIME * (PRIME * serviceName.hashCode() ^ (ticket == null ? 0 : ticket.hashCode())));
++    return (address.hashCode() +
++        PRIME * (PRIME * serviceName.hashCode() ^
++            (ticket == null ? 0 : ticket.hashCode())));
    }
+ }
 diff --git a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/FailedServers.java b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/FailedServers.java
-index b59d84d17f..0a8da3c201 100644
+index b59d84d17f5..5f728bc5ed9 100644
 --- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/FailedServers.java
 +++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/FailedServers.java
-@@ -17,10 +17,10 @@
+@@ -17,7 +17,6 @@
   */
  package org.apache.hadoop.hbase.ipc;
  
@@ -646,11 +715,15 @@ index b59d84d17f..0a8da3c201 100644
  import java.util.HashMap;
  import java.util.Map;
  import org.apache.hadoop.conf.Configuration;
-+import org.apache.hadoop.hbase.net.Address;
- import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+@@ -25,13 +24,15 @@ import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
  import org.apache.yetus.audience.InterfaceAudience;
  import org.slf4j.Logger;
-@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
+ import org.slf4j.LoggerFactory;
++import org.apache.hadoop.hbase.net.Address;
++import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+ 
+ /**
+  * A class to manage a list of servers that failed recently.
   */
  @InterfaceAudience.Private
  public class FailedServers {
@@ -659,7 +732,7 @@ index b59d84d17f..0a8da3c201 100644
    private long latestExpiry = 0;
    private final int recheckServersTimeout;
    private static final Logger LOG = LoggerFactory.getLogger(FailedServers.class);
-@@ -44,12 +44,12 @@ public class FailedServers {
+@@ -44,13 +45,14 @@ public class FailedServers {
    /**
     * Add an address to the list of the failed servers list.
     */
@@ -671,11 +744,14 @@ index b59d84d17f..0a8da3c201 100644
      this.latestExpiry = expiry;
      if (LOG.isDebugEnabled()) {
 -      LOG.debug("Added failed server with address " + address.toString() + " to list caused by "
-+      LOG.debug("Added failed server with address " + address + " to list caused by "
-         + throwable.toString());
+-        + throwable.toString());
++      LOG.debug(
++        "Added failed server with address " + address + " to list caused by "
++            + throwable.toString());
      }
    }
-@@ -58,7 +58,7 @@ public class FailedServers {
+ 
+@@ -58,7 +60,7 @@ public class FailedServers {
     * Check if the server should be considered as bad. Clean the old entries of the list.
     * @return true if the server is in the failed servers list
     */
@@ -684,7 +760,7 @@ index b59d84d17f..0a8da3c201 100644
      if (failedServers.isEmpty()) {
        return false;
      }
-@@ -67,15 +67,14 @@ public class FailedServers {
+@@ -67,15 +69,14 @@ public class FailedServers {
        failedServers.clear();
        return false;
      }
@@ -703,7 +779,7 @@ index b59d84d17f..0a8da3c201 100644
      return false;
    }
 diff --git a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/IPCUtil.java b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/IPCUtil.java
-index 708d8d3e52..86be058432 100644
+index 708d8d3e528..86be0584329 100644
 --- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/IPCUtil.java
 +++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/IPCUtil.java
 @@ -21,7 +21,6 @@ import java.io.IOException;
@@ -741,7 +817,7 @@ index 708d8d3e52..86be058432 100644
        // connection refused; include the host:port in the error
        return (IOException) new ConnectException(
 diff --git a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcConnection.java b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcConnection.java
-index dfba6d6cf9..a0aba5635a 100644
+index 6a889678a5e..6a921503570 100644
 --- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcConnection.java
 +++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcConnection.java
 @@ -24,12 +24,15 @@ import static org.apache.hadoop.hbase.ipc.IPCUtil.setCancelled;
@@ -832,7 +908,7 @@ index dfba6d6cf9..a0aba5635a 100644
            }
            ch.writeAndFlush(connectionHeaderPreamble.retainedDuplicate());
 diff --git a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/RpcClient.java b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/RpcClient.java
-index 1b5f3e0a0e..6ecff49e52 100644
+index 1b5f3e0a0eb..6ecff49e52b 100644
 --- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/RpcClient.java
 +++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/RpcClient.java
 @@ -18,7 +18,6 @@
@@ -866,7 +942,7 @@ index 1b5f3e0a0e..6ecff49e52 100644
    /**
     * Interrupt the connections to the given server. This should be called if the server is known as
 diff --git a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/RpcConnection.java b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/RpcConnection.java
-index 28a628e0fc..a3e2bef30c 100644
+index 28a628e0fcf..a3e2bef30c8 100644
 --- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/RpcConnection.java
 +++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/RpcConnection.java
 @@ -18,11 +18,10 @@
@@ -922,7 +998,7 @@ index 28a628e0fc..a3e2bef30c 100644
      this.securityInfo = SecurityInfo.getInfo(remoteId.getServiceName());
      this.useSasl = isSecurityEnabled;
 diff --git a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/ServerTooBusyException.java b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/ServerTooBusyException.java
-index 6f6bbf67c5..6c22ca94e4 100644
+index 6f6bbf67c54..6c22ca94e42 100644
 --- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/ServerTooBusyException.java
 +++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/ServerTooBusyException.java
 @@ -19,6 +19,7 @@ package org.apache.hadoop.hbase.ipc;
@@ -949,7 +1025,7 @@ index 6f6bbf67c5..6c22ca94e4 100644
 +
  }
 diff --git a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestMasterRegistryHedgedReads.java b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestMasterRegistryHedgedReads.java
-index 0b307bf2e5..2ff6bd640e 100644
+index 0b307bf2e56..2ff6bd640eb 100644
 --- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestMasterRegistryHedgedReads.java
 +++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestMasterRegistryHedgedReads.java
 @@ -90,14 +90,12 @@ public class TestMasterRegistryHedgedReads {
@@ -970,7 +1046,7 @@ index 0b307bf2e5..2ff6bd640e 100644
      }
  
 diff --git a/hbase-client/src/test/java/org/apache/hadoop/hbase/ipc/TestConnectionId.java b/hbase-client/src/test/java/org/apache/hadoop/hbase/ipc/TestConnectionId.java
-index 9b55ecf174..da962cac0d 100644
+index 9b55ecf1743..da962cac0d3 100644
 --- a/hbase-client/src/test/java/org/apache/hadoop/hbase/ipc/TestConnectionId.java
 +++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/ipc/TestConnectionId.java
 @@ -22,10 +22,10 @@ import static org.junit.Assert.assertFalse;
@@ -1004,7 +1080,7 @@ index 9b55ecf174..da962cac0d 100644
    }
  
 diff --git a/hbase-client/src/test/java/org/apache/hadoop/hbase/ipc/TestFailedServersLog.java b/hbase-client/src/test/java/org/apache/hadoop/hbase/ipc/TestFailedServersLog.java
-index 3998fa0880..e119861a30 100644
+index 3998fa0880f..e119861a30d 100644
 --- a/hbase-client/src/test/java/org/apache/hadoop/hbase/ipc/TestFailedServersLog.java
 +++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/ipc/TestFailedServersLog.java
 @@ -21,9 +21,9 @@ import static org.hamcrest.CoreMatchers.is;
@@ -1037,7 +1113,7 @@ index 3998fa0880..e119861a30 100644
      fs.addToFailedServers(addr, nullException);
  
 diff --git a/hbase-client/src/test/java/org/apache/hadoop/hbase/ipc/TestIPCUtil.java b/hbase-client/src/test/java/org/apache/hadoop/hbase/ipc/TestIPCUtil.java
-index 8bdef8eb4a..c327896f72 100644
+index 8bdef8eb4a3..c327896f72a 100644
 --- a/hbase-client/src/test/java/org/apache/hadoop/hbase/ipc/TestIPCUtil.java
 +++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/ipc/TestIPCUtil.java
 @@ -24,7 +24,6 @@ import static org.junit.Assert.assertTrue;
@@ -1066,7 +1142,7 @@ index 8bdef8eb4a..c327896f72 100644
        if (exception instanceof TimeoutException) {
          assertThat(IPCUtil.wrapException(addr, null, exception),
 diff --git a/hbase-client/src/test/java/org/apache/hadoop/hbase/ipc/TestNettyRpcConnection.java b/hbase-client/src/test/java/org/apache/hadoop/hbase/ipc/TestNettyRpcConnection.java
-index 6d543573de..a9c40fd3bb 100644
+index 6d543573de7..a9c40fd3bb7 100644
 --- a/hbase-client/src/test/java/org/apache/hadoop/hbase/ipc/TestNettyRpcConnection.java
 +++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/ipc/TestNettyRpcConnection.java
 @@ -26,9 +26,9 @@ import java.io.IOException;
@@ -1090,18 +1166,19 @@ index 6d543573de..a9c40fd3bb 100644
  
    @AfterClass
 diff --git a/hbase-common/src/main/java/org/apache/hadoop/hbase/net/Address.java b/hbase-common/src/main/java/org/apache/hadoop/hbase/net/Address.java
-index 0d5670965f..61b445fcef 100644
+index 0d5670965f7..7c9f41c9c71 100644
 --- a/hbase-common/src/main/java/org/apache/hadoop/hbase/net/Address.java
 +++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/net/Address.java
-@@ -17,6 +17,7 @@
+@@ -17,6 +17,8 @@
   */
  package org.apache.hadoop.hbase.net;
  
 +import java.net.InetSocketAddress;
++
  import org.apache.commons.lang3.StringUtils;
  import org.apache.yetus.audience.InterfaceAudience;
  
-@@ -33,7 +34,7 @@ import org.apache.hbase.thirdparty.com.google.common.net.HostAndPort;
+@@ -33,7 +35,7 @@ import org.apache.hbase.thirdparty.com.google.common.net.HostAndPort;
   */
  @InterfaceAudience.Public
  public class Address implements Comparable<Address> {
@@ -1110,7 +1187,7 @@ index 0d5670965f..61b445fcef 100644
  
    private Address(HostAndPort hostAndPort) {
      this.hostAndPort = hostAndPort;
-@@ -47,6 +48,33 @@ public class Address implements Comparable<Address> {
+@@ -47,6 +49,33 @@ public class Address implements Comparable<Address> {
      return new Address(HostAndPort.fromString(hostnameAndPort));
    }
  
@@ -1144,21 +1221,26 @@ index 0d5670965f..61b445fcef 100644
    public String getHostname() {
      return this.hostAndPort.getHost();
    }
-@@ -66,7 +94,7 @@ public class Address implements Comparable<Address> {
+@@ -66,8 +95,8 @@ public class Address implements Comparable<Address> {
     *         otherwise returns same as {@link #toString()}}
     */
    public String toStringWithoutDomain() {
 -    String hostname = getHostname();
+-    String[] parts = hostname.split("\\.");
 +    String hostname = getHostName();
-     String[] parts = hostname.split("\\.");
++    String [] parts = hostname.split("\\.");
      if (parts.length > 1) {
        for (String part : parts) {
-@@ -87,19 +115,19 @@ public class Address implements Comparable<Address> {
+         if (!StringUtils.isNumeric(part)) {
+@@ -86,20 +115,21 @@ public class Address implements Comparable<Address> {
+       return true;
      }
      if (other instanceof Address) {
-       Address that = (Address) other;
+-      Address that = (Address) other;
 -      return this.getHostname().equals(that.getHostname()) && this.getPort() == that.getPort();
-+      return this.getHostName().equals(that.getHostName()) && this.getPort() == that.getPort();
++      Address that = (Address)other;
++      return this.getHostName().equals(that.getHostName()) &&
++          this.getPort() == that.getPort();
      }
      return false;
    }
@@ -1177,7 +1259,7 @@ index 0d5670965f..61b445fcef 100644
        return compare;
      }
 diff --git a/hbase-external-blockcache/src/main/java/org/apache/hadoop/hbase/io/hfile/MemcachedBlockCache.java b/hbase-external-blockcache/src/main/java/org/apache/hadoop/hbase/io/hfile/MemcachedBlockCache.java
-index 3077ddb15f..0003a451d7 100644
+index 3077ddb15f1..0003a451d72 100644
 --- a/hbase-external-blockcache/src/main/java/org/apache/hadoop/hbase/io/hfile/MemcachedBlockCache.java
 +++ b/hbase-external-blockcache/src/main/java/org/apache/hadoop/hbase/io/hfile/MemcachedBlockCache.java
 @@ -107,6 +107,9 @@ public class MemcachedBlockCache implements BlockCache {
@@ -1191,7 +1273,7 @@ index 3077ddb15f..0003a451d7 100644
      for (String s : servers) {
        serverAddresses.add(Addressing.createInetSocketAddressFromHostAndPortStr(s));
 diff --git a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
-index 62e781de0d..2bed2a95cb 100644
+index c045ff87ded..8cb07f6c146 100644
 --- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
 +++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
 @@ -129,6 +129,7 @@ import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer;
@@ -1202,7 +1284,7 @@ index 62e781de0d..2bed2a95cb 100644
  import org.apache.hadoop.hbase.procedure.RegionServerProcedureManagerHost;
  import org.apache.hadoop.hbase.procedure2.RSProcedureCallable;
  import org.apache.hadoop.hbase.quotas.FileSystemUtilizationChore;
-@@ -316,14 +317,16 @@ public class HRegionServer extends Thread
+@@ -317,14 +318,17 @@ public class HRegionServer extends Thread
    private final ReentrantReadWriteLock onlineRegionsLock = new ReentrantReadWriteLock();
  
    /**
@@ -1212,25 +1294,28 @@ index 62e781de0d..2bed2a95cb 100644
 -   * but we'd need to convert it to InetSocketAddress at some point before the HDFS API call, and it
 -   * seems a bit weird to store ServerName since ServerName refers to RegionServers and here we
 -   * really mean DataNode locations.
-+   * Map of encoded region names to the DataNode locations they should be hosted on We store the We
-+   * store the value as Address since InetSocketAddress is required by the HDFS nodes as hints for
-+   * placing file blocks). We could have used ServerName here as the value class, but we'd need to
-+   * convert it to InetSocketAddress at some point before the HDFS API call, and it seems a bit
-+   * weird to store ServerName since ServerName refers to RegionServers and here we really mean
-+   * DataNode locations. We don't store it as InetSocketAddress here because the conversion on
-+   * demand from Address to InetSocketAddress will guarantee the resolution results will be fresh
-+   * when we need it.
++   * Map of encoded region names to the DataNode locations they should be hosted on
++   * We store the value as Address since InetSocketAddress is required by the HDFS
++   * API (create() that takes favored nodes as hints for placing file blocks).
++   * We could have used ServerName here as the value class, but we'd need to
++   * convert it to InetSocketAddress at some point before the HDFS API call, and
++   * it seems a bit weird to store ServerName since ServerName refers to RegionServers
++   * and here we really mean DataNode locations. We don't store it as InetSocketAddress
++   * here because the conversion on demand from Address to InetSocketAddress will
++   * guarantee the resolution results will be fresh when we need it.
     */
 -  private final Map<String, InetSocketAddress[]> regionFavoredNodesMap = new ConcurrentHashMap<>();
 +  private final Map<String, Address[]> regionFavoredNodesMap = new ConcurrentHashMap<>();
  
    private LeaseManager leaseManager;
  
-@@ -3455,24 +3458,23 @@ public class HRegionServer extends Thread
+@@ -3453,25 +3457,27 @@ public class HRegionServer extends Thread
+ 
    @Override
    public void updateRegionFavoredNodesMapping(String encodedRegionName,
-     List<org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos.ServerName> favoredNodes) {
+-    List<org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos.ServerName> favoredNodes) {
 -    InetSocketAddress[] addr = new InetSocketAddress[favoredNodes.size()];
++      List<org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos.ServerName> favoredNodes) {
 +    Address[] addr = new Address[favoredNodes.size()];
      // Refer to the comment on the declaration of regionFavoredNodesMap on why
 -    // it is a map of region name to InetSocketAddress[]
@@ -1238,15 +1323,19 @@ index 62e781de0d..2bed2a95cb 100644
      for (int i = 0; i < favoredNodes.size(); i++) {
 -      addr[i] = InetSocketAddress.createUnresolved(favoredNodes.get(i).getHostName(),
 -        favoredNodes.get(i).getPort());
-+      addr[i] = Address.fromParts(favoredNodes.get(i).getHostName(), favoredNodes.get(i).getPort());
++      addr[i] = Address.fromParts(favoredNodes.get(i).getHostName(),
++          favoredNodes.get(i).getPort());
      }
      regionFavoredNodesMap.put(encodedRegionName, addr);
    }
  
    /**
-    * Return the favored nodes for a region given its encoded name. Look at the comment around
+-   * Return the favored nodes for a region given its encoded name. Look at the comment around
 -   * {@link #regionFavoredNodesMap} on why it is InetSocketAddress[]
-+   * {@link #regionFavoredNodesMap} on why we convert to InetSocketAddress[] here.
++   * Return the favored nodes for a region given its encoded name. Look at the
++   * comment around {@link #regionFavoredNodesMap} on why we convert to InetSocketAddress[]
++   * here.
++   * @param encodedRegionName
     * @return array of favored locations
     */
    @Override
@@ -1258,7 +1347,7 @@ index 62e781de0d..2bed2a95cb 100644
    @Override
 diff --git a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestCIBadHostname.java b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestCIBadHostname.java
 deleted file mode 100644
-index c148efe2fe..0000000000
+index c148efe2fef..00000000000
 --- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestCIBadHostname.java
 +++ /dev/null
 @@ -1,97 +0,0 @@
@@ -1360,7 +1449,7 @@ index c148efe2fe..0000000000
 -  }
 -}
 diff --git a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestClientTimeouts.java b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestClientTimeouts.java
-index 86b981276f..3134356cb6 100644
+index 86b981276f6..8a5a0d1cc84 100644
 --- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestClientTimeouts.java
 +++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestClientTimeouts.java
 @@ -20,10 +20,8 @@ package org.apache.hadoop.hbase.client;
@@ -1399,11 +1488,13 @@ index 86b981276f..3134356cb6 100644
        return new RandomTimeoutRpcChannel(this, sn, ticket, rpcTimeout);
      }
    }
-@@ -168,7 +165,7 @@ public class TestClientTimeouts {
+@@ -167,8 +164,8 @@ public class TestClientTimeouts {
+     private static AtomicInteger invokations = new AtomicInteger();
  
      RandomTimeoutBlockingRpcChannel(final BlockingRpcClient rpcClient, final ServerName sn,
-       final User ticket, final int rpcTimeout) {
+-      final User ticket, final int rpcTimeout) {
 -      super(rpcClient, new InetSocketAddress(sn.getHostname(), sn.getPort()), ticket, rpcTimeout);
++        final User ticket, final int rpcTimeout) {
 +      super(rpcClient, Address.fromParts(sn.getHostname(), sn.getPort()), ticket, rpcTimeout);
      }
  
@@ -1414,13 +1505,13 @@ index 86b981276f..3134356cb6 100644
      RandomTimeoutRpcChannel(AbstractRpcClient<?> rpcClient, ServerName sn, User ticket,
 -      int rpcTimeout) throws UnknownHostException {
 -      super(rpcClient, new InetSocketAddress(sn.getHostname(), sn.getPort()), ticket, rpcTimeout);
-+      int rpcTimeout) {
++        int rpcTimeout) {
 +      super(rpcClient, Address.fromParts(sn.getHostname(), sn.getPort()), ticket, rpcTimeout);
      }
  
      @Override
 diff --git a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestHBaseClient.java b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestHBaseClient.java
-index 843b7dfa35..90e696c459 100644
+index 843b7dfa354..9a7af2d490c 100644
 --- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestHBaseClient.java
 +++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestHBaseClient.java
 @@ -17,9 +17,9 @@
@@ -1439,11 +1530,12 @@ index 843b7dfa35..90e696c459 100644
      Throwable testThrowable = new Throwable();// throwable already tested in TestFailedServers.java
  
 -    InetSocketAddress ia = InetSocketAddress.createUnresolved("bad", 12);
-+    Address ia = Address.fromParts("bad", 12);
-     // same server as ia
+-    // same server as ia
 -    InetSocketAddress ia2 = InetSocketAddress.createUnresolved("bad", 12);
 -    InetSocketAddress ia3 = InetSocketAddress.createUnresolved("badtoo", 12);
 -    InetSocketAddress ia4 = InetSocketAddress.createUnresolved("badtoo", 13);
++    Address ia = Address.fromParts("bad", 12);
++     // same server as ia
 +    Address ia2 = Address.fromParts("bad", 12);
 +    Address ia3 = Address.fromParts("badtoo", 12);
 +    Address ia4 = Address.fromParts("badtoo", 13);
@@ -1451,7 +1543,7 @@ index 843b7dfa35..90e696c459 100644
      Assert.assertFalse(fs.isFailedServer(ia));
  
 diff --git a/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKUtil.java b/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKUtil.java
-index cd9d829b60..c2b6dac108 100644
+index cd9d829b60c..c2b6dac1086 100644
 --- a/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKUtil.java
 +++ b/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKUtil.java
 @@ -25,6 +25,7 @@ import java.io.OutputStreamWriter;
@@ -1478,5 +1570,5 @@ index cd9d829b60..c2b6dac108 100644
        try (
          PrintWriter out = new PrintWriter(new BufferedWriter(
 -- 
-2.40.1
+2.42.1
 


### PR DESCRIPTION
# Description

Revert "Update patch to upstream HBase PR"

This reverts commit db478660d03c26bbebd4c58c3abcc9bedee170d9.

The commit updated patch 002-HBASE-25292 but not 003-HBASE-25336 and therefore 003-HBASE-25336 could not be applied anymore:

```
 > [hbase-2_4_17 builder  9/20] RUN patches/apply_patches.sh 2.4.17:
#0 0.137 Applying patches from patches/2.4.17 now
#0 0.140 Found 3 patches, applying now
#0 0.140 Applying patches/2.4.17/001-HBASE-27860-2.4.17.patch
#0 0.143 Applying patches/2.4.17/002-HBASE-25292-2.4.17.patch
#0 0.154 Applying patches/2.4.17/003-HBASE-25336-2.4.17.patch
#0 0.155 error: patch failed: hbase-2.4.17-src/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/AbstractRpcClient.java:393
#0 0.155 error: hbase-2.4.17-src/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/AbstractRpcClient.java: patch does not apply
#0 0.156 error: patch failed: hbase-2.4.17-src/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcConnection.java:374
#0 0.156 error: hbase-2.4.17-src/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcConnection.java: patch does not apply
#0 0.156 Failed to apply patches/2.4.17/003-HBASE-25336-2.4.17.patch
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [x] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] All packages should have (if available) signatures/hashes verified
- [x] Does your change affect an SBOM? Make sure to update all SBOMs
```
