### PR TITLE
Changes default async-profiler support version from 1.x to 2.x

### DIFF
--- a/hbase/stackable/patches/2.4.12/005-HBASE-25685-2.4.12.patch
+++ b/hbase/stackable/patches/2.4.12/005-HBASE-25685-2.4.12.patch
@@ -1,0 +1,26 @@
+Subject: [PATCH] HBASE-25685: Switches default support for async-profiler to version 2.0
+
+This patch was partially applied already but for branch 2.4 the default was kept as it is needed for async-profiler 1.0.
+As we have control over the environment and 2.0 is old by now, we switch to the new version as well
+---
+Index: hbase-http/src/main/java/org/apache/hadoop/hbase/http/ProfileServlet.java
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/ProfileServlet.java b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/ProfileServlet.java
+--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/ProfileServlet.java	(revision e04956f7bb5d95a54612a99905ee2d8e7f0de23a)
++++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/ProfileServlet.java	(date 1701818500309)
+@@ -358,10 +358,10 @@
+       try {
+         return Output.valueOf(outputArg.trim().toUpperCase());
+       } catch (IllegalArgumentException e) {
+-        return Output.SVG;
++        return Output.HTML;
+       }
+     }
+-    return Output.SVG;
++    return Output.HTML;
+   }
+ 
+   static void setResponseHeader(final HttpServletResponse response) {

--- a/hbase/stackable/patches/2.4.17/004-HBASE-25685-2.4.12.patch
+++ b/hbase/stackable/patches/2.4.17/004-HBASE-25685-2.4.12.patch
@@ -1,0 +1,26 @@
+Subject: [PATCH] HBASE-25685: Switches default support for async-profiler to version 2.0
+
+This patch was partially applied already but for branch 2.4 the default was kept as it is needed for async-profiler 1.0.
+As we have control over the environment and 2.0 is old by now, we switch to the new version as well
+---
+Index: hbase-http/src/main/java/org/apache/hadoop/hbase/http/ProfileServlet.java
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/ProfileServlet.java b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/ProfileServlet.java
+--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/ProfileServlet.java	(revision e04956f7bb5d95a54612a99905ee2d8e7f0de23a)
++++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/ProfileServlet.java	(date 1701818500309)
+@@ -358,10 +358,10 @@
+       try {
+         return Output.valueOf(outputArg.trim().toUpperCase());
+       } catch (IllegalArgumentException e) {
+-        return Output.SVG;
++        return Output.HTML;
+       }
+     }
+-    return Output.SVG;
++    return Output.HTML;
+   }
+ 
+   static void setResponseHeader(final HttpServletResponse response) {


### PR DESCRIPTION
# Description

https://issues.apache.org/jira/browse/HBASE-25685

See this comment:

> Here is suggestion... here for branch-2.3/2.4 #3078... i.e. presume asyncprofiler1 but if asyncprofiler2 is there, allow setting output=html. For branch-2 and master, presume asyncprofiler2... thats #3079

This changes our HBase to presume asyncprofiler 2 and thus makes it work without extra parameters.



## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Does your change affect an SBOM? Make sure to update all SBOMs
```
