### PR TITLE
fix(arm): Let Airflow 2.8.x and 2.9.x build on ARM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Let Airflow 2.8.x and 2.9.x build on ARM by adding `make` and `diffutils` ([#XXX]).
+
+## [24.3.0] - 2024-03-20
+
 ### Added
 
 - omid: init at 1.1.0 ([#493]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Let Airflow 2.8.x and 2.9.x build on ARM by adding `make` and `diffutils` ([#XXX]).
+- Let Airflow 2.8.x and 2.9.x build on ARM by adding `make` and `diffutils` ([#612]).
+
+[#612]: https://github.com/stackabletech/docker-images/pull/612
 
 ## [24.3.0] - 2024-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Let Superset 3.1.0 build on ARM by adding `make` and `diffutils` ([#611]).
 - Let Airflow 2.8.x and 2.9.x build on ARM by adding `make` and `diffutils` ([#612]).
 
+[#611]: https://github.com/stackabletech/docker-images/pull/611
 [#612]: https://github.com/stackabletech/docker-images/pull/612
 
 ## [24.3.0] - 2024-03-20

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -28,6 +28,10 @@ RUN microdnf update && \
         # Used to extract statsd_exporter
         tar \
         cyrus-sasl-devel \
+        # Needed by ./configure to build gevent, see snippet [1] at the end of file
+        diffutils \
+        # Needed to build gevent, see snippet [1] at the end of file
+        make \
         gcc \
         gcc-c++ \
         libpq-devel \
@@ -117,3 +121,14 @@ WORKDIR /stackable
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/run-airflow.sh"]
 CMD []
+
+# SNIPPET 1
+# 137.0       Running '(cd  "/tmp/pip-install-cyuymnu6/gevent_0f8b4d282c464210b62acdf399e4a04c/deps/libev"  && sh ./configure -C > configure-output.txt )' in /tmp/pip-install-cyuymnu6/gevent_0f8b4d282c464210b62acdf399e4a04c
+# 137.0       ./configure: line 6350: cmp: command not found
+# 137.0       ./configure: line 6350: cmp: command not found
+# 137.0       ./configure: line 8279: diff: command not found
+# 137.0       config.status: error: in `/tmp/pip-install-cyuymnu6/gevent_0f8b4d282c464210b62acdf399e4a04c/deps/libev':
+# 137.0       config.status: error: Something went wrong bootstrapping makefile fragments
+# 137.0           for automatic dependency tracking.  Try re-running configure with the
+# 137.0           '--disable-dependency-tracking' option to at least be able to build
+# 137.0           the package (albeit without support for automatic dependency tracking).

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -37,8 +37,9 @@ RUN microdnf update && \
         python${PYTHON}-pip \
         python${PYTHON}-wheel \
         unixODBC-devel && \
-    microdnf clean all && \
-    python3 -m venv --system-site-packages /stackable/app && \
+    microdnf clean all
+
+RUN python3 -m venv --system-site-packages /stackable/app && \
     source /stackable/app/bin/activate && \
     pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir apache-airflow[${AIRFLOW_EXTRAS}]==${PRODUCT} --constraint /tmp/constraints.txt && \


### PR DESCRIPTION
# Description

Now all Airflow versions build on the Ampere server 🚀

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [x] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] All packages should have (if available) signatures/hashes verified
- [x] Does your change affect an SBOM? Make sure to update all SBOMs
- [x] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
