### PR TITLE
Make it easier to build products in GitHub

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -1,6 +1,7 @@
 ---
-name: Publish 0.0.0-dev images
+name: Build (and optionally publish) 0.0.0-dev images
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -55,9 +56,9 @@ jobs:
           sudo apt update
           sudo apt install --assume-yes python3
       - name: Set up Cosign
-        uses: sigstore/cosign-installer@9614fae9e5c5eddabb09f90a270fcb487c9f7149 # tag=v3.3.0
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # tag=v3.5.0
       - name: Set up syft
-        uses: anchore/sbom-action/download-syft@24b0d5238516480139aa8bc6f92eeb7b54a9eb0a # tag=v0.15.5
+        uses: anchore/sbom-action/download-syft@7ccf588e3cf3cc2611714c2eeae48550fbc17552 # tag=v0.15.11
       - name: Install image-tools-stackabletech
         run: pip install image-tools-stackabletech==0.0.5
       - uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # tag=v3.1.0
@@ -85,60 +86,63 @@ jobs:
           --shard-index "${{matrix.shard_index}}" \
           --export-tags-file bake-target-tags
 
-          # Push images to image repository
-          if [ -f bake-target-tags ]; then
-            echo "bake-target-tags: "$(< bake-target-tags)
-            IMAGE_NAME=$(cat bake-target-tags | cut -d ":" -f 1)
-            TAG_NAME=$(cat bake-target-tags | cut -d ":" -f 2)
-            echo "image: $IMAGE_NAME"
-            echo "tag: $TAG_NAME"
-            # Store the output of `docker image push` into a variable, so we can parse it for the digest
-            PUSH_OUTPUT=$(docker image push "$(< bake-target-tags)" 2>&1)
-            echo "$PUSH_OUTPUT"
-            # Obtain the digest of the pushed image from the output of `docker image push`, because signing by tag is deprecated and will be removed from cosign in the future
-            DIGEST=$(echo "$PUSH_OUTPUT" | awk "/: digest: sha256:[a-f0-9]{64} size: [0-9]+$/ { print \$3 }")
-            # Refer to image via its digest (docker.stackable.tech/stackable/airflow@sha256:0a1b2c...)
-            # This generates a signature and publishes it to the registry, next to the image
-            # Uses the keyless signing flow with Github Actions as identity provider
-            cosign sign -y "$IMAGE_NAME@$DIGEST"
-
-            # Generate SBOM for the image
-            syft scan --output cyclonedx-json=sbom.json --select-catalogers "-cargo-auditable-binary-cataloger" --scope all-layers --source-name "${{ matrix.product }}" --source-version "$TAG_NAME" "$IMAGE_NAME@$DIGEST";
-            # Determine the PURL for the image
-            PURL="pkg:docker/stackable/${{ matrix.product }}@$DIGEST?repository_url=docker.stackable.tech";
-            # Get metadata from the image
-            IMAGE_METADATA_DESCRIPTION=$(docker inspect --format='{{.Config.Labels.description}}' "$IMAGE_NAME@$DIGEST");
-            IMAGE_METADATA_NAME=$(docker inspect --format='{{.Config.Labels.name}}' "$IMAGE_NAME@$DIGEST");
-            # Merge the SBOM with the metadata for the image
-            jq -s '{"metadata":{"component":{"description":"'"$IMAGE_METADATA_NAME. $IMAGE_METADATA_DESCRIPTION"'","supplier":{"name":"Stackable GmbH","url":["https://stackable.tech/"]},"author":"Stackable GmbH","purl":"'"$PURL"'","publisher":"Stackable GmbH"}}} * .[0]' sbom.json > sbom.merged.json;
-            # Attest the SBOM to the image
-            cosign attest -y --predicate sbom.merged.json --type cyclonedx "$IMAGE_NAME@$DIGEST"
-
-            # Push to oci.stackable.tech as well
-            IMAGE_NAME=oci.stackable.tech/sdp/${{ matrix.product }}
-            echo "image: $IMAGE_NAME"
-            docker tag "$(< bake-target-tags)" "$IMAGE_NAME:$TAG_NAME"
-            # Store the output of `docker image push` into a variable, so we can parse it for the digest
-            PUSH_OUTPUT=$(docker image push "$IMAGE_NAME:$TAG_NAME" 2>&1)
-            echo "$PUSH_OUTPUT"
-            # Obtain the digest of the pushed image from the output of `docker image push`, because signing by tag is deprecated and will be removed from cosign in the future
-            DIGEST=$(echo "$PUSH_OUTPUT" | awk "/: digest: sha256:[a-f0-9]{64} size: [0-9]+$/ { print \$3 }")
-            # Refer to image via its digest (oci.stackable.tech/sdp/airflow@sha256:0a1b2c...)
-            # This generates a signature and publishes it to the registry, next to the image
-            # Uses the keyless signing flow with Github Actions as identity provider
-            cosign sign -y "$IMAGE_NAME@$DIGEST"
-
-            # Generate SBOM for the image
-            syft scan --output cyclonedx-json=sbom.json --select-catalogers "-cargo-auditable-binary-cataloger" --scope all-layers --source-name "${{ matrix.product }}" --source-version "$TAG_NAME" "$IMAGE_NAME@$DIGEST";
-            # Determine the PURL for the image
-            PURL="pkg:docker/sdp/${{ matrix.product }}@$DIGEST?repository_url=oci.stackable.tech";
-            # Get metadata from the image
-            IMAGE_METADATA_DESCRIPTION=$(docker inspect --format='{{.Config.Labels.description}}' "$IMAGE_NAME@$DIGEST");
-            IMAGE_METADATA_NAME=$(docker inspect --format='{{.Config.Labels.name}}' "$IMAGE_NAME@$DIGEST");
-            # Merge the SBOM with the metadata for the image
-            jq -s '{"metadata":{"component":{"description":"'"$IMAGE_METADATA_NAME. $IMAGE_METADATA_DESCRIPTION"'","supplier":{"name":"Stackable GmbH","url":["https://stackable.tech/"]},"author":"Stackable GmbH","purl":"'"$PURL"'","publisher":"Stackable GmbH"}}} * .[0]' sbom.json > sbom.merged.json;
-            # Attest the SBOM to the image
-            cosign attest -y --predicate sbom.merged.json --type cyclonedx "$IMAGE_NAME@$DIGEST"
+          # Conditionally push images if not triggered by workflow_dispatch
+          if [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+            # Push images to image repository
+            if [ -f bake-target-tags ]; then
+              echo "bake-target-tags: "$(< bake-target-tags)
+              IMAGE_NAME=$(cat bake-target-tags | cut -d ":" -f 1)
+              TAG_NAME=$(cat bake-target-tags | cut -d ":" -f 2)
+              echo "image: $IMAGE_NAME"
+              echo "tag: $TAG_NAME"
+              # Store the output of `docker image push` into a variable, so we can parse it for the digest
+              PUSH_OUTPUT=$(docker image push "$(< bake-target-tags)" 2>&1)
+              echo "$PUSH_OUTPUT"
+              # Obtain the digest of the pushed image from the output of `docker image push`, because signing by tag is deprecated and will be removed from cosign in the future
+              DIGEST=$(echo "$PUSH_OUTPUT" | awk "/: digest: sha256:[a-f0-9]{64} size: [0-9]+$/ { print \$3 }")
+              # Refer to image via its digest (docker.stackable.tech/stackable/airflow@sha256:0a1b2c...)
+              # This generates a signature and publishes it to the registry, next to the image
+              # Uses the keyless signing flow with Github Actions as identity provider
+              cosign sign -y "$IMAGE_NAME@$DIGEST"
+  
+              # Generate SBOM for the image
+              syft scan --output cyclonedx-json=sbom.json --select-catalogers "-cargo-auditable-binary-cataloger" --scope all-layers --source-name "${{ matrix.product }}" --source-version "$TAG_NAME" "$IMAGE_NAME@$DIGEST";
+              # Determine the PURL for the image
+              PURL="pkg:docker/stackable/${{ matrix.product }}@$DIGEST?repository_url=docker.stackable.tech";
+              # Get metadata from the image
+              IMAGE_METADATA_DESCRIPTION=$(docker inspect --format='{{.Config.Labels.description}}' "$IMAGE_NAME@$DIGEST");
+              IMAGE_METADATA_NAME=$(docker inspect --format='{{.Config.Labels.name}}' "$IMAGE_NAME@$DIGEST");
+              # Merge the SBOM with the metadata for the image
+              jq -s '{"metadata":{"component":{"description":"'"$IMAGE_METADATA_NAME. $IMAGE_METADATA_DESCRIPTION"'","supplier":{"name":"Stackable GmbH","url":["https://stackable.tech/"]},"author":"Stackable GmbH","purl":"'"$PURL"'","publisher":"Stackable GmbH"}}} * .[0]' sbom.json > sbom.merged.json;
+              # Attest the SBOM to the image
+              cosign attest -y --predicate sbom.merged.json --type cyclonedx "$IMAGE_NAME@$DIGEST"
+  
+              # Push to oci.stackable.tech as well
+              IMAGE_NAME=oci.stackable.tech/sdp/${{ matrix.product }}
+              echo "image: $IMAGE_NAME"
+              docker tag "$(< bake-target-tags)" "$IMAGE_NAME:$TAG_NAME"
+              # Store the output of `docker image push` into a variable, so we can parse it for the digest
+              PUSH_OUTPUT=$(docker image push "$IMAGE_NAME:$TAG_NAME" 2>&1)
+              echo "$PUSH_OUTPUT"
+              # Obtain the digest of the pushed image from the output of `docker image push`, because signing by tag is deprecated and will be removed from cosign in the future
+              DIGEST=$(echo "$PUSH_OUTPUT" | awk "/: digest: sha256:[a-f0-9]{64} size: [0-9]+$/ { print \$3 }")
+              # Refer to image via its digest (oci.stackable.tech/sdp/airflow@sha256:0a1b2c...)
+              # This generates a signature and publishes it to the registry, next to the image
+              # Uses the keyless signing flow with Github Actions as identity provider
+              cosign sign -y "$IMAGE_NAME@$DIGEST"
+  
+              # Generate SBOM for the image
+              syft scan --output cyclonedx-json=sbom.json --select-catalogers "-cargo-auditable-binary-cataloger" --scope all-layers --source-name "${{ matrix.product }}" --source-version "$TAG_NAME" "$IMAGE_NAME@$DIGEST";
+              # Determine the PURL for the image
+              PURL="pkg:docker/sdp/${{ matrix.product }}@$DIGEST?repository_url=oci.stackable.tech";
+              # Get metadata from the image
+              IMAGE_METADATA_DESCRIPTION=$(docker inspect --format='{{.Config.Labels.description}}' "$IMAGE_NAME@$DIGEST");
+              IMAGE_METADATA_NAME=$(docker inspect --format='{{.Config.Labels.name}}' "$IMAGE_NAME@$DIGEST");
+              # Merge the SBOM with the metadata for the image
+              jq -s '{"metadata":{"component":{"description":"'"$IMAGE_METADATA_NAME. $IMAGE_METADATA_DESCRIPTION"'","supplier":{"name":"Stackable GmbH","url":["https://stackable.tech/"]},"author":"Stackable GmbH","purl":"'"$PURL"'","publisher":"Stackable GmbH"}}} * .[0]' sbom.json > sbom.merged.json;
+              # Attest the SBOM to the image
+              cosign attest -y --predicate sbom.merged.json --type cyclonedx "$IMAGE_NAME@$DIGEST"
+            fi
           fi
   create_manifests:
     permissions:

--- a/.github/workflows/ubi-rust-builder.yml
+++ b/.github/workflows/ubi-rust-builder.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: UBI Builder rebuild
 
 on:
   push:

--- a/README.adoc
+++ b/README.adoc
@@ -12,6 +12,8 @@ This repository contains Dockerfiles and scripts to build base images for use wi
 
 Product images are published to the `docker.stackable.tech` registry under the `stackable` organization by default.
 
+=== Build single products locally
+
 To build and push product images to the default repository use this command:
 
     bake --product zookeeper --image 0.0.0-dev --push
@@ -24,7 +26,16 @@ You can select a specific version of a product to build using the syntax `produc
 
 NOTE: `-i` is the shorthand for `--image` (i.e. the resulting image tag)
 
-The GitHub action called `Product images` can be triggered manually to do the same but not on the local machine.
+=== Build all products locally
+
+To build all products in all versions locally you can use this command
+
+    bake --image-version 0.0.0-dev
+
+=== Build everything in GitHub
+
+The GitHub action called `Build (and optionally publish) 0.0.0-dev images` can be triggered manually to do build all images in all versions.
+When triggered manually it will _not_ push the images to the registry.
 
 == Verify Product Images
 
@@ -35,6 +46,7 @@ To verify if Apache Zookeeper validate against OpenShift preflight, run:
 == ubi8-rust-builder
 
 This image is meant to be used in multi-stage builds as a base image for projects building Rust projects.
+It is automatically rebuilt and pushed every night and also on every push to the main branch, in addition a build can be triggered using GitHub Actions.
 
 The image will run `cargo build --release` in the current context and copy all binaries to an `/app` directory.
 


### PR DESCRIPTION
# Description

- Renames "docker.yml" to "ubi-rust-builder.yml" to make it easier to identify
- Add workflow_dispatch trigger to dev workflow
- Update README

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
