### PR TITLE
fix(hive): Fix build on ARM by back-porting HIVE-21939

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,17 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Let Superset 3.1.0 build on ARM by adding `make` and `diffutils` ([#611]).
-- Let Airflow 2.8.x and 2.9.x build on ARM by adding `make` and `diffutils` ([#612]).
+- superset: Let Superset 3.1.0 build on ARM by adding `make` and `diffutils` ([#611]).
+- airflow: Let Airflow 2.8.x and 2.9.x build on ARM by adding `make` and `diffutils` ([#612]).
 - python:3.11 manifest list fixed. Added proper hash ([#613]).
 - trino-cli: Include the trino-cli in the CI build process ([#614]).
+- hive: Fix compilation on ARM by back-porting [HIVE-21939](https://issues.apache.org/jira/browse/HIVE-21939) from [this](https://github.com/apache/hive/commit/2baf21bb55fcf33d8522444c78a8d8cab60e7415) commit ([#617]).
 
 [#611]: https://github.com/stackabletech/docker-images/pull/611
 [#612]: https://github.com/stackabletech/docker-images/pull/612
 [#613]: https://github.com/stackabletech/docker-images/pull/613
 [#614]: https://github.com/stackabletech/docker-images/pull/614
+[#617]: https://github.com/stackabletech/docker-images/pull/617
 
 ## [24.3.0] - 2024-03-20
 

--- a/hive/stackable/patches/3.1.3/002-HIVE-21939-protoc-2.5.0-dependence-has-broken-buildi.patch
+++ b/hive/stackable/patches/3.1.3/002-HIVE-21939-protoc-2.5.0-dependence-has-broken-buildi.patch
@@ -1,4 +1,4 @@
-From 469951e91d22e06525aa9a3e079cd4d1da538598 Mon Sep 17 00:00:00 2001
+From d0fc55929e2fb00dbd84fb092771bf558dd20f16 Mon Sep 17 00:00:00 2001
 From: Sebastian Bernauer <sebastian.bernauer@stackable.de>
 Date: Thu, 11 Apr 2024 15:41:05 +0200
 Subject: [PATCH] HIVE-21939: protoc:2.5.0 dependence has broken building on
@@ -8,11 +8,11 @@ Cherry-picked from 2baf21bb55fcf33d8522444c78a8d8cab60e7415
 
 Co-authored-by: Chinna Rao L <chinnaraol@apache.org>
 ---
- standalone-metastore/pom.xml | 23 ++++++++++++++++++++---
- 1 file changed, 20 insertions(+), 3 deletions(-)
+ standalone-metastore/pom.xml | 21 +++++++++++++++++++--
+ 1 file changed, 19 insertions(+), 2 deletions(-)
 
 diff --git a/standalone-metastore/pom.xml b/standalone-metastore/pom.xml
-index e36f1e64f0..dd46c1bcc9 100644
+index e36f1e64f0..6007b7961b 100644
 --- a/standalone-metastore/pom.xml
 +++ b/standalone-metastore/pom.xml
 @@ -81,7 +81,10 @@
@@ -27,15 +27,6 @@ index e36f1e64f0..dd46c1bcc9 100644
      <sqlline.version>1.3.0</sqlline.version>
      <storage-api.version>2.7.0</storage-api.version>
  
-@@ -124,7 +127,7 @@
-       <version>${guava.version}</version>
-     </dependency>
-     <dependency>
--      <groupId>com.google.protobuf</groupId>
-+      <groupId>${protobuf.group}</groupId>
-       <artifactId>protobuf-java</artifactId>
-       <version>${protobuf.version}</version>
-     </dependency>
 @@ -443,6 +446,20 @@
          </plugins>
        </build>

--- a/hive/stackable/patches/3.1.3/002-HIVE-21939-protoc-2.5.0-dependence-has-broken-buildi.patch
+++ b/hive/stackable/patches/3.1.3/002-HIVE-21939-protoc-2.5.0-dependence-has-broken-buildi.patch
@@ -1,4 +1,4 @@
-From 3ab66fc0d92bbdf2b96c58af26c9ad6ca31a2b8a Mon Sep 17 00:00:00 2001
+From 469951e91d22e06525aa9a3e079cd4d1da538598 Mon Sep 17 00:00:00 2001
 From: Sebastian Bernauer <sebastian.bernauer@stackable.de>
 Date: Thu, 11 Apr 2024 15:41:05 +0200
 Subject: [PATCH] HIVE-21939: protoc:2.5.0 dependence has broken building on
@@ -8,14 +8,14 @@ Cherry-picked from 2baf21bb55fcf33d8522444c78a8d8cab60e7415
 
 Co-authored-by: Chinna Rao L <chinnaraol@apache.org>
 ---
- standalone-metastore/pom.xml | 21 ++++++++++++++++++---
- 1 file changed, 18 insertions(+), 3 deletions(-)
+ standalone-metastore/pom.xml | 23 ++++++++++++++++++++---
+ 1 file changed, 20 insertions(+), 3 deletions(-)
 
 diff --git a/standalone-metastore/pom.xml b/standalone-metastore/pom.xml
-index e36f1e64f0..726eeba197 100644
+index e36f1e64f0..dd46c1bcc9 100644
 --- a/standalone-metastore/pom.xml
 +++ b/standalone-metastore/pom.xml
-@@ -81,7 +81,9 @@
+@@ -81,7 +81,10 @@
      <log4j2.version>2.17.1</log4j2.version>
      <mockito-all.version>1.10.19</mockito-all.version>
      <orc.version>1.5.1</orc.version>
@@ -23,10 +23,11 @@ index e36f1e64f0..726eeba197 100644
 +    <!-- com.google repo will be used except on Aarch64 platform. -->
 +    <protobuf.group>com.google.protobuf</protobuf.group>
 +    <protobuf.version>2.6.1</protobuf.version>
++    <protobuf-exc.version>2.6.1</protobuf-exc.version>
      <sqlline.version>1.3.0</sqlline.version>
      <storage-api.version>2.7.0</storage-api.version>
  
-@@ -124,7 +126,7 @@
+@@ -124,7 +127,7 @@
        <version>${guava.version}</version>
      </dependency>
      <dependency>
@@ -35,7 +36,7 @@ index e36f1e64f0..726eeba197 100644
        <artifactId>protobuf-java</artifactId>
        <version>${protobuf.version}</version>
      </dependency>
-@@ -443,6 +445,19 @@
+@@ -443,6 +446,20 @@
          </plugins>
        </build>
      </profile>
@@ -44,6 +45,7 @@ index e36f1e64f0..726eeba197 100644
 +      <id>aarch64</id>
 +      <properties>
 +        <protobuf.group>com.github.os72</protobuf.group>
++        <protobuf-exc.version>2.6.1-build3</protobuf-exc.version>
 +      </properties>
 +      <activation>
 +        <os>
@@ -55,12 +57,12 @@ index e36f1e64f0..726eeba197 100644
        <!--
      <profile>
        <id>checkin</id>
-@@ -604,7 +619,7 @@
+@@ -604,7 +621,7 @@
                <goal>run</goal>
              </goals>
              <configuration>
 -              <protocArtifact>com.google.protobuf:protoc:2.5.0</protocArtifact>
-+              <protocArtifact>com.google.protobuf:protoc:2.6.1</protocArtifact>
++              <protocArtifact>${protobuf.group}:protoc:${protobuf-exc.version}</protocArtifact>
                <addSources>none</addSources>
                <inputDirectories>
                  <include>${basedir}/src/main/protobuf/org/apache/hadoop/hive/metastore</include>

--- a/hive/stackable/patches/3.1.3/002-HIVE-21939-protoc-2.5.0-dependence-has-broken-buildi.patch
+++ b/hive/stackable/patches/3.1.3/002-HIVE-21939-protoc-2.5.0-dependence-has-broken-buildi.patch
@@ -1,0 +1,69 @@
+From 3ab66fc0d92bbdf2b96c58af26c9ad6ca31a2b8a Mon Sep 17 00:00:00 2001
+From: Sebastian Bernauer <sebastian.bernauer@stackable.de>
+Date: Thu, 11 Apr 2024 15:41:05 +0200
+Subject: [PATCH] HIVE-21939: protoc:2.5.0 dependence has broken building on
+ aarch64
+
+Cherry-picked from 2baf21bb55fcf33d8522444c78a8d8cab60e7415
+
+Co-authored-by: Chinna Rao L <chinnaraol@apache.org>
+---
+ standalone-metastore/pom.xml | 21 ++++++++++++++++++---
+ 1 file changed, 18 insertions(+), 3 deletions(-)
+
+diff --git a/standalone-metastore/pom.xml b/standalone-metastore/pom.xml
+index e36f1e64f0..726eeba197 100644
+--- a/standalone-metastore/pom.xml
++++ b/standalone-metastore/pom.xml
+@@ -81,7 +81,9 @@
+     <log4j2.version>2.17.1</log4j2.version>
+     <mockito-all.version>1.10.19</mockito-all.version>
+     <orc.version>1.5.1</orc.version>
+-    <protobuf.version>2.5.0</protobuf.version>
++    <!-- com.google repo will be used except on Aarch64 platform. -->
++    <protobuf.group>com.google.protobuf</protobuf.group>
++    <protobuf.version>2.6.1</protobuf.version>
+     <sqlline.version>1.3.0</sqlline.version>
+     <storage-api.version>2.7.0</storage-api.version>
+ 
+@@ -124,7 +126,7 @@
+       <version>${guava.version}</version>
+     </dependency>
+     <dependency>
+-      <groupId>com.google.protobuf</groupId>
++      <groupId>${protobuf.group}</groupId>
+       <artifactId>protobuf-java</artifactId>
+       <version>${protobuf.version}</version>
+     </dependency>
+@@ -443,6 +445,19 @@
+         </plugins>
+       </build>
+     </profile>
++    <!-- use com.github.os72 on aarch64 platform -->
++    <profile>
++      <id>aarch64</id>
++      <properties>
++        <protobuf.group>com.github.os72</protobuf.group>
++      </properties>
++      <activation>
++        <os>
++          <family>linux</family>
++          <arch>aarch64</arch>
++        </os>
++      </activation>
++      </profile>
+       <!--
+     <profile>
+       <id>checkin</id>
+@@ -604,7 +619,7 @@
+               <goal>run</goal>
+             </goals>
+             <configuration>
+-              <protocArtifact>com.google.protobuf:protoc:2.5.0</protocArtifact>
++              <protocArtifact>com.google.protobuf:protoc:2.6.1</protocArtifact>
+               <addSources>none</addSources>
+               <inputDirectories>
+                 <include>${basedir}/src/main/protobuf/org/apache/hadoop/hive/metastore</include>
+-- 
+2.43.0
+


### PR DESCRIPTION
# Description

Cherry-picking https://issues.apache.org/jira/browse/HIVE-21939 from https://github.com/apache/hive/commit/2baf21bb55fcf33d8522444c78a8d8cab60e7415

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [x] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] All packages should have (if available) signatures/hashes verified
- [x] Does your change affect an SBOM? Make sure to update all SBOMs
- [x] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
