### PR TITLE
Generate SBOMs for product images

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -19,6 +19,20 @@ jobs:
       matrix:
         product:
           - airflow
+          - druid
+          - hadoop
+          - hbase
+          - hive
+          - kafka
+          - krb5
+          - nifi
+          - opa
+          - spark-k8s
+          - superset
+          - testing-tools
+          - trino
+          - tools
+          - zookeeper
         shard_count:
           - 5
         shard_index: [0, 1, 2, 3, 4] # between 0 and shard_count-1

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -31,6 +31,8 @@ jobs:
           python-version: '3.x'
       - name: Set up Cosign
         uses: sigstore/cosign-installer@9614fae9e5c5eddabb09f90a270fcb487c9f7149 # tag=v3.3.0
+      - name: Set up syft
+        uses: anchore/sbom-action/download-syft@24b0d5238516480139aa8bc6f92eeb7b54a9eb0a # tag=v0.15.5
       - name: Install image-tools-stackabletech
         run: pip install image-tools-stackabletech==0.0.5
       - uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # tag=v3.0.0

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feat/generate-sboms
 
 jobs:
   development:
@@ -108,7 +107,7 @@ jobs:
             # Get metadata from the image
             IMAGE_METADATA_DESCRIPTION=$(docker inspect --format='{{.Config.Labels.description}}' "$IMAGE_NAME@$DIGEST");
             IMAGE_METADATA_NAME=$(docker inspect --format='{{.Config.Labels.name}}' "$IMAGE_NAME@$DIGEST");
-            # Merge the SBOM with the metadata for the operator
+            # Merge the SBOM with the metadata for the image
             jq -s '{"metadata":{"component":{"description":"'"$IMAGE_METADATA_NAME. $IMAGE_METADATA_DESCRIPTION"'","supplier":{"name":"Stackable GmbH","url":["https://stackable.tech/"]},"author":"Stackable GmbH","purl":"'"$PURL"'","publisher":"Stackable GmbH"}}} * .[0]' sbom.json > sbom.merged.json;
             # Attest the SBOM to the image
             cosign attest -y --predicate sbom.merged.json --type cyclonedx "$IMAGE_NAME@$DIGEST"

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -102,7 +102,7 @@ jobs:
 
             # Generate SBOM for the image
             syft scan --output cyclonedx-json=sbom.json --select-catalogers "-cargo-auditable-binary-cataloger" --scope all-layers --source-name "${{ matrix.product }}" --source-version "$TAG_NAME" "$IMAGE_NAME@$DIGEST";
-            # Determine the PURL for the container image
+            # Determine the PURL for the image
             PURL="pkg:docker/sdp/${{ matrix.product }}@$DIGEST?repository_url=oci.stackable.tech";
             # Get metadata from the image
             IMAGE_METADATA_DESCRIPTION=$(docker inspect --format='{{.Config.Labels.description}}' "$IMAGE_NAME@$DIGEST");

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feat/generate-sboms
 
 jobs:
   development:
@@ -18,20 +19,6 @@ jobs:
       matrix:
         product:
           - airflow
-          - druid
-          - hadoop
-          - hbase
-          - hive
-          - kafka
-          - krb5
-          - nifi
-          - opa
-          - spark-k8s
-          - superset
-          - testing-tools
-          - trino
-          - tools
-          - zookeeper
         shard_count:
           - 5
         shard_index: [0, 1, 2, 3, 4] # between 0 and shard_count-1
@@ -97,4 +84,16 @@ jobs:
             # This generates a signature and publishes it to the registry, next to the image
             # Uses the keyless signing flow with Github Actions as identity provider
             cosign sign -y "$IMAGE_NAME@$DIGEST"
+
+            # Generate SBOM for the image
+            syft scan --output cyclonedx-json=sbom.json --select-catalogers "-cargo-auditable-binary-cataloger" --scope all-layers --source-name "${{ matrix.product }}" --source-version "$TAG_NAME" "$IMAGE_NAME@$DIGEST";
+            # Determine the PURL for the container image
+            PURL="pkg:docker/sdp/${{ matrix.product }}@$DIGEST?repository_url=oci.stackable.tech";
+            # Get metadata from the image
+            IMAGE_METADATA_DESCRIPTION=$(docker inspect --format='{{.Config.Labels.description}}' "$IMAGE_NAME@$DIGEST");
+            IMAGE_METADATA_NAME=$(docker inspect --format='{{.Config.Labels.name}}' "$IMAGE_NAME@$DIGEST");
+            # Merge the SBOM with the metadata for the operator
+            jq -s '{"metadata":{"component":{"description":"'"$IMAGE_METADATA_NAME. $IMAGE_METADATA_DESCRIPTION"'","supplier":{"name":"Stackable GmbH","url":["https://stackable.tech/"]},"author":"Stackable GmbH","purl":"'"$PURL"'","publisher":"Stackable GmbH"}}} * .[0]' sbom.json > sbom.merged.json;
+            # Attest the SBOM to the image
+            cosign attest -y --predicate sbom.merged.json --type cyclonedx "$IMAGE_NAME@$DIGEST"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
           python-version: '3.x'
       - name: Set up Cosign
         uses: sigstore/cosign-installer@9614fae9e5c5eddabb09f90a270fcb487c9f7149 # tag=v3.3.0
+      - name: Set up syft
+        uses: anchore/sbom-action/download-syft@24b0d5238516480139aa8bc6f92eeb7b54a9eb0a # tag=v0.15.5
       - name: Install image-tools-stackabletech
         run: pip install image-tools-stackabletech==0.0.5
       - uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # tag=v3.0.0
@@ -104,4 +106,16 @@ jobs:
             # This generates a signature and publishes it to the registry, next to the image
             # Uses the keyless signing flow with Github Actions as identity provider
             cosign sign -y "$IMAGE_NAME@$DIGEST"
+
+            # Generate SBOM for the image
+            syft scan --output cyclonedx-json=sbom.json --select-catalogers "-cargo-auditable-binary-cataloger" --scope all-layers --source-name "${{ matrix.product }}" --source-version "$TAG_NAME" "$IMAGE_NAME@$DIGEST";
+            # Determine the PURL for the container image
+            PURL="pkg:docker/sdp/${{ matrix.product }}@$DIGEST?repository_url=oci.stackable.tech";
+            # Get metadata from the image
+            IMAGE_METADATA_DESCRIPTION=$(docker inspect --format='{{.Config.Labels.description}}' "$IMAGE_NAME@$DIGEST");
+            IMAGE_METADATA_NAME=$(docker inspect --format='{{.Config.Labels.name}}' "$IMAGE_NAME@$DIGEST");
+            # Merge the SBOM with the metadata for the operator
+            jq -s '{"metadata":{"component":{"description":"'"$IMAGE_METADATA_NAME. $IMAGE_METADATA_DESCRIPTION"'","supplier":{"name":"Stackable GmbH","url":["https://stackable.tech/"]},"author":"Stackable GmbH","purl":"'"$PURL"'","publisher":"Stackable GmbH"}}} * .[0]' sbom.json > sbom.merged.json;
+            # Attest the SBOM to the image
+            cosign attest -y --predicate sbom.merged.json --type cyclonedx "$IMAGE_NAME@$DIGEST"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
 
             # Generate SBOM for the image
             syft scan --output cyclonedx-json=sbom.json --select-catalogers "-cargo-auditable-binary-cataloger" --scope all-layers --source-name "${{ matrix.product }}" --source-version "$TAG_NAME" "$IMAGE_NAME@$DIGEST";
-            # Determine the PURL for the container image
+            # Determine the PURL for the image
             PURL="pkg:docker/sdp/${{ matrix.product }}@$DIGEST?repository_url=oci.stackable.tech";
             # Get metadata from the image
             IMAGE_METADATA_DESCRIPTION=$(docker inspect --format='{{.Config.Labels.description}}' "$IMAGE_NAME@$DIGEST");

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
             # Get metadata from the image
             IMAGE_METADATA_DESCRIPTION=$(docker inspect --format='{{.Config.Labels.description}}' "$IMAGE_NAME@$DIGEST");
             IMAGE_METADATA_NAME=$(docker inspect --format='{{.Config.Labels.name}}' "$IMAGE_NAME@$DIGEST");
-            # Merge the SBOM with the metadata for the operator
+            # Merge the SBOM with the metadata for the image
             jq -s '{"metadata":{"component":{"description":"'"$IMAGE_METADATA_NAME. $IMAGE_METADATA_DESCRIPTION"'","supplier":{"name":"Stackable GmbH","url":["https://stackable.tech/"]},"author":"Stackable GmbH","purl":"'"$PURL"'","publisher":"Stackable GmbH"}}} * .[0]' sbom.json > sbom.merged.json;
             # Attest the SBOM to the image
             cosign attest -y --predicate sbom.merged.json --type cyclonedx "$IMAGE_NAME@$DIGEST"


### PR DESCRIPTION
# Description

First version of SBOM generation, for now we'll simply generate an SBOM by scanning the built image with [syft](https://github.com/anchore/syft).

Fixes https://github.com/stackabletech/issues/issues/512
For further explanation and next steps, please check out [this comment](https://github.com/stackabletech/issues/issues/512#issuecomment-1927621802).

I attached two example SBOMs for Druid and Superset.
 
```[tasklist]
- [x] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] All packages should have (if available) signatures/hashes verified
- [x] Does your change affect an SBOM? Make sure to update all SBOMs
```
[druid.sbom.json](https://github.com/stackabletech/docker-images/files/14169604/druid.sbom.json)
[superset.sbom.json](https://github.com/stackabletech/docker-images/files/14169606/superset.sbom.json)
