### PR TITLE
fix: add jaxb library no longer bundled with hadoop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to this project will be documented in this file.
 - hive: Fix compilation on ARM by back-porting [HIVE-21939](https://issues.apache.org/jira/browse/HIVE-21939) from [this](https://github.com/apache/hive/commit/2baf21bb55fcf33d8522444c78a8d8cab60e7415) commit ([#617]).
 - hive: Fix compilation on ARM in CI as well ([#619]).
 - hive: Fix compilation of x86 in CI due to lower disk usage to prevent disk running full ([#619]).
+- hive: Provide logging dependency previously bundled with the hadoop yarn client ([#688]).
 
 ### Removed
 
@@ -83,6 +84,7 @@ All notable changes to this project will be documented in this file.
 [#679]: https://github.com/stackabletech/docker-images/pull/679
 [#682]: https://github.com/stackabletech/docker-images/pull/682
 [#685]: https://github.com/stackabletech/docker-images/pull/685
+[#688]: https://github.com/stackabletech/docker-images/pull/688
 
 ## [24.3.0] - 2024-03-20
 

--- a/conf.py
+++ b/conf.py
@@ -147,6 +147,8 @@ products = [
                 "java-devel": "1.8.0",
                 "hadoop": "3.3.4",
                 "jackson_dataformat_xml": "2.12.3",
+                # No longer bundled with the hadoop-yarn/mapreduce libraries (2.12.7 corresponds to the hadoop build for 3.3.4).
+                "jackson_jaxb_annotations": "2.12.7",
                 # Normally Hive 3.1.3 ships with "postgresql-9.4.1208.jre7.jar", but as this is old enough it does only support
                 # MD5 based authentication. Because of this, it does not work against more recent PostgresQL versions.
                 # See https://github.com/stackabletech/hive-operator/issues/170 for details.

--- a/hive/Dockerfile
+++ b/hive/Dockerfile
@@ -20,6 +20,7 @@ ARG PRODUCT
 ARG HADOOP
 ARG JMX_EXPORTER
 ARG JACKSON_DATAFORMAT_XML
+ARG JACKSON_JAXB_ANNOTATIONS
 ARG POSTGRES_DRIVER
 ARG AWS_JAVA_SDK_BUNDLE
 ARG AZURE_STORAGE
@@ -67,9 +68,11 @@ RUN curl --fail -L "https://repo.stackable.tech/repository/packages/jmx-exporter
     ln -s "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar" /stackable/jmx/jmx_prometheus_javaagent.jar && \
     ln -s /stackable/jmx/jmx_prometheus_javaagent.jar /stackable/jmx/jmx_prometheus_javaagent-0.16.1.jar
 
-# Logging
+# Logging.
+# jackson-module-jaxb-annotations: this is no longer bundled with the hadoop-yarn/mapreduce libraries (excluded from the hadoop build).
 RUN rm /stackable/hive-metastore/lib/log4j-slf4j-impl* && \
-    curl --fail -L https://repo.stackable.tech/repository/packages/jackson-dataformat-xml/jackson-dataformat-xml-${JACKSON_DATAFORMAT_XML}.jar -o /stackable/hive-metastore/lib/jackson-dataformat-xml-${JACKSON_DATAFORMAT_XML}.jar
+    curl --fail -L https://repo.stackable.tech/repository/packages/jackson-dataformat-xml/jackson-dataformat-xml-${JACKSON_DATAFORMAT_XML}.jar -o /stackable/hive-metastore/lib/jackson-dataformat-xml-${JACKSON_DATAFORMAT_XML}.jar && \
+    curl --fail -L https://repo.stackable.tech/repository/packages/jackson-module-jaxb-annotations/jackson-module-jaxb-annotations-${JACKSON_JAXB_ANNOTATIONS}.jar -o /stackable/hive-metastore/lib/jackson-module-jaxb-annotations-${JACKSON_JAXB_ANNOTATIONS}.jar
 
 # ===
 # For earlier versions this script removes the .class file that contains the
@@ -133,6 +136,11 @@ ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true
 ENV HADOOP_HOME=/stackable/hadoop
 ENV HIVE_HOME=/stackable/hive-metastore
 ENV PATH="${PATH}":/stackable/hadoop/bin:/stackable/hive-metastore/bin
+
+# The following 2 env-vars are required for common hadoop scripts even if the respective libraries are never used.
+# We set them here to a sensible default.
+ENV HADOOP_YARN_HOME=/stackable/hadoop
+ENV HADOOP_MAPRED_HOME=/stackable/hadoop
 
 WORKDIR /stackable/hive-metastore
 # Start command is set by operator to something like "bin/start-metastore --config /stackable/config --db-type postgres --hive-bin-dir bin"


### PR DESCRIPTION
# Description

fixes https://github.com/stackabletech/hive-operator/issues/468.

Recent changes to the hadoop image resulted in a missing logging dependency (jackson-module-jaxb-annotations was originally bundler with the hadoop yarn client): this PR adds the missing specific version.
Start-up scripts for hadoop functions check various env-vars, even if the associated modules are never run. To avoid errors with the initialisation of these scripts default values have been set where necessary.

Local testing with `repo: docker.stackable.tech/sandbox/yarnless-hive` :-
```
--- PASS: kuttl (1193.36s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/kerberos-s3_postgres-12.5.6_hive-3.1.3_openshift-false_s3-use-tls-true_kerberos-realm-PROD.MYCORP_kerberos-backend-mit (315.83s)
        --- PASS: kuttl/harness/logging_postgres-12.5.6_hive-3.1.3_openshift-false (167.48s)
        --- PASS: kuttl/harness/orphaned-resources_hive-latest-3.1.3_openshift-false (124.31s)
        --- PASS: kuttl/harness/cluster-operation_hive-latest-3.1.3_openshift-false (75.79s)
        --- PASS: kuttl/harness/resources_hive-3.1.3_openshift-false (41.52s)
        --- PASS: kuttl/harness/smoke_postgres-12.5.6_hive-3.1.3_openshift-false_s3-use-tls-true (95.33s)
        --- PASS: kuttl/harness/kerberos-hdfs_postgres-12.5.6_hive-3.1.3_hdfs-latest-3.3.6_zookeeper-latest-3.9.2_openshift-false_kerberos-realm-PROD.MYCORP_kerberos-backend-mit (372.61s)
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [x] Add an entry to the CHANGELOG.md file
- [x] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
