### PR TITLE
chore: Bump opa-bundle-builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - ubi8-rust-builder: Bump `protoc` from `21.5` to `26.1` ([#624]).
 - pass platform argument to preflight check ([#626]).
 - nifi: provision stackable-bcrypt from Maven ([#663])
+- opa-bundle-builder: Bump image to 1.1.2 ([#666])
 
 ### Fixed
 
@@ -57,6 +58,7 @@ All notable changes to this project will be documented in this file.
 [#659]: https://github.com/stackabletech/docker-images/pull/659
 [#661]: https://github.com/stackabletech/docker-images/pull/661
 [#663]: https://github.com/stackabletech/docker-images/pull/663
+[#666]: https://github.com/stackabletech/docker-images/pull/666
 
 ## [24.3.0] - 2024-03-20
 

--- a/conf.py
+++ b/conf.py
@@ -250,12 +250,12 @@ products = [
             {
                 "product": "0.57.0",
                 "vector": "0.35.0",
-                "bundle_builder_version": "1.1.1",
+                "bundle_builder_version": "1.1.2",
             },
             {
                 "product": "0.61.0",
                 "vector": "0.35.0",
-                "bundle_builder_version": "1.1.1",
+                "bundle_builder_version": "1.1.2",
             },
         ],
     },


### PR DESCRIPTION
# Description

Bump opa-bundle-builder with updated dependencies from https://github.com/stackabletech/opa-bundle-builder/pull/20

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Does your change affect an SBOM? Make sure to update all SBOMs
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
