### PR TITLE
Setting opa authorizer to

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -399,7 +399,9 @@ products = [
                 "product": "442",
                 "java-base": "21",
                 "jmx_exporter": "0.20.0",
-                "storage_connector": "442"
+                "storage_connector": "442",
+                "opa_authorizer": "",
+
             },
         ],
     },


### PR DESCRIPTION
# Description

Currently Trino 442 can't be build locally since it fails with

```
> [trino-442  7/16] RUN if [[ -n ${OPA_AUTHORIZER} ]] ; then         curl --fail -L [https://repo.stackable.tech/repository/packages/trino-opa-authorizer/trino-opa-authorizer-442-${OPA_AUTHORIZER}.tar.gz](https://repo.stackable.tech/repository/packages/trino-opa-authorizer/trino-opa-authorizer-442-$%7BOPA_AUTHORIZER%7D.tar.gz) | tar -xzC /stackable/trino-server/plugin ;     fi:
0.085 /bin/bash: OPA_AUTHORIZER: unbound variable
------
Dockerfile:44
--------------------
  43 |     # TODO: remove the following RUN statement once Trino versions 414 and 428 are removed
  44 | >>> RUN if [[ -n ${OPA_AUTHORIZER} ]] ; then \
  45 | >>>         curl --fail -L [https://repo.stackable.tech/repository/packages/trino-opa-authorizer/trino-opa-authorizer-${PRODUCT}-${OPA_AUTHORIZER}.tar.gz](https://repo.stackable.tech/repository/packages/trino-opa-authorizer/trino-opa-authorizer-$%7BPRODUCT%7D-$%7BOPA_AUTHORIZER%7D.tar.gz) | tar -xzC /stackable/trino-server/plugin ; \
  46 | >>>     fi
  47 |     
--------------------
```

This was due to `opa_authorizer` not being set in `conf.py`.

This fix sets it to ""