### PR TITLE
Add trino 438

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to this project will be documented in this file.
 - java-base: Add JDK 21 ([#547]).
 - opa: Add version `0.61.0` ([#538]).
 - trino: Add version `438` ([#547]).
-- vector: Add version `0.35.0` ([#547]).
+- vector: Switch from version `0.33.0` to `0.35.0` ([#547]).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,10 @@ All notable changes to this project will be documented in this file.
 - testing-tools: Add krb5-user library for Kerberos tests ([#531]).
 - testing-tools: Add the Python library Beautiful Soup 4 ([#536]).
 - java-base: Add `openjdk-devel` package for tool such as `jps` or `jmap` ([#537]).
+- java-base: Add JDK 21 ([#547]).
 - opa: Add version `0.61.0` ([#538]).
+- trino: Add version `438` ([#547]).
+- vector: Add version `0.35.0` ([#547]).
 
 ### Changed
 
@@ -34,7 +37,8 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 
-- hadoop: Remove support for version 3.2.2 ([#540]).
+- hadoop: Remove support for version `3.2.2` ([#540]).
+- opa: Remove support for version `0.51.0` ([#547]).
 
 [#493]: https://github.com/stackabletech/docker-images/pull/493
 [#506]: https://github.com/stackabletech/docker-images/pull/506
@@ -51,6 +55,7 @@ All notable changes to this project will be documented in this file.
 [#540]: https://github.com/stackabletech/docker-images/pull/540
 [#542]: https://github.com/stackabletech/docker-images/pull/542
 [#544]: https://github.com/stackabletech/docker-images/pull/544
+[#547]: https://github.com/stackabletech/docker-images/pull/547
 
 ## [23.11.0] - 2023-11-30
 

--- a/conf.py
+++ b/conf.py
@@ -142,11 +142,15 @@ products = [
         "versions": [
             {
                 "product": "11",
-                "vector": "0.33.0",
+                "vector": "0.35.0",
             },
             {
                 "product": "17",
-                "vector": "0.33.0",
+                "vector": "0.35.0",
+            },
+            {
+                "product": "21",
+                "vector": "0.35.0",
             },
         ],
     },
@@ -203,7 +207,7 @@ products = [
         "name": "vector",
         "versions": [
             {
-                "product": "0.33.0",
+                "product": "0.35.0",
                 "rpm_release": "1",
                 "stackable-base": "1.0.0"
             }
@@ -230,20 +234,13 @@ products = [
         "name": "opa",
         "versions": [
             {
-                "product": "0.51.0",
-                "vector": "0.33.0",
-                "bundle_builder_version": "1.1.0",
-            },
-            {
                 "product": "0.57.0",
-                "vector": "0.33.0",
+                "vector": "0.35.0",
                 "bundle_builder_version": "1.1.0",
             },
-            # 2024-01-30: We only added 0.61.0 to be able to write Rego rules v1.
-            # The regular product version update process must take care of removing unsupported versions and bumping vector
             {
                 "product": "0.61.0",
-                "vector": "0.33.0",
+                "vector": "0.35.0",
                 "bundle_builder_version": "1.1.0",
             },
         ],
@@ -351,8 +348,27 @@ products = [
     {
         "name": "trino",
         "versions": [
-            {"product": "414", "java-base": "17", "opa_authorizer": "stackable0.2.0", "jmx_exporter": "0.20.0", "storage_connector": "414"},
-            {"product": "428", "java-base": "17", "opa_authorizer": "stackable0.3.0", "jmx_exporter": "0.20.0", "storage_connector": "428-jackson"},
+            {
+                "product": "414",
+                "java-base": "17",
+                "opa_authorizer": "stackable0.2.0", 
+                "jmx_exporter": "0.20.0", 
+                "storage_connector": "414"
+            },
+            {
+                "product": "428",
+                "java-base": "17",
+                "opa_authorizer": "stackable0.3.0",
+                "jmx_exporter": "0.20.0",
+                "storage_connector": "428-jackson"
+            },
+            {
+                # OPA authorizer included
+                "product": "438",
+                "java-base": "21",
+                "jmx_exporter": "0.20.0",
+                "storage_connector": "438"
+            },
         ],
     },
     {

--- a/trino/Dockerfile
+++ b/trino/Dockerfile
@@ -2,6 +2,8 @@
 FROM stackable/image/java-base
 
 ARG PRODUCT
+# External OPA authorizer only required for 414 and 428, included in 438
+# The `OPA_AUTHORIZER` is not set in the conf.py for version 438 to remove the ARG as soon as 414 and 428 are removed
 ARG OPA_AUTHORIZER
 ARG JMX_EXPORTER
 ARG RELEASE
@@ -37,8 +39,7 @@ RUN curl --fail https://repo.stackable.tech/repository/packages/jmx-exporter/jmx
     chmod +x /stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar && \
     ln -s /stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar /stackable/jmx/jmx_prometheus_javaagent.jar
 
-# External OPA authorizer only required for 414 and 428, included in 438
-# The `OPA_AUTHORIZER` is not set in the conf.py for version 438 to remove the ARG as soon as 414 and 428 are removed
+# TODO: remove the following RUN statement once Trino versions 414 and 428 are removed
 RUN if [[ -n ${OPA_AUTHORIZER} ]] ; then \
         curl --fail -L https://repo.stackable.tech/repository/packages/trino-opa-authorizer/trino-opa-authorizer-${PRODUCT}-${OPA_AUTHORIZER}.tar.gz | tar -xzC /stackable/trino-server/plugin ; \
     fi

--- a/trino/Dockerfile
+++ b/trino/Dockerfile
@@ -37,7 +37,11 @@ RUN curl --fail https://repo.stackable.tech/repository/packages/jmx-exporter/jmx
     chmod +x /stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar && \
     ln -s /stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar /stackable/jmx/jmx_prometheus_javaagent.jar
 
-RUN curl --fail -L https://repo.stackable.tech/repository/packages/trino-opa-authorizer/trino-opa-authorizer-${PRODUCT}-${OPA_AUTHORIZER}.tar.gz | tar -xzC /stackable/trino-server/plugin
+# External OPA authorizer only required for 414 and 428, included in 438
+# The `OPA_AUTHORIZER` is not set in the conf.py for version 438 to remove the ARG as soon as 414 and 428 are removed
+RUN if [[ -n ${OPA_AUTHORIZER} ]] ; then \
+        curl --fail -L https://repo.stackable.tech/repository/packages/trino-opa-authorizer/trino-opa-authorizer-${PRODUCT}-${OPA_AUTHORIZER}.tar.gz | tar -xzC /stackable/trino-server/plugin ; \
+    fi
 
 RUN curl --fail https://repo.stackable.tech/repository/packages/trino-storage/trino-storage-${STORAGE_CONNECTOR}.zip -o /tmp/trino-storage-${STORAGE_CONNECTOR}.zip && \
     unzip /tmp/trino-storage-${STORAGE_CONNECTOR}.zip -d /stackable/trino-server/plugin && \


### PR DESCRIPTION
# Description

- Added trino 438. This requires a conditional statement to not download the extra OPA authorizer for this version.
- Removed OPA 0.51.0
- Add java-base 21
- Add vector 0.35.0

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Does your change affect an SBOM? Make sure to update all SBOMs
```
