### PR TITLE
hadoop: upgrade topology provider to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to this project will be documented in this file.
 - inotify-tools: Download from Nexus instead of using the EPEL 8 repository ([#549]).
 - hadoop: Add patches to fix missing operationType for some operations in authorizer ([#555], [#564]).
 - airflow: bump git-sync to `4.2.1` ([#562]).
+- hdfs: bump topology-provider to `0.2.0` ([#565]).
 
 ### Removed
 
@@ -86,6 +87,7 @@ All notable changes to this project will be documented in this file.
 [#562]: https://github.com/stackabletech/docker-images/pull/562
 [#563]: https://github.com/stackabletech/docker-images/pull/563
 [#564]: https://github.com/stackabletech/docker-images/pull/564
+[#565]: https://github.com/stackabletech/docker-images/pull/565
 
 ## [23.11.0] - 2023-11-30
 

--- a/conf.py
+++ b/conf.py
@@ -84,7 +84,7 @@ products = [
                 "async_profiler": "2.9",
                 "jmx_exporter": "0.20.0",
                 "protobuf": "2.5.0",
-                "topology_provider": "0.1.0"
+                "topology_provider": "0.2.0"
             },
             {
                 "product": "3.3.4",
@@ -92,7 +92,7 @@ products = [
                 "async_profiler": "2.9",
                 "jmx_exporter": "0.20.0",
                 "protobuf": "3.7.1",
-                "topology_provider": "0.1.0"
+                "topology_provider": "0.2.0"
             },
             {
                 "product": "3.3.6",
@@ -100,7 +100,7 @@ products = [
                 "async_profiler": "2.9",
                 "jmx_exporter": "0.20.0",
                 "protobuf": "3.7.1",
-                "topology_provider": "0.1.0"
+                "topology_provider": "0.2.0"
             },
         ],
     },

--- a/hadoop/Dockerfile
+++ b/hadoop/Dockerfile
@@ -137,7 +137,8 @@ COPY --chown=stackable:stackable --from=builder /stackable/async-profiler /stack
 # The topology provider provides rack awareness functionality for HDFS by allowing users to specify Kubernetes
 # labels to build a rackID from
 # source code is at: https://github.com/stackabletech/hdfs-topology-provider
-RUN curl --fail -L -s -S https://repo.stackable.tech/repository/packages/hdfs-topology-provider/topology-provider-${TOPOLOGY_PROVIDER}.jar -o /stackable/hadoop-${PRODUCT}/share/hadoop/tools/lib/topology-provider-${TOPOLOGY_PROVIDER}.jar
+# N.B. the artifact name changed from 0.2.0 onwards i.e. from topology-provider-0.1.0.jar to hdfs-topology-provider-0.2.0.jar
+RUN curl --fail -L -s -S https://repo.stackable.tech/repository/packages/hdfs-topology-provider/hdfs-topology-provider-${TOPOLOGY_PROVIDER}.jar -o /stackable/hadoop-${PRODUCT}/share/hadoop/tools/lib/hdfs-topology-provider-${TOPOLOGY_PROVIDER}.jar
 
 RUN ln -s /stackable/hadoop-${PRODUCT} /stackable/hadoop
 COPY hadoop/stackable/fuse_dfs_wrapper /stackable/hadoop/bin


### PR DESCRIPTION
# Description

hadoop: upgrade topology provider to 0.2.0
Part of https://github.com/stackabletech/hdfs-operator/issues/325


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Does your change affect an SBOM? Make sure to update all SBOMs
```
