### PR TITLE
Remove hadoop version 3.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ All notable changes to this project will be documented in this file.
 ### Removed
 
 - airflow: Remove support for `2.6.1` ([#562]).
-- hadoop: Remove support for version `3.2.2` and `3.2.4` (this ends the `3.2` line) ([#540], [#XXX]).
+- hadoop: Remove support for version `3.2.2` and `3.2.4` (this ends the `3.2` line) ([#540], [#571]).
 - hbase: Remove support for version `2.4.12` ([#567]).
 - kafka: Remove support for version `2.8.2`, `3.4.0`, `3.5.1` ([#559]).
 - opa: Remove support for version `0.51.0` ([#547]).
@@ -95,6 +95,7 @@ All notable changes to this project will be documented in this file.
 [#566]: https://github.com/stackabletech/docker-images/pull/566
 [#567]: https://github.com/stackabletech/docker-images/pull/567
 [#570]: https://github.com/stackabletech/docker-images/pull/570
+[#571]: https://github.com/stackabletech/docker-images/pull/571
 
 ## [23.11.0] - 2023-11-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ All notable changes to this project will be documented in this file.
 ### Removed
 
 - airflow: Remove support for `2.6.1` ([#562]).
-- hadoop: Remove support for version `3.2.2` ([#540]).
+- hadoop: Remove support for version `3.2.2` and `3.2.4` (this ends the `3.2` line) ([#540], [#XXX]).
 - hbase: Remove support for version `2.4.12` ([#567]).
 - kafka: Remove support for version `2.8.2`, `3.4.0`, `3.5.1` ([#559]).
 - opa: Remove support for version `0.51.0` ([#547]).

--- a/conf.py
+++ b/conf.py
@@ -79,15 +79,6 @@ products = [
         "name": "hadoop",
         "versions": [
             {
-                "product": "3.2.4",
-                "java-base": "11",
-                "async_profiler": "2.9",
-                "jmx_exporter": "0.20.0",
-                "protobuf": "2.5.0",
-                # no HDFS utils, as e.g. patches from https://github.com/apache/hadoop/pull/6553 are missing. 3.2.x will probably removed in version 24.3 anyway.
-                "topology_provider": "0.2.0"
-            },
-            {
                 "product": "3.3.4",
                 "java-base": "11",
                 "async_profiler": "2.9",

--- a/hadoop/Dockerfile
+++ b/hadoop/Dockerfile
@@ -134,6 +134,7 @@ WORKDIR /stackable
 COPY --chown=stackable:stackable --from=builder /stackable/hadoop-${PRODUCT} /stackable/hadoop-${PRODUCT}/
 COPY --chown=stackable:stackable --from=builder /stackable/jmx /stackable/jmx/
 COPY --chown=stackable:stackable --from=builder /stackable/async-profiler /stackable/async-profiler/
+RUN ln -s /stackable/hadoop-${PRODUCT} /stackable/hadoop
 
 # The topology provider provides rack awareness functionality for HDFS by allowing users to specify Kubernetes
 # labels to build a rackID from
@@ -144,7 +145,6 @@ RUN curl --fail -L -s -S https://repo.stackable.tech/repository/packages/hdfs-to
 # The Stackable HDFS utils contain an OPA authorizer and group mapper
 RUN curl --fail -L -s -S https://repo.stackable.tech/repository/packages/hdfs-utils/hdfs-utils-${HDFS_UTILS}.jar -o /stackable/hadoop/share/hadoop/common/lib/hdfs-utils-${HDFS_UTILS}.jar
 
-RUN ln -s /stackable/hadoop-${PRODUCT} /stackable/hadoop
 COPY hadoop/stackable/fuse_dfs_wrapper /stackable/hadoop/bin
 
 ENV HOME=/stackable

--- a/hadoop/Dockerfile
+++ b/hadoop/Dockerfile
@@ -142,9 +142,7 @@ COPY --chown=stackable:stackable --from=builder /stackable/async-profiler /stack
 RUN curl --fail -L -s -S https://repo.stackable.tech/repository/packages/hdfs-topology-provider/hdfs-topology-provider-${TOPOLOGY_PROVIDER}.jar -o /stackable/hadoop/share/hadoop/common/lib/hdfs-topology-provider-${TOPOLOGY_PROVIDER}.jar
 
 # The Stackable HDFS utils contain an OPA authorizer and group mapper
-RUN if [[ -n "${HDFS_UTILS}" ]] ; then \
-        curl --fail -L -s -S https://repo.stackable.tech/repository/packages/hdfs-utils/hdfs-utils-${HDFS_UTILS}.jar -o /stackable/hadoop/share/hadoop/common/lib/hdfs-utils-${HDFS_UTILS}.jar ; \
-    fi
+RUN curl --fail -L -s -S https://repo.stackable.tech/repository/packages/hdfs-utils/hdfs-utils-${HDFS_UTILS}.jar -o /stackable/hadoop/share/hadoop/common/lib/hdfs-utils-${HDFS_UTILS}.jar
 
 RUN ln -s /stackable/hadoop-${PRODUCT} /stackable/hadoop
 COPY hadoop/stackable/fuse_dfs_wrapper /stackable/hadoop/bin


### PR DESCRIPTION
# Description

As decided on [Slack](https://stackable-workspace.slack.com/archives/C031A56R127/p1708412435743889). This ends the 3.2 release line

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Does your change affect an SBOM? Make sure to update all SBOMs
```
