### PR TITLE
Remove hbase 2.4.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to this project will be documented in this file.
 
 - airflow: Remove support for `2.6.1` ([#562]).
 - hadoop: Remove support for version `3.2.2` ([#540]).
+- hbase: Remove support for version `2.4.12` ([#567]).
 - kafka: Remove support for version `2.8.2`, `3.4.0`, `3.5.1` ([#559]).
 - opa: Remove support for version `0.51.0` ([#547]).
 - spark: Remove support for version `3.4.0`, `3.4.0-java17` ([#560]).
@@ -88,6 +89,7 @@ All notable changes to this project will be documented in this file.
 [#563]: https://github.com/stackabletech/docker-images/pull/563
 [#564]: https://github.com/stackabletech/docker-images/pull/564
 [#565]: https://github.com/stackabletech/docker-images/pull/565
+[#567]: https://github.com/stackabletech/docker-images/pull/567
 
 ## [23.11.0] - 2023-11-30
 

--- a/conf.py
+++ b/conf.py
@@ -112,18 +112,8 @@ products = [
         # Also do not merge java-base with java below as "JAVA-BASE is not a valid identifier" in Dockerfiles, it's unfortunate but to fix this would require a bigger refactoring of names or the image tools
         # hbase-thirdparty is used to build the hbase-operator-tools and should be set to the version defined in the POM of HBase.
              {
-                 "product": "2.4.12",
-                 "hbase_thirdparty": "3.5.1",
-                 "hbase_operator_tools": "1.2.0",
-                 "java-base": "11",
-                 "async_profiler": "2.9",
-                 "phoenix": "2.4-5.1.2",
-                 "hadoop_m2": "3.3.6",
-                 "jmx_exporter": "0.20.0",
-             },
-             {
                  "product": "2.4.17",
-                 "hbase_thirdparty": "4.1.4",
+                 "hbase_thirdparty": "4.1.5",
                  "hbase_operator_tools": "1.2.0",
                  "java-base": "11",
                  "async_profiler": "2.9",


### PR DESCRIPTION
# Description

- remove hbase version 2.4.12
- bump hbase_thirdparty (4.1.4 -> 4.1.5)


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Does your change affect an SBOM? Make sure to update all SBOMs
```
