### PR TITLE
Install krb5-devel which is needed since UBI9 for secret-operator

### DIFF
--- a/ubi9-rust-builder/Dockerfile
+++ b/ubi9-rust-builder/Dockerfile
@@ -37,6 +37,8 @@ RUN microdnf update \
     findutils \
     gcc \
     gcc-c++ \
+    # krb5 needed for secret-operator
+    krb5-devel \
     krb5-libs \
     libkadm5 \
     make \


### PR DESCRIPTION
# Description

Install krb5-devel which is needed since UBI9 for secret-operator

```
#13 92.00   [/root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libgssapi-sys-0.3.0/build.rs:9:11] res = Ok(
#13 92.00       Output {
#13 92.00           status: ExitStatus(
#13 92.00               unix_wait_status(
#13 92.00                   0,
#13 92.00               ),
#13 92.00           ),
#13 92.00           stdout: "/usr/lib64/libgssapi_krb5.so.2\n/usr/lib64/libgssapi_krb5.so.2.2\n",
#13 92.00           stderr: "",
#13 92.00       },
#13 92.00   )
#13 92.00   src/wrapper_mit.h:1:10: fatal error: 'gssapi.h' file not found
#13 92.00   thread 'main' panicked at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libgssapi-sys-0.3.0/build.rs:80:10:
#13 92.00   failed to generate gssapi bindings: ClangDiagnostic("src/wrapper_mit.h:1:10: fatal error: 'gssapi.h' file not found\n")
#13 92.00   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
#13 92.00 warning: build failed, waiting for other jobs to finish...
#13 ERROR: process "/bin/bash -euo pipefail -c . \"$HOME/.cargo/env\" && cargo auditable build --release --workspace && cargo cyclonedx --output-pattern package --all --output-cdx" did not complete successfully: exit code: 101
------
 > [builder 4/1] RUN . "$HOME/.cargo/env" && cargo auditable build --release --workspace && cargo cyclonedx --output-pattern package --all --output-cdx:
92.00           ),
92.00           stdout: "/usr/lib64/libgssapi_krb5.so.2\n/usr/lib64/libgssapi_krb5.so.2.2\n",
92.00           stderr: "",
92.00       },
92.00   )
92.00   src/wrapper_mit.h:1:10: fatal error: 'gssapi.h' file not found
92.00   thread 'main' panicked at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libgssapi-sys-0.3.0/build.rs:80:10:
92.00   failed to generate gssapi bindings: ClangDiagnostic("src/wrapper_mit.h:1:10: fatal error: 'gssapi.h' file not found\n")
92.00   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
92.00 warning: build failed, waiting for other jobs to finish...
```


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Does your change affect an SBOM? Make sure to update all SBOMs
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
