### PR TITLE
chore: Bump protoc to 26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file.
 - hbase: Remove the symlink `/stackable/jmx/jmx_prometheus_javaagent-0.16.1.jar`
   which is unused since SDP 23.11 ([#621]).
 - hive: Only build and ship Hive metastore. This reduces the image size from `2.63GB` to `1.9GB` and should also reduce the number of dependencies ([#619], [#622]).
-- ubi8-rust-builder: Bump `protoc` from `21.5` to `261` ([#624]).
+- ubi8-rust-builder: Bump `protoc` from `21.5` to `26.1` ([#624]).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file.
 - hbase: Remove the symlink `/stackable/jmx/jmx_prometheus_javaagent-0.16.1.jar`
   which is unused since SDP 23.11 ([#621]).
 - hive: Only build and ship Hive metastore. This reduces the image size from `2.63GB` to `1.9GB` and should also reduce the number of dependencies ([#619], [#622]).
-- ubi8-rust-builder: Bump `protoc` from `21.5` to `261` ([#XXX]).
+- ubi8-rust-builder: Bump `protoc` from `21.5` to `261` ([#624]).
 
 ### Fixed
 
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 [#619]: https://github.com/stackabletech/docker-images/pull/619
 [#621]: https://github.com/stackabletech/docker-images/pull/621
 [#622]: https://github.com/stackabletech/docker-images/pull/622
+[#624]: https://github.com/stackabletech/docker-images/pull/624
 
 ## [24.3.0] - 2024-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - hbase: Remove the symlink `/stackable/jmx/jmx_prometheus_javaagent-0.16.1.jar`
   which is unused since SDP 23.11 ([#621]).
 - hive: Only build and ship Hive metastore. This reduces the image size from `2.63GB` to `1.9GB` and should also reduce the number of dependencies ([#619], [#622]).
+- ubi8-rust-builder: Bump `protoc` from `21.5` to `261` ([#XXX]).
 
 ### Fixed
 

--- a/ubi8-rust-builder/Dockerfile
+++ b/ubi8-rust-builder/Dockerfile
@@ -24,7 +24,7 @@ RUN microdnf update --disablerepo=* --enablerepo=ubi-8-appstream-rpms --enablere
 WORKDIR /opt/protoc
 # Prost does not document which version of protoc it expects (https://docs.rs/prost-build/0.12.4/prost_build/), so this should be the latest upstream version
 # (within reason).
-RUN PROTOC_VERSION=21.5 \
+RUN PROTOC_VERSION=26.1 \
   ARCH=$(arch | sed 's/^aarch64$/aarch_64/') \
   && curl --location --output protoc.zip "https://repo.stackable.tech/repository/packages/protoc/protoc-${PROTOC_VERSION}-linux-${ARCH}.zip" \
   && unzip protoc.zip \


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/docker-images/issues/541

Tested using `secret-operator git:(main) ✗ docker build -f docker/Dockerfile .`


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Does your change affect an SBOM? Make sure to update all SBOMs
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
