### PR TITLE
feat(opa): Add version 0.61.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 - testing-tools: Add krb5-user library for Kerberos tests ([#531]).
 - testing-tools: Add the Python library Beautiful Soup 4 ([#536]).
 - java-base: Add `openjdk-devel` package for tool such as `jps` or `jmap` ([#537]).
-- opa: Add version `0.61.0` ([#XXX]).
+- opa: Add version `0.61.0` ([#538]).
 
 ### Changed
 
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 [#531]: https://github.com/stackabletech/docker-images/pull/531
 [#536]: https://github.com/stackabletech/docker-images/pull/536
 [#537]: https://github.com/stackabletech/docker-images/pull/537
+[#538]: https://github.com/stackabletech/docker-images/pull/538
 
 ## [23.11.0] - 2023-11-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - testing-tools: Add krb5-user library for Kerberos tests ([#531]).
 - testing-tools: Add the Python library Beautiful Soup 4 ([#536]).
 - java-base: Add `openjdk-devel` package for tool such as `jps` or `jmap` ([#537]).
+- opa: Add version `0.61.0` ([#XXX]).
 
 ### Changed
 

--- a/conf.py
+++ b/conf.py
@@ -241,6 +241,13 @@ products = [
                 "vector": "0.33.0",
                 "bundle_builder_version": "1.1.0",
             },
+            # 2024-01-30: We only added 0.61.0 to be able to write Rego rules v1.
+            # The regular product version update process must take care of removing unsupported versions and bumping vector
+            {
+                "product": "0.61.0",
+                "vector": "0.33.0",
+                "bundle_builder_version": "1.1.0",
+            },
         ],
     },
     {

--- a/opa/upload_new_opa_version.sh
+++ b/opa/upload_new_opa_version.sh
@@ -29,34 +29,35 @@ trap cleanup EXIT
 
 cd "$WORK_DIR" || exit
 
-bin_file=opa_linux_amd64_static
-download_url="https://openpolicyagent.org/downloads/v${VERSION}/${bin_file}"
+for bin_file in opa_linux_amd64_static opa_linux_arm64_static; do
+  download_url="https://openpolicyagent.org/downloads/v${VERSION}/${bin_file}"
 
-echo "Downloading OPA from ${download_url}"
-curl --fail -L -o "${bin_file}" "${download_url}"
-echo "Downloading OPA checksum from ${download_url}.sha256"
-curl --fail -L -o "${bin_file}".sha256 "${download_url}".sha256
+  echo "Downloading OPA from ${download_url}"
+  curl --fail -L -o "${bin_file}" "${download_url}"
+  echo "Downloading OPA checksum from ${download_url}.sha256"
+  curl --fail -L -o "${bin_file}".sha256 "${download_url}".sha256
 
-echo "Validating SHA256 Checksum"
-if ! (sha256sum "${bin_file}" | diff - "${bin_file}".sha256); then
-  echo "ERROR: One of the SHA256 sums does not match"
-  exit 1
-fi
+  echo "Validating SHA256 Checksum"
+  if ! (sha256sum "${bin_file}" | diff - "${bin_file}".sha256); then
+    echo "ERROR: One of the SHA256 sums does not match"
+    exit 1
+  fi
 
-versioned_bin_file=${bin_file}_${VERSION}
-echo "Tag bin file and SHA with version ${bin_file} -> ${versioned_bin_file}"
-mv "${bin_file}" "${versioned_bin_file}"
-mv "${bin_file}".sha256 "${versioned_bin_file}".sha256
+  versioned_bin_file=${bin_file}_${VERSION}
+  echo "Tag bin file and SHA with version ${bin_file} -> ${versioned_bin_file}"
+  mv "${bin_file}" "${versioned_bin_file}"
+  mv "${bin_file}".sha256 "${versioned_bin_file}".sha256
 
-echo "Uploading everything to Nexus"
-EXIT_STATUS=0
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${versioned_bin_file}" 'https://repo.stackable.tech/repository/packages/opa/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${versioned_bin_file}".sha256 'https://repo.stackable.tech/repository/packages/opa/' || EXIT_STATUS=$?
+  echo "Uploading everything to Nexus"
+  EXIT_STATUS=0
+  curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${versioned_bin_file}" 'https://repo.stackable.tech/repository/packages/opa/' || EXIT_STATUS=$?
+  curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${versioned_bin_file}".sha256 'https://repo.stackable.tech/repository/packages/opa/' || EXIT_STATUS=$?
 
-if [ $EXIT_STATUS -ne 0 ]; then
-  echo "ERROR: Upload failed"
-  exit 1
-fi
+  if [ $EXIT_STATUS -ne 0 ]; then
+    echo "ERROR: Upload failed"
+    exit 1
+  fi
 
-echo "Successfully uploaded version $VERSION of OPA to Nexus"
-echo "https://repo.stackable.tech/service/rest/repository/browse/packages/opa/"
+  echo "Successfully uploaded version $VERSION of OPA to Nexus"
+  echo "https://repo.stackable.tech/service/rest/repository/browse/packages/opa/"
+done


### PR DESCRIPTION
# Description

We need opa >= 0.59.0 to be able to write [Rego v1](https://github.com/open-policy-agent/opa/releases/tag/v0.59.0).
In our supported product versions we planned to support 0.61.0 anyway, this just pulls the new version a few days early to make our lives easier at other places

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Does your change affect an SBOM? Make sure to update all SBOMs
```
