### PR TITLE
hadoop: Always use registered hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - omid: init at 1.1.0 ([#493]).
-- hadoop: Allow datanodes to override their registration addresses ([#506]).
+- hadoop: Allow datanodes to override their registration addresses ([#506], [#544]).
 - nifi: Add Apache Iceberg extensions ([#529]).
 - testing-tools: Add krb5-user library for Kerberos tests ([#531]).
 - testing-tools: Add the Python library Beautiful Soup 4 ([#536]).
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
 [#538]: https://github.com/stackabletech/docker-images/pull/538
 [#539]: https://github.com/stackabletech/docker-images/pull/539
 [#542]: https://github.com/stackabletech/docker-images/pull/542
+[#544]: https://github.com/stackabletech/docker-images/pull/544
 
 ## [23.11.0] - 2023-11-30
 

--- a/hadoop/stackable/patches/3.3.4/002-datanode-registration-override-3.3.4.patch
+++ b/hadoop/stackable/patches/3.3.4/002-datanode-registration-override-3.3.4.patch
@@ -234,7 +234,7 @@ index c1507a45120..d253779e70d 100644
 +    }
 +
 +    DatanodeID dnId = new DatanodeID(registeredHostname,
-+                                     hostName,
++                                     registeredHostname,
 +                                     storage.getDatanodeUuid(),
 +                                     registeredDataPort,
 +                                     registeredHttpPort,

--- a/hadoop/stackable/patches/3.3.6/002-datanode-registration-override-3.3.6.patch
+++ b/hadoop/stackable/patches/3.3.6/002-datanode-registration-override-3.3.6.patch
@@ -234,7 +234,7 @@ index 96c4ad9ae28..fdb8e631dc8 100644
 +    }
 +
 +    DatanodeID dnId = new DatanodeID(registeredHostname,
-+                                     hostName,
++                                     registeredHostname,
 +                                     storage.getDatanodeUuid(),
 +                                     registeredDataPort,
 +                                     registeredHttpPort,


### PR DESCRIPTION
# Description

Fixes https://github.com/stackabletech/hdfs-operator/issues/468, fixes https://github.com/stackabletech/hdfs-operator/issues/467

This changes the datanode identity from the pod hostname to the IP address. This fixes both WebHDFS and the broken datanode dashboard in the namenode web UI.


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
```
