### PR TITLE
fix(hive): Fix TLS problems by switching back to Java 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- hive: Only build and ship Hive metastore. This reduces the image size from `2.63GB` to `1.9GB` and should also reduce the number of dependencies ([#619]).
+- hive: Only build and ship Hive metastore. This reduces the image size from `2.63GB` to `1.9GB` and should also reduce the number of dependencies ([#619], [#622]).
 
 ### Fixed
 
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 [#614]: https://github.com/stackabletech/docker-images/pull/614
 [#617]: https://github.com/stackabletech/docker-images/pull/617
 [#619]: https://github.com/stackabletech/docker-images/pull/619
+[#622]: https://github.com/stackabletech/docker-images/pull/622
 
 ## [24.3.0] - 2024-03-20
 

--- a/conf.py
+++ b/conf.py
@@ -140,7 +140,7 @@ products = [
             {
                 "product": "3.1.3",
                 "jmx_exporter": "0.20.0",
-                "java-base": "1.8.0",
+                "java-base": "11",
                 "hadoop": "3.3.4",
                 "jackson_dataformat_xml": "2.12.3",
                 # Normally Hive 3.1.3 ships with "postgresql-9.4.1208.jre7.jar", but as this is old enough it does only support

--- a/hive/Dockerfile
+++ b/hive/Dockerfile
@@ -7,6 +7,17 @@ FROM stackable/image/hadoop AS hadoop-builder
 
 FROM stackable/image/java-base AS builder
 
+# Apache Hive up t0 4.x(!) officially requires Java 8 (there is no distincion between building and running). As of
+# 2024-04-15 we for sure need Java 8 for building, but we used a Java 11 runtime for months now without any problems.
+# As we got weird TLS errors (https://stackable-workspace.slack.com/archives/C031A5BEFS7/p1713185172557459) with a
+# Java 8 runtime we bumped the Runtime to Java 11 again. As we can only select a single version from the java-base
+# image, we pick 11 (which is used in the final image), and install Java 8 here.
+RUN microdnf update && \
+    microdnf remove java-11-openjdk-headless java-11-openjdk-devel java-11-openjdk && \
+    microdnf install java-1.8.0-openjdk-headless java-1.8.0-openjdk-devel --nodocs && \
+    microdnf clean all
+ENV JAVA_HOME=/usr/lib/jvm/jre-1.8.0
+
 ARG PRODUCT
 ARG HADOOP
 ARG JMX_EXPORTER


### PR DESCRIPTION
# Description

Should fix broken tests introduced in https://github.com/stackabletech/docker-images/pull/581

To sum this up for the suits:
* We used to ship the pre-built Hive binary in a container with java 11 runtime and everything worked (this was presumably built on java 8 )
* After building ourselves from source (with java 8 ) we switched the java runtime in the container from 11 to 8 and some weird tls stuff broker
* Switching back to 11 in the container fixes it

The log of the failing TLS access to MinIO is attached

[hive-metastore-default-0.log](https://github.com/stackabletech/docker-images/files/14988211/hive-metastore-default-0.log)

See https://stackable-workspace.slack.com/archives/C031A5BEFS7/p1713185172557459 for details

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [x] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] All packages should have (if available) signatures/hashes verified
- [ ] Does your change affect an SBOM? Make sure to update all SBOMs
- [x] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
