### PR TITLE
hdfs: bump hdfs-topology-provider to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ All notable changes to this project will be documented in this file.
 - hdfs: bump topology-provider to `0.2.0` ([#565]).
 - java-base: Add `krb5-workstation` for all Java based products, as it is used by at least Zookeeper (in the future),
   HDFS, HBase, Trino, Spark, Druid ([#572]).
+- hdfs: bump topology-provider to `0.3.0` ([#579]).
 
 ### Removed
 
@@ -103,6 +104,7 @@ All notable changes to this project will be documented in this file.
 [#572]: https://github.com/stackabletech/docker-images/pull/572
 [#575]: https://github.com/stackabletech/docker-images/pull/575
 [#576]: https://github.com/stackabletech/docker-images/pull/576
+[#579]: https://github.com/stackabletech/docker-images/pull/579
 
 ## [23.11.0] - 2023-11-30
 

--- a/conf.py
+++ b/conf.py
@@ -85,7 +85,7 @@ products = [
                 "jmx_exporter": "0.20.0",
                 "protobuf": "3.7.1",
                 "hdfs_utils": "0.2.1",
-                "topology_provider": "0.2.0"
+                "topology_provider": "0.3.0"
             },
             {
                 "product": "3.3.6",
@@ -94,7 +94,7 @@ products = [
                 "jmx_exporter": "0.20.0",
                 "protobuf": "3.7.1",
                 "hdfs_utils": "0.2.1",
-                "topology_provider": "0.2.0"
+                "topology_provider": "0.3.0"
             },
         ],
     },


### PR DESCRIPTION
# Description

bump hdfs-topology-provider to 0.3.0


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Does your change affect an SBOM? Make sure to update all SBOMs
```
