### PR TITLE
Patch NiFi assembly to not zip binaries to save disk space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 - pass platform argument to preflight check ([#626]).
 - nifi: provision stackable-bcrypt from Maven ([#663])
 - nifi: move /bin/stackable-bcrypt to /stackable/stackable-bcrypt and added softlink for backwards compatibility ([#678]).
+- nifi: patch nifi-assembly pom file to not zip binaries after the build to save disk space ([#685]).
 - hadoop: use java-devel as base layer for the builder stage ([#665])
 - hive: use java-devel as base layer for the builder stage ([#665])
 - zookeeper: use java-devel as base layer for the builder stage ([#665])
@@ -81,6 +82,7 @@ All notable changes to this project will be documented in this file.
 [#678]: https://github.com/stackabletech/docker-images/pull/678
 [#679]: https://github.com/stackabletech/docker-images/pull/679
 [#682]: https://github.com/stackabletech/docker-images/pull/682
+[#685]: https://github.com/stackabletech/docker-images/pull/685
 
 ## [24.3.0] - 2024-03-20
 

--- a/nifi/Dockerfile
+++ b/nifi/Dockerfile
@@ -17,6 +17,8 @@ RUN microdnf update && \
 USER stackable
 WORKDIR /stackable
 
+COPY --chown=stackable:stackable nifi/stackable/patches /stackable/patches
+
 RUN curl --fail -L 'https://repo.stackable.tech/repository/m2/tech/stackable/nifi/stackable-bcrypt/1.0-SNAPSHOT/stackable-bcrypt-1.0-20240508.153334-1-jar-with-dependencies.jar' \
     # This used to be located in /bin/stackable-bcrypt.jar. We create a softlink for /bin/stackable-bcrypt.jar in the main container for backwards compatibility.
     -o /stackable/stackable-bcrypt.jar && \
@@ -29,12 +31,18 @@ RUN curl --fail -L 'https://repo.stackable.tech/repository/m2/tech/stackable/nif
     # from /stackable/nifi-${PRODUCT}-src/nifi-assembly/target/nifi-${PRODUCT}-bin/nifi-${PRODUCT} (see later steps)
     # Therefore we add the suffix "-src" to be able to copy the binary and remove the unzipped sources afterwards.
     mv nifi-${PRODUCT} nifi-${PRODUCT}-src && \
+    # Apply patches
+    chmod +x patches/apply_patches.sh && \
+    patches/apply_patches.sh ${PRODUCT} && \
+    # Build NiFi
     cd /stackable/nifi-${PRODUCT}-src/ && \
     mvn clean install -DskipTests && \
     # Copy the binaries to the /stackable folder
     mv /stackable/nifi-${PRODUCT}-src/nifi-assembly/target/nifi-${PRODUCT}-bin/nifi-${PRODUCT} /stackable/nifi-${PRODUCT} && \
     # Remove the unzipped sources
-    rm -rf /stackable/nifi-${PRODUCT}-src 
+    rm -rf /stackable/nifi-${PRODUCT}-src && \
+    # Remove generated docs in binary
+    rm -rf /stackable/nifi-${PRODUCT}/docs
 
 # Add Iceberg extensions as they are not included by default and are important enough
 # They need to be build from source, as https://mvnrepository.com/artifact/org.apache.nifi/nifi-iceberg-processors-nar does not ship the org.apache.hadoop.fs.s3a.S3AFileSystem (see https://github.com/apache/nifi/pull/6368#issuecomment-1502175258)

--- a/nifi/stackable/patches/1.21.0/001-NIFI-no-zip-assembly.patch
+++ b/nifi/stackable/patches/1.21.0/001-NIFI-no-zip-assembly.patch
@@ -1,0 +1,12 @@
+diff --git a/nifi-assembly/pom.xml b/nifi-assembly/pom.xml
+index 3206b0468d..5ae52932cc 100644
+--- a/nifi-assembly/pom.xml
++++ b/nifi-assembly/pom.xml
+@@ -66,7 +66,6 @@ language governing permissions and limitations under the License. -->
+                             <tarLongFileMode>posix</tarLongFileMode>
+                             <formats>
+                                 <format>dir</format>
+-                                <format>zip</format>
+                             </formats>
+                         </configuration>
+                     </execution>

--- a/nifi/stackable/patches/1.23.2/001-NIFI-no-zip-assembly.patch
+++ b/nifi/stackable/patches/1.23.2/001-NIFI-no-zip-assembly.patch
@@ -1,0 +1,12 @@
+diff --git a/nifi-assembly/pom.xml b/nifi-assembly/pom.xml
+index b520c113ce..5cf04f421d 100644
+--- a/nifi-assembly/pom.xml
++++ b/nifi-assembly/pom.xml
+@@ -66,7 +66,6 @@ language governing permissions and limitations under the License. -->
+                             <tarLongFileMode>posix</tarLongFileMode>
+                             <formats>
+                                 <format>dir</format>
+-                                <format>zip</format>
+                             </formats>
+                         </configuration>
+                     </execution>

--- a/nifi/stackable/patches/1.25.0/001-NIFI-no-zip-assembly.patch
+++ b/nifi/stackable/patches/1.25.0/001-NIFI-no-zip-assembly.patch
@@ -1,0 +1,12 @@
+diff --git a/nifi-assembly/pom.xml b/nifi-assembly/pom.xml
+index f2d236cd56..fdb3879c9f 100644
+--- a/nifi-assembly/pom.xml
++++ b/nifi-assembly/pom.xml
+@@ -66,7 +66,6 @@ language governing permissions and limitations under the License. -->
+                             <tarLongFileMode>posix</tarLongFileMode>
+                             <formats>
+                                 <format>dir</format>
+-                                <format>zip</format>
+                             </formats>
+                         </configuration>
+                     </execution>

--- a/nifi/stackable/patches/apply_patches.sh
+++ b/nifi/stackable/patches/apply_patches.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Enable error handling and unset variable checking
+set -eu
+set -o pipefail
+
+# Check if $1 (VERSION) is provided
+if [ -z "${1-}" ]; then
+  echo "Please provide a value for VERSION as the first argument."
+  exit 1
+fi
+
+VERSION="$1"
+PATCH_DIR="patches/$VERSION"
+
+# Check if version-specific patches directory exists
+if [ ! -d "$PATCH_DIR" ]; then
+  echo "Patches directory '$PATCH_DIR' does not exist."
+  exit 1
+fi
+
+# Create an array to hold the patches in sorted order
+declare -a patch_files
+
+echo "Applying patches from ${PATCH_DIR}" now
+
+# Read the patch files into the array
+while IFS= read -r -d $'\0' file; do
+  patch_files+=("$file")
+done < <(find "$PATCH_DIR" -name "*.patch" -print0 | sort -zV)
+
+echo "Found ${#patch_files[@]} patches, applying now"
+
+# Iterate through sorted patch files
+for patch_file in "${patch_files[@]}"; do
+  echo "Applying $patch_file"
+  git apply --directory "nifi-${VERSION}-src" "$patch_file" || {
+    echo "Failed to apply $patch_file"
+    exit 1
+  }
+done
+
+echo "All patches applied successfully."


### PR DESCRIPTION
# Description

For NiFi version 1.21.0 and 1.23.2 the github runners do not have enough space and fail to build these images:
```
Error: [ERROR] Failed to execute goal org.apache.maven.plugins:maven-install-plugin:3.1.0:install (default-install) on project nifi-toolkit-assembly: Failed to install artifact org.apache.nifi:nifi-toolkit-assembly:zip:bin:1.21.0: No space left on device -> [Help 1]
```
The nifi-assembly zips the resulting binaries which adds another ~1.3 GB but are not used in the main image since the unzipped binaries are copied over.

This PR patches the pom file to not zip the binaries in the end to save disk space.


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
