### PR TITLE
chore: hdfs - remove unnecessary jars and bump dependency versions to fix CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - java-devel: New image to serve as base layer for builder stages ([#665]).
 - hdfs: Exclude YARN and Mapreduce projects from build ([#667]).
 - stackable-base: Mitigate CVE-2023-37920 by removing e-Tugra root certificates ([#673]).
+- hdfs: Exclude unused jars and mitigate snappy-java CVEs by bumping dependency ([#682]).
 
 ### Changed
 
@@ -72,8 +73,9 @@ All notable changes to this project will be documented in this file.
 [#665]: https://github.com/stackabletech/docker-images/pull/665
 [#666]: https://github.com/stackabletech/docker-images/pull/666
 [#667]: https://github.com/stackabletech/docker-images/pull/667
-[#676]: https://github.com/stackabletech/docker-images/pull/676
 [#673]: https://github.com/stackabletech/docker-images/pull/673
+[#676]: https://github.com/stackabletech/docker-images/pull/676
+[#682]: https://github.com/stackabletech/docker-images/pull/682
 
 ## [24.3.0] - 2024-03-20
 

--- a/hadoop/Dockerfile
+++ b/hadoop/Dockerfile
@@ -53,7 +53,9 @@ WORKDIR /stackable
 
 # Hadoop Pipes requires libtirpc to build, whose headers are not packaged in RedHat UBI, so skip building this module
 # Build from source to enable FUSE module, and to apply custom patches.
-# Also skip building the yarn, mapreduce and minicluster modules.
+# Also skip building the yarn, mapreduce and minicluster modules: this will result in the modules being excluded but not all
+# jar files will be stripped if they are needed elsewhere e.g. share/hadoop/yarn will not be part of the build, but yarn jars
+# will still exist in share/hadoop/tools as they would be needed by the resource estimator tool. Such jars are removed in a later step.
 RUN curl --fail -L "https://repo.stackable.tech/repository/packages/hadoop/hadoop-${PRODUCT}-src.tar.gz" | tar -xzC . && \
     patches/apply_patches.sh ${PRODUCT} && \
     cd hadoop-${PRODUCT}-src && \
@@ -155,7 +157,7 @@ ENV HADOOP_YARN_HOME=/stackable/hadoop
 ENV HADOOP_MAPRED_HOME=/stackable/hadoop
 
 # Remove unneeded binaries:
-#  - source code
+#  - code sources
 #  - mapreduce/yarn binaries that were built as cross-project dependencies
 #  - minicluster (only used for testing) and test .jars
 #  - json-io: this is a transitive dependency pulled in by cedarsoft/java-utils/json-io and is excluded in 3.4.0. See CVE-2023-34610.
@@ -165,9 +167,9 @@ RUN rm -rf /stackable/hadoop/share/hadoop/common/sources/ && \
   rm -rf /stackable/hadoop/share/hadoop/tools/lib/json-io-*.jar && \
   rm -rf /stackable/hadoop/share/hadoop/tools/lib/hadoop-mapreduce-client-*.jar && \
   rm -rf /stackable/hadoop/share/hadoop/tools/lib/hadoop-yarn-server*.jar && \
-  find . -name hadoop-minicluster-*.jar -type f -delete && \
-  find . -name hadoop-client-minicluster-*.jar -type f -delete && \
-  find . -name hadoop-*tests.jar -type f -delete
+  find . -name 'hadoop-minicluster-*.jar' -type f -delete && \
+  find . -name 'hadoop-client-minicluster-*.jar' -type f -delete && \
+  find . -name 'hadoop-*tests.jar' -type f -delete
 
 WORKDIR /stackable/hadoop
 CMD ["echo", "This image is not meant to be 'run' directly."]

--- a/hadoop/Dockerfile
+++ b/hadoop/Dockerfile
@@ -53,10 +53,11 @@ WORKDIR /stackable
 
 # Hadoop Pipes requires libtirpc to build, whose headers are not packaged in RedHat UBI, so skip building this module
 # Build from source to enable FUSE module, and to apply custom patches.
+# Also skip building the yarn, mapreduce and minicluster modules.
 RUN curl --fail -L "https://repo.stackable.tech/repository/packages/hadoop/hadoop-${PRODUCT}-src.tar.gz" | tar -xzC . && \
     patches/apply_patches.sh ${PRODUCT} && \
     cd hadoop-${PRODUCT}-src && \
-    mvn clean package -Pdist,native -pl '!hadoop-tools/hadoop-pipes,!hadoop-yarn-project,!hadoop-mapreduce-project' -Drequire.fuse=true -DskipTests -Dmaven.javadoc.skip=true && \
+    mvn clean package -Pdist,native -pl '!hadoop-tools/hadoop-pipes,!hadoop-yarn-project,!hadoop-mapreduce-project,!hadoop-minicluster' -Drequire.fuse=true -DskipTests -Dmaven.javadoc.skip=true && \
     cp -r hadoop-dist/target/hadoop-${PRODUCT} /stackable/hadoop-${PRODUCT} && \
     # HDFS fuse-dfs is not part of the regular dist output, so we need to copy it in ourselves
     cp hadoop-hdfs-project/hadoop-hdfs-native-client/target/main/native/fuse-dfs/fuse_dfs /stackable/hadoop-${PRODUCT}/bin && \
@@ -152,6 +153,21 @@ ENV ASYNC_PROFILER_HOME=/stackable/async-profiler
 # if HADOOP_YARN_HOME does not exist at all, so we set it here to a sensible default.
 ENV HADOOP_YARN_HOME=/stackable/hadoop
 ENV HADOOP_MAPRED_HOME=/stackable/hadoop
+
+# Remove unneeded binaries:
+#  - source code
+#  - mapreduce/yarn binaries that were built as cross-project dependencies
+#  - minicluster (only used for testing) and test .jars
+#  - json-io: this is a transitive dependency pulled in by cedarsoft/java-utils/json-io and is excluded in 3.4.0. See CVE-2023-34610.
+RUN rm -rf /stackable/hadoop/share/hadoop/common/sources/ && \
+  rm -rf /stackable/hadoop/share/hadoop/hdfs/sources/ && \
+  rm -rf /stackable/hadoop/share/hadoop/tools/sources/ && \
+  rm -rf /stackable/hadoop/share/hadoop/tools/lib/json-io-*.jar && \
+  rm -rf /stackable/hadoop/share/hadoop/tools/lib/hadoop-mapreduce-client-*.jar && \
+  rm -rf /stackable/hadoop/share/hadoop/tools/lib/hadoop-yarn-server*.jar && \
+  find . -name hadoop-minicluster-*.jar -type f -delete && \
+  find . -name hadoop-client-minicluster-*.jar -type f -delete && \
+  find . -name hadoop-*tests.jar -type f -delete
 
 WORKDIR /stackable/hadoop
 CMD ["echo", "This image is not meant to be 'run' directly."]

--- a/hadoop/stackable/patches/3.3.4/007-snappy-cves-3.3.4.patch
+++ b/hadoop/stackable/patches/3.3.4/007-snappy-cves-3.3.4.patch
@@ -1,0 +1,13 @@
+diff --git a/hadoop-project/pom.xml b/hadoop-project/pom.xml
+index 0b2f6f17157..9e7d5cc3973 100644
+--- a/hadoop-project/pom.xml
++++ b/hadoop-project/pom.xml
+@@ -142,7 +142,7 @@
+     <metrics.version>3.2.4</metrics.version>
+     <netty3.version>3.10.6.Final</netty3.version>
+     <netty4.version>4.1.77.Final</netty4.version>
+-    <snappy-java.version>1.1.8.2</snappy-java.version>
++    <snappy-java.version>1.1.10.4</snappy-java.version>
+     <lz4-java.version>1.7.1</lz4-java.version>
+
+     <!-- Maven protoc compiler -->

--- a/hadoop/stackable/patches/3.3.6/007-snappy-cves-3.3.6.patch
+++ b/hadoop/stackable/patches/3.3.6/007-snappy-cves-3.3.6.patch
@@ -1,0 +1,13 @@
+diff --git a/hadoop-project/pom.xml b/hadoop-project/pom.xml
+index f1ac43ed5b3..0d1e42acc75 100644
+--- a/hadoop-project/pom.xml
++++ b/hadoop-project/pom.xml
+@@ -144,7 +144,7 @@
+     <metrics.version>3.2.4</metrics.version>
+     <netty3.version>3.10.6.Final</netty3.version>
+     <netty4.version>4.1.89.Final</netty4.version>
+-    <snappy-java.version>1.1.8.2</snappy-java.version>
++    <snappy-java.version>1.1.10.4</snappy-java.version>
+     <lz4-java.version>1.7.1</lz4-java.version>
+
+     <!-- Maven protoc compiler -->


### PR DESCRIPTION
# Description

This PR fixes the following CVEs for snappy-java (bumped from 1.1.8.2 to 1.1.10.4):

CVE-2023-34453
CVE-2023-34454
CVE-2023-43642
CVE-2023-34455

It also strips the image of jars that we do not need (yarn, mapreduce, minicluster modules, plus test/source jars).

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [x] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Add an entry to the CHANGELOG.md file
- [x] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
