### PR TITLE
fix(arm): Let Superset 3.1.0 build on ARM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Let Superset 3.1.0 build on ARM by adding `make` and `diffutils` ([#540]).
+
+[#540]: https://github.com/stackabletech/docker-images/pull/540
+
+## [24.3.0] - 2024-03-20
+
 ### Added
 
 - omid: init at 1.1.0 ([#493]).

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -32,8 +32,9 @@ RUN microdnf update \
         python${PYTHON//./}-pip \
         python${PYTHON//./}-wheel \
         libpq-devel \
-    && microdnf clean all \
-    && python3 -m venv /stackable/app \
+    && microdnf clean all
+
+RUN python3 -m venv /stackable/app \
     && source /stackable/app/bin/activate \
     && pip install \
         --no-cache-dir \

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -22,6 +22,13 @@ RUN microdnf update \
         cyrus-sasl-devel \
         # Needed to find all patch files, used in `apply_patches.sh`
         findutils \
+        # Needed by ./configure to work out SQLite compilation flags, see snippet [1] at the end of file
+        diffutils \
+        # According to https://stackoverflow.com/q/19530974 normally sqlite3 should be shipped with the Python
+        # distribution. However, while addig ARM support we noticed that this does not seem to be the case for the
+        # Python installation shipped in the ARM image variant. So I guess Make is used to find out the sqlite
+        # compilation flags (and propably to not build sqlite from source(?)), see snippet [1] at the end of file
+        make \
         gcc \
         gcc-c++ \
         libffi-devel \
@@ -120,3 +127,30 @@ CMD ["/bin/sh", "-c", \
     --limit-request-line 0 \
     --limit-request-field_size 0 \
     'superset.app:create_app()'"]
+
+# SNIPPET 1
+# 60.38   × Getting requirements to build wheel did not run successfully.
+# 60.38   │ exit code: 1
+# 60.38   ╰─> [77 lines of output]
+# 60.38       running egg_info
+# 60.38       writing apsw.egg-info/PKG-INFO
+# 60.38       writing dependency_links to apsw.egg-info/dependency_links.txt
+# 60.38       writing top-level names to apsw.egg-info/top_level.txt
+# 60.38         Getting the SQLite amalgamation
+# 60.38           Fetching https://sqlite.org/2023/sqlite-autoconf-3420000.tar.gz
+# 60.38           Length: 3148813  SHA1: 036575929b174c1b829769255491ba2b32bda9ee  MD5: 0c5a92bc51cf07cae45b4a1e94653dea
+# 60.38           Checksums verified
+# 60.38       /usr/lib64/python3.9/tarfile.py:2239: RuntimeWarning: The default behavior of tarfile extraction has been changed to disallow common exploits (including CVE-2007-4559). By default, absolute/parent paths are disallowed and some mode bits are cleared. See https://access.redhat.com/articles/7004769 for more details.
+# 60.38         warnings.warn(
+# 60.38           Running configure to work out SQLite compilation flags
+# 60.38       ./configure: line 8084: cmp: command not found
+# 60.38       ./configure: line 8084: cmp: command not found
+# 60.38       ./configure: line 9847: diff: command not found
+# 60.38       config.status: error: in `/tmp/pip-install-eu6p7tvi/apsw_df5f74a30ca84a5c90de5ea3a0691bec/sqlite3':
+# 60.38       config.status: error: Something went wrong bootstrapping makefile fragments
+# 60.38           for automatic dependency tracking.  If GNU make was not used, consider
+# 60.38           re-running the configure script with MAKE="gmake" (or whatever is
+# 60.38           necessary).  You can also try re-running configure with the
+# 60.38           '--disable-dependency-tracking' option to at least be able to build
+# 60.38           the package (albeit without support for automatic dependency tracking).
+# 60.38       See `config.log' for more details


### PR DESCRIPTION
# Description

Now all Superset versions build on the Ampere server :rocket: 

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [x] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] All packages should have (if available) signatures/hashes verified
- [x] Does your change affect an SBOM? Make sure to update all SBOMs
- [x] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
