### PR TITLE
Add release components (product images) to the feature DB

### DIFF
--- a/update_feature_tracker_db.sh
+++ b/update_feature_tracker_db.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
-# Update the release components table with image identifiers and
-# product versions for a given release version.
+#
+# Update the release components table with image identifiers and product
+# versions for a given release version.
+#
+# This script is idempotent, provided the inputs (especially the image digests)
+# do not change.
 #
 # Requirements:
 #
-# 1. crane - Remote image handler
+# 1. crane - https://github.com/google/go-containerregistry/tree/main/cmd/crane
 # 2. psql  - Postgres command line client.
 #
 # Environment:
@@ -181,6 +185,8 @@ main() {
 		exit 1
 	fi
 
+	echo "Update release components for release $RELEASE_NAME and version $RELEASE_VERSION"
+
 	ensure_release_version "${RELEASE_NAME}" "${RELEASE_VERSION}"
 
 	for PRODUCT_CODE_NAME in "${PRODUCT_CODE_NAMES[@]}"; do
@@ -195,9 +201,13 @@ main() {
 
 			PRODUCT_IMAGE_DIGEST=$(product_image_digest "${IMAGE_NAME}")
 
+			echo "Updating compnents for image $IMAGE_NAME"
+
 			update_release_components "${RELEASE_VERSION}" "${PRODUCT_VERSION_ID}" "${REPOSITORY_NAME}" "${PRODUCT_IMAGE_DIGEST}"
 		done
 	done
+
+	echo "Done."
 }
 
 main "$@"

--- a/update_feature_tracker_db.sh
+++ b/update_feature_tracker_db.sh
@@ -64,8 +64,8 @@ ensure_release_version() {
 	# RELEASE_NAME    - Example: 2023-11
 	# RELEASE_VERSION - Example: 23.11.0
 
-	# -AtR "": in this case this basically means "just output the content of the selected column"
-	# -c: execute the provided command and exit
+	# -AtR "": In this case this basically means "just output the content of the selected column"
+	# -c: Execute the provided command and exit
 	RELEASE_ID=$(psql -qAtR "" -c "SELECT id FROM $DB_SCHEMA.releases WHERE name = '$RELEASE_NAME'")
 
 	if [ -z "$RELEASE_ID" ]; then

--- a/update_feature_tracker_db.sh
+++ b/update_feature_tracker_db.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -euo pipefail
+
+export PGPASSWORD=secret
+export PGHOST=localhost
+export PGUSER=postgres
+export PGDATABASE=postgres
+
+DB_SCHEMA=public
+
+REGISTRY=docker.stackable.tech # REGISTRY=oci.stackable.tech
+REGISTRY_PATH=stackable        # REGISTRY_PATH=sdp
+PRODUCT_NAME=airflow
+PRODUCT_VERSION=2.6.1
+RELEASE_NAME=23.11
+RELEASE_VERSION=23.11.0
+
+IMAGE_TAG=$PRODUCT_VERSION-stackable$RELEASE_VERSION
+
+IMAGE_DIGEST=$(crane digest $REGISTRY/$REGISTRY_PATH/$PRODUCT_NAME:$IMAGE_TAG)
+
+if [ -z "$IMAGE_DIGEST" ]; then
+    echo "Image $REGISTRY/$REGISTRY_PATH/$PRODUCT_NAME:$IMAGE_TAG not found in registry"
+    exit 1
+fi
+
+PURL="pkg:docker/$REGISTRY_PATH/$PRODUCT_NAME@$IMAGE_DIGEST?repository_url=$REGISTRY"
+
+echo "PURL is $PURL"
+
+# -AtR "": in this case this basically means "just output the content of the selected column"
+# -c: execute the provided command and exit
+RELEASE_ID=$(psql -AtR "" -c "SELECT id FROM $DB_SCHEMA.releases WHERE name = '$RELEASE_NAME'")
+
+if [ -z "$RELEASE_ID" ]; then
+    echo "Release $RELEASE_NAME not found in database"
+    exit 1
+fi
+
+# create release version if it does not exist
+psql -c "INSERT INTO $DB_SCHEMA.release_versions (release_id, version, created_at) VALUES ($RELEASE_ID, '$RELEASE_VERSION', now()) ON CONFLICT DO NOTHING"
+
+PRODUCT_ID=$(psql -AtR "" -c "SELECT id FROM $DB_SCHEMA.products WHERE name = '$PRODUCT_NAME'")
+
+if [ -z "$PRODUCT_ID" ]; then
+    echo "Product $PRODUCT_NAME not found in database"
+    exit 1
+fi
+
+PRODUCT_VERSION_ID=$(psql -AtR "" -c "SELECT id FROM $DB_SCHEMA.product_versions WHERE product_id = $PRODUCT_ID AND version = '$PRODUCT_VERSION'")
+
+if [ -z "$PRODUCT_VERSION_ID" ]; then
+    echo "Product version $PRODUCT_VERSION not found in database, creating it now"
+    PRODUCT_VERSION_ID=$(psql -AtR "" -c "INSERT INTO $DB_SCHEMA.product_versions (product_id, version) VALUES ($PRODUCT_ID, '$PRODUCT_VERSION') RETURNING id" | head -n1)
+fi
+
+echo "INSERT INTO release_components (product_version_id, release_version, purl) VALUES ($PRODUCT_VERSION_ID, '$RELEASE_VERSION', '$PURL')"
+psql -c "INSERT INTO release_components (product_version_id, release_version, purl) VALUES ($PRODUCT_VERSION_ID, '$RELEASE_VERSION', '$PURL')"

--- a/update_feature_tracker_db.sh
+++ b/update_feature_tracker_db.sh
@@ -1,57 +1,203 @@
 #!/bin/bash
+# Update the release components table with image identifiers and
+# product versions for a given release version.
+#
+# Requirements:
+#
+# 1. crane - Remote image handler
+# 2. psql  - Postgres command line client.
+#
+# Environment:
+#
+# The following variables are read from the environment:
+#
+#  PGPASSWORD
+#  PGHOST
+#  PGUSER
+#  PGDATABASE
+#  DB_SCHEMA
+#
+
 set -euo pipefail
-set -x
+#set -x
 
-#PGPASSWORD=secret
-export PGHOST=localhost
-export PGUSER=postgres
-export PGDATABASE=postgres
-export DB_SCHEMA=feature_tracker
+PRODUCT_CODE_NAMES=(
+	airflow
+	druid
+	hadoop
+	hbase
+	hive
+	kafka
+	nifi
+	spark-k8s
+	superset
+	trino
+	zookeeper
+)
 
-REGISTRY=docker.stackable.tech # REGISTRY=oci.stackable.tech
-REGISTRY_PATH=stackable        # REGISTRY_PATH=sdp
-PRODUCT_CODE_NAME=airflow
-PRODUCT_VERSION=2.6.1
-RELEASE_NAME=2023-11
-RELEASE_VERSION=23.11.0
+product_image_digest() {
+	# Return the digest for the given image name.
+	#
+	# Example output: sha256:822d427031bf93055c51f4dc3bcaa468867ce83f59de6824af279df4cce2d066
+	#
+	# Params:
+	#
+	# IMAGE_NAME - Example: docker.stackable.tech/stackable/zookeeper:3.8.3-stackable23.11.0
+	#
+	IMAGE_NAME="$1"
 
-IMAGE_TAG=$PRODUCT_VERSION-stackable$RELEASE_VERSION
+	IMAGE_DIGEST=$(crane digest "${IMAGE_NAME}")
 
-IMAGE_DIGEST=$(crane digest $REGISTRY/$REGISTRY_PATH/$PRODUCT_CODE_NAME:$IMAGE_TAG)
+	if [ -z "$IMAGE_DIGEST" ]; then
+		echo "Image ${IMAGE_NAME} not found in registry"
+		exit 1
+	fi
 
-if [ -z "$IMAGE_DIGEST" ]; then
-    echo "Image $REGISTRY/$REGISTRY_PATH/$PRODUCT_CODE_NAME:$IMAGE_TAG not found in registry"
-    exit 1
-fi
+	echo "${IMAGE_DIGEST}"
+}
 
-PURL="pkg:docker/$REGISTRY_PATH/$PRODUCT_CODE_NAME@$IMAGE_DIGEST?repository_url=$REGISTRY"
+ensure_release_version() {
+	# Ensure the release version is present in the DB.
+	#
+	# Params:
+	#
+	# RELEASE_NAME    - Example: 2023-11
+	# RELEASE_VERSION - Example: 23.11.0
 
-echo "PURL is $PURL"
+	# -AtR "": in this case this basically means "just output the content of the selected column"
+	# -c: execute the provided command and exit
+	RELEASE_ID=$(psql -qAtR "" -c "SELECT id FROM $DB_SCHEMA.releases WHERE name = '$RELEASE_NAME'")
 
-# -AtR "": in this case this basically means "just output the content of the selected column"
-# -c: execute the provided command and exit
-RELEASE_ID=$(psql -AtR "" -c "SELECT id FROM $DB_SCHEMA.releases WHERE name = '$RELEASE_NAME'")
+	if [ -z "$RELEASE_ID" ]; then
+		echo "Release $RELEASE_NAME not found in database"
+		exit 1
+	fi
 
-if [ -z "$RELEASE_ID" ]; then
-    echo "Release $RELEASE_NAME not found in database"
-    exit 1
-fi
+	# create release version if it does not exist
+	psql -q -c "INSERT INTO $DB_SCHEMA.release_versions (release_id, version, created_at) VALUES ($RELEASE_ID, '$RELEASE_VERSION', now()) ON CONFLICT DO NOTHING"
+}
 
-# create release version if it does not exist
-psql -c "INSERT INTO $DB_SCHEMA.release_versions (release_id, version, created_at) VALUES ($RELEASE_ID, '$RELEASE_VERSION', now()) ON CONFLICT DO NOTHING"
+ensure_product_version() {
+	# Ensure that a given product version exists in the DB.
+	# Returns the product version id.
+	#
+	# Params:
+	#
+	# PRODUCT_CODE_NAME - See the PRODUCT_CODE_NAMES array for valid values.
+	# PRODUCT_VERSION   - Example: 2.6.1
+	#
+	# Return:
+	#
+	# The id of the product version.
+	#
+	PRODUCT_CODE_NAME="$1"
+	PRODUCT_VERSION="$2"
 
-PRODUCT_ID=$(psql -AtR "" -c "SELECT id FROM $DB_SCHEMA.products WHERE code_name = '$PRODUCT_CODE_NAME'")
+	PRODUCT_ID=$(psql -qAtR "" -c "SELECT id FROM $DB_SCHEMA.products WHERE code_name = '$PRODUCT_CODE_NAME'")
 
-if [ -z "$PRODUCT_ID" ]; then
-    echo "Product $PRODUCT_CODE_NAME not found in database"
-    exit 1
-fi
+	if [ -z "$PRODUCT_ID" ]; then
+		echo >&2 "Product $PRODUCT_CODE_NAME not found in database"
+		exit 1
+	fi
 
-PRODUCT_VERSION_ID=$(psql -AtR "" -c "SELECT id FROM $DB_SCHEMA.product_versions WHERE product_id = $PRODUCT_ID AND version = '$PRODUCT_VERSION'")
+	PRODUCT_VERSION_ID=$(psql -qAtR "" -c "SELECT id FROM $DB_SCHEMA.product_versions WHERE product_id = $PRODUCT_ID AND version = '$PRODUCT_VERSION'")
 
-if [ -z "$PRODUCT_VERSION_ID" ]; then
-    echo "Product version $PRODUCT_VERSION not found in database, creating it now"
-    PRODUCT_VERSION_ID=$(psql -AtR "" -c "INSERT INTO $DB_SCHEMA.product_versions (product_id, version) VALUES ($PRODUCT_ID, '$PRODUCT_VERSION') RETURNING id" | head -n1)
-fi
+	if [ -z "$PRODUCT_VERSION_ID" ]; then
+		echo >&2 "Product version $PRODUCT_VERSION not found in database, creating it now"
+		psql -qAtR "" -c "INSERT INTO $DB_SCHEMA.product_versions (product_id, version) VALUES ($PRODUCT_ID, '$PRODUCT_VERSION')"
+	fi
 
-psql -c "INSERT INTO $DB_SCHEMA.release_components (product_version_id, release_version, purl) VALUES ($PRODUCT_VERSION_ID, '$RELEASE_VERSION', '$PURL')"
+	PRODUCT_VERSION_ID=$(psql -qAtR "" -c "SELECT id FROM $DB_SCHEMA.product_versions WHERE product_id = $PRODUCT_ID AND version = '$PRODUCT_VERSION'")
+
+	echo "${PRODUCT_VERSION_ID}"
+}
+
+update_release_components() {
+	# Update the release components table for the given parameters.
+	#
+	# Params:
+	#
+	# RELEASE_VERSION     - Example: 23.11.0
+	# PRODUCT_VERSION_ID  - Example: 38. See ensure_product_version() above.
+	# REPOSITORY_NAME     - Example: docker.stackable.tech/stackable/zookeeper
+	# IMAGE_DIGEST        - Example: sha256:822d427031bf93055c51f4dc3bcaa468867ce83f59de6824af279df4cce2d066
+
+	local RELEASE_VERSION="$1"
+	local PRODUCT_VERSION_ID="$2"
+	local REPOSITORY_NAME="$3"
+	local IMAGE_DIGEST="$4"
+
+	REGISTRY=$(echo "${REPOSITORY_NAME}" | sed 's/\/.*//')
+
+	PURL="pkg:docker/${REPOSITORY_NAME}@${IMAGE_DIGEST}?repository_url=$REGISTRY"
+
+	psql -q -c "INSERT INTO $DB_SCHEMA.release_components (product_version_id, release_version, purl) VALUES ($PRODUCT_VERSION_ID, '$RELEASE_VERSION', '$PURL') ON CONFLICT DO NOTHING"
+}
+
+usage() {
+	cat <<EOF
+
+  Usage: $0 <release> <version>
+
+  Options:
+
+  release - release name (ex. 2023-11)"
+  version - release version (ex. 23.11.0)
+
+  The following environment variables are required for the connection to the Postgres DB:
+
+    PGPASSWORD
+    PGHOST
+    PGUSER
+    PGDATABASE
+    DB_SCHEMA
+
+EOF
+}
+
+main() {
+	# Update the release components for the given release (version).
+	#
+	# Params
+	#
+	# RELEASE_NAME    - Example: 2023-11
+	# RELEASE_VERSION - Example: 23.11.0
+	#
+	local RELEASE_NAME="${1:-}"
+	local RELEASE_VERSION="${2:-}"
+
+	local REGISTRY=docker.stackable.tech # REGISTRY=oci.stackable.tech
+	local REGISTRY_PATH=stackable        # REGISTRY_PATH=sdp
+
+	if [ -z "$RELEASE_NAME" ]; then
+		echo "Release name cannot be empty."
+		usage
+		exit 1
+	fi
+
+	if [ -z "$RELEASE_VERSION" ]; then
+		echo "Release version cannot be empty."
+		usage
+		exit 1
+	fi
+
+	ensure_release_version "${RELEASE_NAME}" "${RELEASE_VERSION}"
+
+	for PRODUCT_CODE_NAME in "${PRODUCT_CODE_NAMES[@]}"; do
+		REPOSITORY_NAME="${REGISTRY}/${REGISTRY_PATH}/${PRODUCT_CODE_NAME}"
+
+		IMAGES=$(crane ls "${REPOSITORY_NAME}" | grep "stackable${RELEASE_VERSION}" | xargs -I '{}' echo "${REPOSITORY_NAME}":'{}')
+
+		for IMAGE_NAME in $(echo "${IMAGES}"); do
+			PRODUCT_VERSION=$(echo "${IMAGE_NAME}" | sed 's/^.*://' | sed 's/-.*//')
+
+			PRODUCT_VERSION_ID=$(ensure_product_version "${PRODUCT_CODE_NAME}" "${PRODUCT_VERSION}")
+
+			PRODUCT_IMAGE_DIGEST=$(product_image_digest "${IMAGE_NAME}")
+
+			update_release_components "${RELEASE_VERSION}" "${PRODUCT_VERSION_ID}" "${REPOSITORY_NAME}" "${PRODUCT_IMAGE_DIGEST}"
+		done
+	done
+}
+
+main "$@"

--- a/update_feature_tracker_db.sh
+++ b/update_feature_tracker_db.sh
@@ -26,120 +26,120 @@ set -euo pipefail
 #set -x
 
 PRODUCT_CODE_NAMES=(
-	airflow
-	druid
-	hadoop
-	hbase
-	hive
-	kafka
-	nifi
-	spark-k8s
-	superset
-	trino
-	zookeeper
+  airflow
+  druid
+  hadoop
+  hbase
+  hive
+  kafka
+  nifi
+  spark-k8s
+  superset
+  trino
+  zookeeper
 )
 
 product_image_digest() {
-	# Return the digest for the given image name.
-	#
-	# Example output: sha256:822d427031bf93055c51f4dc3bcaa468867ce83f59de6824af279df4cce2d066
-	#
-	# Params:
-	#
-	# IMAGE_NAME - Example: docker.stackable.tech/stackable/zookeeper:3.8.3-stackable23.11.0
-	#
-	IMAGE_NAME="$1"
+  # Return the digest for the given image name.
+  #
+  # Example output: sha256:822d427031bf93055c51f4dc3bcaa468867ce83f59de6824af279df4cce2d066
+  #
+  # Params:
+  #
+  # IMAGE_NAME - Example: docker.stackable.tech/stackable/zookeeper:3.8.3-stackable23.11.0
+  #
+  IMAGE_NAME="$1"
 
-	IMAGE_DIGEST=$(crane digest "${IMAGE_NAME}")
+  IMAGE_DIGEST=$(crane digest "${IMAGE_NAME}")
 
-	if [ -z "$IMAGE_DIGEST" ]; then
-		echo "Image ${IMAGE_NAME} not found in registry"
-		exit 1
-	fi
+  if [ -z "$IMAGE_DIGEST" ]; then
+    echo "Image ${IMAGE_NAME} not found in registry"
+    exit 1
+  fi
 
-	echo "${IMAGE_DIGEST}"
+  echo "${IMAGE_DIGEST}"
 }
 
 ensure_release_version() {
-	# Ensure the release version is present in the DB.
-	#
-	# Params:
-	#
-	# RELEASE_NAME    - Example: 2023-11
-	# RELEASE_VERSION - Example: 23.11.0
+  # Ensure the release version is present in the DB.
+  #
+  # Params:
+  #
+  # RELEASE_NAME    - Example: 2023-11
+  # RELEASE_VERSION - Example: 23.11.0
 
-	# -AtR "": In this case this basically means "just output the content of the selected column"
-	# -c: Execute the provided command and exit
-	RELEASE_ID=$(psql -qAtR "" -c "SELECT id FROM $DB_SCHEMA.releases WHERE name = '$RELEASE_NAME'")
+  # -AtR "": In this case this basically means "just output the content of the selected column"
+  # -c: Execute the provided command and exit
+  RELEASE_ID=$(psql -qAtR "" -c "SELECT id FROM $DB_SCHEMA.releases WHERE name = '$RELEASE_NAME'")
 
-	if [ -z "$RELEASE_ID" ]; then
-		echo "Release $RELEASE_NAME not found in database"
-		exit 1
-	fi
+  if [ -z "$RELEASE_ID" ]; then
+    echo "Release $RELEASE_NAME not found in database"
+    exit 1
+  fi
 
-	# Create release version if it does not exist
-	psql -q -c "INSERT INTO $DB_SCHEMA.release_versions (release_id, version, created_at) VALUES ($RELEASE_ID, '$RELEASE_VERSION', now()) ON CONFLICT DO NOTHING"
+  # Create release version if it does not exist
+  psql -q -c "INSERT INTO $DB_SCHEMA.release_versions (release_id, version, created_at) VALUES ($RELEASE_ID, '$RELEASE_VERSION', now()) ON CONFLICT DO NOTHING"
 }
 
 ensure_product_version() {
-	# Ensure that a given product version exists in the DB.
-	# Returns the product version id.
-	#
-	# Params:
-	#
-	# PRODUCT_CODE_NAME - See the PRODUCT_CODE_NAMES array for valid values.
-	# PRODUCT_VERSION   - Example: 2.6.1
-	#
-	# Return:
-	#
-	# The id of the product version.
-	#
-	PRODUCT_CODE_NAME="$1"
-	PRODUCT_VERSION="$2"
+  # Ensure that a given product version exists in the DB.
+  # Returns the product version id.
+  #
+  # Params:
+  #
+  # PRODUCT_CODE_NAME - See the PRODUCT_CODE_NAMES array for valid values.
+  # PRODUCT_VERSION   - Example: 2.6.1
+  #
+  # Return:
+  #
+  # The id of the product version.
+  #
+  PRODUCT_CODE_NAME="$1"
+  PRODUCT_VERSION="$2"
 
-	PRODUCT_ID=$(psql -qAtR "" -c "SELECT id FROM $DB_SCHEMA.products WHERE code_name = '$PRODUCT_CODE_NAME'")
+  PRODUCT_ID=$(psql -qAtR "" -c "SELECT id FROM $DB_SCHEMA.products WHERE code_name = '$PRODUCT_CODE_NAME'")
 
-	if [ -z "$PRODUCT_ID" ]; then
-		echo >&2 "Product $PRODUCT_CODE_NAME not found in database"
-		exit 1
-	fi
+  if [ -z "$PRODUCT_ID" ]; then
+    echo >&2 "Product $PRODUCT_CODE_NAME not found in database"
+    exit 1
+  fi
 
-	PRODUCT_VERSION_ID=$(psql -qAtR "" -c "SELECT id FROM $DB_SCHEMA.product_versions WHERE product_id = $PRODUCT_ID AND version = '$PRODUCT_VERSION'")
+  PRODUCT_VERSION_ID=$(psql -qAtR "" -c "SELECT id FROM $DB_SCHEMA.product_versions WHERE product_id = $PRODUCT_ID AND version = '$PRODUCT_VERSION'")
 
-	if [ -z "$PRODUCT_VERSION_ID" ]; then
-		echo >&2 "Product version $PRODUCT_VERSION not found in database, creating it now"
-		psql -qAtR "" -c "INSERT INTO $DB_SCHEMA.product_versions (product_id, version) VALUES ($PRODUCT_ID, '$PRODUCT_VERSION')"
-	fi
+  if [ -z "$PRODUCT_VERSION_ID" ]; then
+    echo >&2 "Product version $PRODUCT_VERSION not found in database, creating it now"
+    psql -qAtR "" -c "INSERT INTO $DB_SCHEMA.product_versions (product_id, version) VALUES ($PRODUCT_ID, '$PRODUCT_VERSION')"
+  fi
 
-	PRODUCT_VERSION_ID=$(psql -qAtR "" -c "SELECT id FROM $DB_SCHEMA.product_versions WHERE product_id = $PRODUCT_ID AND version = '$PRODUCT_VERSION'")
+  PRODUCT_VERSION_ID=$(psql -qAtR "" -c "SELECT id FROM $DB_SCHEMA.product_versions WHERE product_id = $PRODUCT_ID AND version = '$PRODUCT_VERSION'")
 
-	echo "${PRODUCT_VERSION_ID}"
+  echo "${PRODUCT_VERSION_ID}"
 }
 
 update_release_components() {
-	# Update the release components table for the given parameters.
-	#
-	# Params:
-	#
-	# RELEASE_VERSION     - Example: 23.11.0
-	# PRODUCT_VERSION_ID  - Example: 38. See ensure_product_version() above.
-	# REPOSITORY_NAME     - Example: docker.stackable.tech/stackable/zookeeper
-	# IMAGE_DIGEST        - Example: sha256:822d427031bf93055c51f4dc3bcaa468867ce83f59de6824af279df4cce2d066
+  # Update the release components table for the given parameters.
+  #
+  # Params:
+  #
+  # RELEASE_VERSION     - Example: 23.11.0
+  # PRODUCT_VERSION_ID  - Example: 38. See ensure_product_version() above.
+  # REPOSITORY_NAME     - Example: docker.stackable.tech/stackable/zookeeper
+  # IMAGE_DIGEST        - Example: sha256:822d427031bf93055c51f4dc3bcaa468867ce83f59de6824af279df4cce2d066
 
-	local RELEASE_VERSION="$1"
-	local PRODUCT_VERSION_ID="$2"
-	local REPOSITORY_NAME="$3"
-	local IMAGE_DIGEST="$4"
+  local RELEASE_VERSION="$1"
+  local PRODUCT_VERSION_ID="$2"
+  local REPOSITORY_NAME="$3"
+  local IMAGE_DIGEST="$4"
 
-	REGISTRY=$(echo "${REPOSITORY_NAME}" | sed 's/\/.*//')
+  REGISTRY=$(echo "${REPOSITORY_NAME}" | sed 's/\/.*//')
 
-	PURL="pkg:docker/${REPOSITORY_NAME}@${IMAGE_DIGEST}?repository_url=$REGISTRY"
+  PURL="pkg:docker/${REPOSITORY_NAME}@${IMAGE_DIGEST}?repository_url=$REGISTRY"
 
-	psql -q -c "INSERT INTO $DB_SCHEMA.release_components (product_version_id, release_version, purl) VALUES ($PRODUCT_VERSION_ID, '$RELEASE_VERSION', '$PURL') ON CONFLICT DO NOTHING"
+  psql -q -c "INSERT INTO $DB_SCHEMA.release_components (product_version_id, release_version, purl) VALUES ($PRODUCT_VERSION_ID, '$RELEASE_VERSION', '$PURL') ON CONFLICT DO NOTHING"
 }
 
 usage() {
-	cat <<EOF
+  cat <<EOF
 
   Usage: $0 <release> <version>
 
@@ -160,54 +160,60 @@ EOF
 }
 
 main() {
-	# Update the release components for the given release (version).
-	#
-	# Params
-	#
-	# RELEASE_NAME    - Example: 2023-11
-	# RELEASE_VERSION - Example: 23.11.0
-	#
-	local RELEASE_NAME="${1:-}"
-	local RELEASE_VERSION="${2:-}"
+  # Update the release components for the given release (version).
+  #
+  # Params
+  #
+  # RELEASE_NAME    - Example: 2023-11
+  # RELEASE_VERSION - Example: 23.11.0
+  #
+  local RELEASE_NAME="${1:-}"
+  local RELEASE_VERSION="${2:-}"
 
-	local REGISTRY=docker.stackable.tech # REGISTRY=oci.stackable.tech
-	local REGISTRY_PATH=stackable        # REGISTRY_PATH=sdp
+  local REGISTRY=docker.stackable.tech # REGISTRY=oci.stackable.tech
+  local REGISTRY_PATH=stackable        # REGISTRY_PATH=sdp
 
-	if [ -z "$RELEASE_NAME" ]; then
-		echo "Release name cannot be empty."
-		usage
-		exit 1
-	fi
+  if [ -z "$RELEASE_NAME" ]; then
+    echo "Release name cannot be empty."
+    usage
+    exit 1
+  fi
 
-	if [ -z "$RELEASE_VERSION" ]; then
-		echo "Release version cannot be empty."
-		usage
-		exit 1
-	fi
+  if [ -z "$RELEASE_VERSION" ]; then
+    echo "Release version cannot be empty."
+    usage
+    exit 1
+  fi
 
-	echo "Update release components for release $RELEASE_NAME and version $RELEASE_VERSION"
+  echo "Update release components for release $RELEASE_NAME and version $RELEASE_VERSION"
 
-	ensure_release_version "${RELEASE_NAME}" "${RELEASE_VERSION}"
+  ensure_release_version "${RELEASE_NAME}" "${RELEASE_VERSION}"
 
-	for PRODUCT_CODE_NAME in "${PRODUCT_CODE_NAMES[@]}"; do
-		REPOSITORY_NAME="${REGISTRY}/${REGISTRY_PATH}/${PRODUCT_CODE_NAME}"
+  for PRODUCT_CODE_NAME in "${PRODUCT_CODE_NAMES[@]}"; do
+    REPOSITORY_NAME="${REGISTRY}/${REGISTRY_PATH}/${PRODUCT_CODE_NAME}"
 
-		IMAGES=$(crane ls "${REPOSITORY_NAME}" | grep "stackable${RELEASE_VERSION}" | xargs -I '{}' echo "${REPOSITORY_NAME}":'{}')
+    IMAGES=$(crane ls "${REPOSITORY_NAME}" | grep "stackable${RELEASE_VERSION}" | xargs -I '{}' echo "${REPOSITORY_NAME}":'{}')
 
-		for IMAGE_NAME in $(echo "${IMAGES}"); do
-			PRODUCT_VERSION=$(echo "${IMAGE_NAME}" | sed 's/^.*://' | sed 's/-.*//')
+    # Linter complains about usless echo in $(echo $IMAGES)
+    # but the "echo" is necessary to split IMAGES into multiple lines.
+    # Otherwise IMAGE_NAME contains a long string with all images separated by
+    # newline.
+    #
+    # shellcheck disable=SC2116
+    for IMAGE_NAME in $(echo "${IMAGES}"); do
+      PRODUCT_VERSION=$(echo "${IMAGE_NAME}" | sed 's/^.*://' | sed 's/-.*//')
 
-			PRODUCT_VERSION_ID=$(ensure_product_version "${PRODUCT_CODE_NAME}" "${PRODUCT_VERSION}")
+      PRODUCT_VERSION_ID=$(ensure_product_version "${PRODUCT_CODE_NAME}" "${PRODUCT_VERSION}")
 
-			PRODUCT_IMAGE_DIGEST=$(product_image_digest "${IMAGE_NAME}")
+      PRODUCT_IMAGE_DIGEST=$(product_image_digest "${IMAGE_NAME}")
 
-			echo "Updating compnents for image $IMAGE_NAME"
+      echo "Updating compnents for image $IMAGE_NAME"
 
-			update_release_components "${RELEASE_VERSION}" "${PRODUCT_VERSION_ID}" "${REPOSITORY_NAME}" "${PRODUCT_IMAGE_DIGEST}"
-		done
-	done
+      update_release_components "${RELEASE_VERSION}" "${PRODUCT_VERSION_ID}" "${REPOSITORY_NAME}" "${PRODUCT_IMAGE_DIGEST}"
+    done
+  done
 
-	echo "Done."
+  echo "Done."
 }
 
 main "$@"

--- a/update_feature_tracker_db.sh
+++ b/update_feature_tracker_db.sh
@@ -1,30 +1,30 @@
 #!/bin/bash
 set -euo pipefail
+set -x
 
-export PGPASSWORD=secret
+#PGPASSWORD=secret
 export PGHOST=localhost
 export PGUSER=postgres
 export PGDATABASE=postgres
-
-DB_SCHEMA=public
+export DB_SCHEMA=feature_tracker
 
 REGISTRY=docker.stackable.tech # REGISTRY=oci.stackable.tech
 REGISTRY_PATH=stackable        # REGISTRY_PATH=sdp
-PRODUCT_NAME=airflow
+PRODUCT_CODE_NAME=airflow
 PRODUCT_VERSION=2.6.1
-RELEASE_NAME=23.11
+RELEASE_NAME=2023-11
 RELEASE_VERSION=23.11.0
 
 IMAGE_TAG=$PRODUCT_VERSION-stackable$RELEASE_VERSION
 
-IMAGE_DIGEST=$(crane digest $REGISTRY/$REGISTRY_PATH/$PRODUCT_NAME:$IMAGE_TAG)
+IMAGE_DIGEST=$(crane digest $REGISTRY/$REGISTRY_PATH/$PRODUCT_CODE_NAME:$IMAGE_TAG)
 
 if [ -z "$IMAGE_DIGEST" ]; then
-    echo "Image $REGISTRY/$REGISTRY_PATH/$PRODUCT_NAME:$IMAGE_TAG not found in registry"
+    echo "Image $REGISTRY/$REGISTRY_PATH/$PRODUCT_CODE_NAME:$IMAGE_TAG not found in registry"
     exit 1
 fi
 
-PURL="pkg:docker/$REGISTRY_PATH/$PRODUCT_NAME@$IMAGE_DIGEST?repository_url=$REGISTRY"
+PURL="pkg:docker/$REGISTRY_PATH/$PRODUCT_CODE_NAME@$IMAGE_DIGEST?repository_url=$REGISTRY"
 
 echo "PURL is $PURL"
 
@@ -40,10 +40,10 @@ fi
 # create release version if it does not exist
 psql -c "INSERT INTO $DB_SCHEMA.release_versions (release_id, version, created_at) VALUES ($RELEASE_ID, '$RELEASE_VERSION', now()) ON CONFLICT DO NOTHING"
 
-PRODUCT_ID=$(psql -AtR "" -c "SELECT id FROM $DB_SCHEMA.products WHERE name = '$PRODUCT_NAME'")
+PRODUCT_ID=$(psql -AtR "" -c "SELECT id FROM $DB_SCHEMA.products WHERE code_name = '$PRODUCT_CODE_NAME'")
 
 if [ -z "$PRODUCT_ID" ]; then
-    echo "Product $PRODUCT_NAME not found in database"
+    echo "Product $PRODUCT_CODE_NAME not found in database"
     exit 1
 fi
 
@@ -54,5 +54,4 @@ if [ -z "$PRODUCT_VERSION_ID" ]; then
     PRODUCT_VERSION_ID=$(psql -AtR "" -c "INSERT INTO $DB_SCHEMA.product_versions (product_id, version) VALUES ($PRODUCT_ID, '$PRODUCT_VERSION') RETURNING id" | head -n1)
 fi
 
-echo "INSERT INTO release_components (product_version_id, release_version, purl) VALUES ($PRODUCT_VERSION_ID, '$RELEASE_VERSION', '$PURL')"
-psql -c "INSERT INTO release_components (product_version_id, release_version, purl) VALUES ($PRODUCT_VERSION_ID, '$RELEASE_VERSION', '$PURL')"
+psql -c "INSERT INTO $DB_SCHEMA.release_components (product_version_id, release_version, purl) VALUES ($PRODUCT_VERSION_ID, '$RELEASE_VERSION', '$PURL')"

--- a/update_feature_tracker_db.sh
+++ b/update_feature_tracker_db.sh
@@ -73,7 +73,7 @@ ensure_release_version() {
 		exit 1
 	fi
 
-	# create release version if it does not exist
+	# Create release version if it does not exist
 	psql -q -c "INSERT INTO $DB_SCHEMA.release_versions (release_id, version, created_at) VALUES ($RELEASE_ID, '$RELEASE_VERSION', now()) ON CONFLICT DO NOTHING"
 }
 


### PR DESCRIPTION
# Description

This PR is part of https://github.com/stackabletech/feature-tracker/issues/52 and depends on https://github.com/stackabletech/feature-tracker/pull/53.

It adds a new script that updates the feature DB for a given release (version).

For example, after release version 23.11.0, the database can be updated with:

```
./update_feature_tracker_db.sh 2023-11 23.11.0
```


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [x] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] All packages should have (if available) signatures/hashes verified
- [x] Does your change affect an SBOM? Make sure to update all SBOMs
```
