### PR TITLE
Patchfile for HBase arm builds

### DIFF
--- a/hbase/stackable/patches/2.4.17/004-HBASE-27103-2.4.17.patch
+++ b/hbase/stackable/patches/2.4.17/004-HBASE-27103-2.4.17.patch
@@ -1,0 +1,31 @@
+Subject: [PATCH] HBASE-27103 & HBASE-27065 Fix license validation warning for leveldbjni-all
+---
+Index: hbase-resource-bundle/src/main/resources/supplemental-models.xml
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/hbase-resource-bundle/src/main/resources/supplemental-models.xml b/hbase-resource-bundle/src/main/resources/supplemental-models.xml
+--- a/hbase-resource-bundle/src/main/resources/supplemental-models.xml	(revision 35781955c09db984f87c239c7a0dba900a16eb60)
++++ b/hbase-resource-bundle/src/main/resources/supplemental-models.xml	(date 1702637740114)
+@@ -2316,6 +2316,20 @@
+       </licenses>
+     </project>
+   </supplement>
++  <supplement>
++    <project>
++      <groupId>org.openlabtesting.leveldbjni</groupId>
++      <artifactId>leveldbjni-all</artifactId>
++
++      <licenses>
++        <license>
++          <name>BSD 3-Clause License</name>
++          <url>http://www.opensource.org/licenses/BSD-3-Clause</url>
++          <distribution>repo</distribution>
++        </license>
++      </licenses>
++    </project>
++  </supplement>
+ <!-- Category B licenses that need text in LICENSE and a NOTICE -->
+   <supplement>
+     <project>


### PR DESCRIPTION
# Description

This fixes a known hbase Issue for leveldbjni. Before, the arm64 build failed with
```[bash]
This product includes leveldbjni-all licensed under the The BSD 3-Clause License.

ERROR: Please check ^^^^^^^^^^^^ this License for acceptability here:

https://www.apache.org/legal/resolved
```
This was a part of https://github.com/stackabletech/issues/issues/483.

Epic: https://github.com/stackabletech/issues/issues/463

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Does your change affect an SBOM? Make sure to update all SBOMs
```
 