### PR TITLE
fix missing vector bumps to 0.35.0

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -14,7 +14,7 @@ products = [
                 "python": "39",
                 "statsd_exporter": "v0.24.0",
                 "tini": "0.19.0",
-                "vector": "0.33.0",
+                "vector": "0.35.0",
             },
             {
                 "product": "2.6.3",
@@ -22,7 +22,7 @@ products = [
                 "python": "39",
                 "statsd_exporter": "v0.24.0",
                 "tini": "0.19.0",
-                "vector": "0.33.0",
+                "vector": "0.35.0",
             },
             {
                 "product": "2.7.2",
@@ -30,7 +30,7 @@ products = [
                 "python": "39",
                 "statsd_exporter": "v0.24.0",
                 "tini": "0.19.0",
-                "vector": "0.33.0",
+                "vector": "0.35.0",
             },
         ],
     },
@@ -261,7 +261,7 @@ products = [
                 "jackson_dataformat_xml": "2.14.2",
                 "stax2_api": "4.2.1",
                 "woodstox_core": "6.5.0",
-                "vector": "0.33.0",
+                "vector": "0.35.0",
                 "jmx_exporter": "0.20.0",
             },
             # required for a customer
@@ -278,7 +278,7 @@ products = [
                 "jackson_dataformat_xml": "2.14.2",  # https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.13/3.4.0
                 "stax2_api": "4.2.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.14.2
                 "woodstox_core": "6.5.0",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.14.2
-                "vector": "0.33.0",
+                "vector": "0.35.0",
                 "jmx_exporter": "0.20.0",
             },
             {
@@ -294,7 +294,7 @@ products = [
                 "jackson_dataformat_xml": "2.14.2",  # https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.13/3.4.0
                 "stax2_api": "4.2.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.14.2
                 "woodstox_core": "6.5.0",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.14.2
-                "vector": "0.33.0",
+                "vector": "0.35.0",
                 "jmx_exporter": "0.20.0",
             },
             {
@@ -310,7 +310,7 @@ products = [
                 "jackson_dataformat_xml": "2.15.2",  # https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.13/3.5.0
                 "stax2_api": "4.2.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.2
                 "woodstox_core": "6.5.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.2
-                "vector": "0.33.0",
+                "vector": "0.35.0",
                 "jmx_exporter": "0.20.0",
             },
         ],
@@ -325,21 +325,21 @@ products = [
             {
                 "product": "2.1.0",
                 "python": "3.9",
-                "vector": "0.33.0",
+                "vector": "0.35.0",
                 "statsd_exporter": "v0.24.0",
                 "authlib": "0.15.4"  # https://github.com/dpgaspar/Flask-AppBuilder/blob/v4.3.0/requirements-extra.txt#L10
             },
             {
                 "product": "2.1.1",
                 "python": "3.9",
-                "vector": "0.33.0",
+                "vector": "0.35.0",
                 "statsd_exporter": "v0.24.0",
                 "authlib": "0.15.4"  # https://github.com/dpgaspar/Flask-AppBuilder/blob/v4.3.0/requirements-extra.txt#L10
             },
             {
                 "product": "3.0.1",
                 "python": "3.9",
-                "vector": "0.33.0",
+                "vector": "0.35.0",
                 "statsd_exporter": "v0.24.0",
                 "authlib": "0.15.4"  # https://github.com/dpgaspar/Flask-AppBuilder/blob/v4.3.6/requirements-extra.txt#L7
             },


### PR DESCRIPTION
# Description

Bumping vector for dockerfiles airflow, superset and spark-k8s.

Either we bump them or we keep supporting `vector-0.33.0`

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Does your change affect an SBOM? Make sure to update all SBOMs
```
