### PR TITLE
chore: pass linux arch to check-container

### DIFF
--- a/.github/workflows/preflight.yaml
+++ b/.github/workflows/preflight.yaml
@@ -86,8 +86,10 @@ jobs:
       - name: Run preflight checks (no submit)
         if: ${{ inputs.submit == false }}
         run: |
+          ARCH_FOR_DOCKER="$(arch | sed -e 's#x86_64#amd64#' | sed -e 's#aarch64#arm64#')"
           check-container --product "${{ matrix.product }}" \
             --image-version "${{inputs.tag }}" \
             --registry "${{ inputs.registry }}" \
+            --architecture "linux/${ARCH_FOR_DOCKER}" \
             --executable ./preflight-linux-amd64 \
             --token "${{ secrets.RH_PYXIS_API_TOKEN }}" \

--- a/.github/workflows/preflight.yaml
+++ b/.github/workflows/preflight.yaml
@@ -77,9 +77,11 @@ jobs:
       - name: Submit preflight checks
         if: ${{ inputs.submit == true }}
         run: |
+          ARCH_FOR_PREFLIGHT="$(arch | sed -e 's#x86_64#amd64#' | sed -e 's#aarch64#arm64#')"
           check-container --product "${{ matrix.product }}" \
             --image-version "${{inputs.tag }}" \
             --registry "${{ inputs.registry }}" \
+            --architecture "linux/${ARCH_FOR_PREFLIGHT}" \
             --executable ./preflight-linux-amd64 \
             --token "${{ secrets.RH_PYXIS_API_TOKEN }}" \
             --submit

--- a/.github/workflows/preflight.yaml
+++ b/.github/workflows/preflight.yaml
@@ -86,10 +86,10 @@ jobs:
       - name: Run preflight checks (no submit)
         if: ${{ inputs.submit == false }}
         run: |
-          ARCH_FOR_DOCKER="$(arch | sed -e 's#x86_64#amd64#' | sed -e 's#aarch64#arm64#')"
+          ARCH_FOR_PREFLIGHT="$(arch | sed -e 's#x86_64#amd64#' | sed -e 's#aarch64#arm64#')"
           check-container --product "${{ matrix.product }}" \
             --image-version "${{inputs.tag }}" \
             --registry "${{ inputs.registry }}" \
-            --architecture "linux/${ARCH_FOR_DOCKER}" \
+            --architecture "linux/${ARCH_FOR_PREFLIGHT}" \
             --executable ./preflight-linux-amd64 \
             --token "${{ secrets.RH_PYXIS_API_TOKEN }}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
   which is unused since SDP 23.11 ([#621]).
 - hive: Only build and ship Hive metastore. This reduces the image size from `2.63GB` to `1.9GB` and should also reduce the number of dependencies ([#619], [#622]).
 - ubi8-rust-builder: Bump `protoc` from `21.5` to `26.1` ([#624]).
+- pass platform argument to preflight check ([#626]).
 
 ### Fixed
 
@@ -40,6 +41,7 @@ All notable changes to this project will be documented in this file.
 [#621]: https://github.com/stackabletech/docker-images/pull/621
 [#622]: https://github.com/stackabletech/docker-images/pull/622
 [#624]: https://github.com/stackabletech/docker-images/pull/624
+[#626]: https://github.com/stackabletech/docker-images/pull/626
 
 ## [24.3.0] - 2024-03-20
 


### PR DESCRIPTION
# Description
Part of stackabletech/issues#559.
chore: pass linux arch to check-container so that the correct image can be pulled when using manifest lists.

Tested with:
`gh workflow run --ref chore/use-arch-for-preflight preflight.yaml`
https://github.com/stackabletech/docker-images/actions/runs/8829927993

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [x] Changes are OpenShift compatible
- [x] Add an entry to the CHANGELOG.md file
- [x] ~Integration tests~ github action ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
