### PR TITLE
Add topology provider jar to Hadoop image.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- hadoop: Added Stackable topology provider jar to enable k8s-based rack awareness ([#509])
 - hadoop: Add all necessary components to the image to mount HDFS using FUSE ([#400])
 - hbase: Add hbase-operator-tools ([#497], [#498]).
 - java-base: Add needed tzdata-java package ([#425]).
@@ -109,6 +110,7 @@ All notable changes to this project will be documented in this file.
 [#498]: https://github.com/stackabletech/docker-images/pull/498
 [#499]: https://github.com/stackabletech/docker-images/pull/499
 [#505]: https://github.com/stackabletech/docker-images/pull/505
+[#509]: https://github.com/stackabletech/docker-images/pull/509
 
 ## [23.7.0] - 2023-07-14
 

--- a/conf.py
+++ b/conf.py
@@ -62,25 +62,29 @@ products = [
                 "product": "3.2.2",
                 "java-base": "11",
                 "java": "11",
-                "jmx_exporter": "0.20.0"
+                "jmx_exporter": "0.20.0",
+                "topology_provider": "0.1.0"
             },
             {
                 "product": "3.2.4",
                 "java-base": "11",
                 "java": "11",
-                "jmx_exporter": "0.20.0"
+                "jmx_exporter": "0.20.0",
+                "topology_provider": "0.1.0"
             },
             {
                 "product": "3.3.4",
                 "java-base": "11",
                 "java": "11",
-                "jmx_exporter": "0.20.0"
+                "jmx_exporter": "0.20.0",
+                "topology_provider": "0.1.0"
             },
             {
                 "product": "3.3.6",
                 "java-base": "11",
                 "java": "11",
-                "jmx_exporter": "0.20.0"
+                "jmx_exporter": "0.20.0",
+                "topology_provider": "0.1.0"
             },
         ],
     },

--- a/hadoop/Dockerfile
+++ b/hadoop/Dockerfile
@@ -144,7 +144,7 @@ COPY --chown=stackable:stackable --from=builder /stackable/jmx /stackable/jmx/
 # The topology provider provides rack awareness functionality for HDFS by allowing users to specify Kubernetes
 # labels to build a rackID from
 # source code is at: https://github.com/stackabletech/hdfs-topology-provider
-ADD --chown=stackable:stackable https://repo.stackable.tech/repository/packages/hdfs-topology-provider/topology-provider-${TOPOLOGY_PROVIDER}.jar /stackable/hadoop/share/hadoop/tools/lib/
+RUN curl --fail -L -s -S https://repo.stackable.tech/repository/packages/hdfs-topology-provider/topology-provider-${TOPOLOGY_PROVIDER}.jar -o /stackable/hadoop/share/hadoop/tools/lib/ --chown=stackable:stackable
 
 RUN ln -s /stackable/hadoop-${PRODUCT} /stackable/hadoop
 COPY hadoop/stackable/fuse_dfs_wrapper /stackable/hadoop/bin

--- a/hadoop/Dockerfile
+++ b/hadoop/Dockerfile
@@ -4,6 +4,7 @@ FROM stackable/image/java-base AS builder
 ARG PRODUCT
 ARG JAVA
 ARG JMX_EXPORTER
+ARG TOPOLOGY_PROVIDER
 
 # https://github.com/hadolint/hadolint/wiki/DL4006
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -139,6 +140,12 @@ WORKDIR /stackable
 
 COPY --chown=stackable:stackable --from=builder /stackable/hadoop-${PRODUCT} /stackable/hadoop-${PRODUCT}/
 COPY --chown=stackable:stackable --from=builder /stackable/jmx /stackable/jmx/
+
+# The topology provider provides rack awareness functionality for HDFS by allowing users to specify Kubernetes
+# labels to build a rackID from
+# source code is at: https://github.com/stackabletech/hdfs-topology-provider
+ADD --chown=stackable:stackable https://repo.stackable.tech/repository/packages/hdfs-topology-provider/topology-provider-${TOPOLOGY_PROVIDER}.jar /stackable/hadoop/share/hadoop/tools/lib/
+
 RUN ln -s /stackable/hadoop-${PRODUCT} /stackable/hadoop
 COPY hadoop/stackable/fuse_dfs_wrapper /stackable/hadoop/bin
 


### PR DESCRIPTION
# Description

This adds an extra jar file to the Hadoop image which contains an implementation of the `org.apache.hadoop.net.DNSToSwitchMapping` interface to generate rack IDs based on Kubernetes labels, so that HDFS knows the underlying Kubernetes architecture and can distribute blocks properly.


Related to https://github.com/stackabletech/hdfs-operator/issues/325


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Does your change affect an SBOM? Make sure to update all SBOMs
```
