### PR TITLE
Update Flask-appbuilder and gevent

### DIFF
--- a/superset/constraints-3.1.0.txt
+++ b/superset/constraints-3.1.0.txt
@@ -98,7 +98,8 @@ flask==2.2.5
     #   flask-session
     #   flask-sqlalchemy
     #   flask-wtf
-flask-appbuilder==4.3.10
+# Bumping to 4.3.11 to get rid of CVE-2024-25128
+flask-appbuilder==4.3.11
     # via apache-superset
 flask-babel==1.0.0
     # via flask-appbuilder
@@ -134,7 +135,9 @@ geographiclib==1.52
     # via geopy
 geopy==2.2.0
     # via apache-superset
-greenlet==2.0.2
+# Letting python decide which greenlet version to compile at
+# since we diverge from the vendor to fix CVE's
+# greenlet==3.0.0
     # via
     #   shillelagh
     #   sqlalchemy
@@ -383,7 +386,9 @@ zipp==3.15.0
     #   importlib-metadata
     #   importlib-resources
 # from https://github.com/apache/superset/blob/3.1.0/requirements/docker.txt
-gevent==22.10.2
+# Bumped to latest version to get rid of
+# CVE-2023-41419
+gevent==24.2.1
     # via -r requirements/docker.in
 psycopg2-binary==2.9.6
     # via apache-superset


### PR DESCRIPTION
# Description

This updates two dependencies:
- flask-appbuilde 4.3.10 -> 4.3.11 [CVE-2024-25128](https://secobserve.stackable.tech/#/observations/1251500/show)
- gevent 22.10.2 -> 24.2.1 [CVE-2023-41419](https://secobserve.stackable.tech/#/observations/1251453/show)

Dependencie greenlet has been removed from `3.1.0 constrains.txt` since python have to choose it on it's own.

This has only be done for `3.1.0` since customers could update to the latest version of superset we support and having  most critical vulnerabilities fixed.


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
