### PR TITLE
test: set -Xmx to 6gb to avoid java heap error

### DIFF
--- a/nifi/Dockerfile
+++ b/nifi/Dockerfile
@@ -36,7 +36,7 @@ RUN curl --fail -L 'https://repo.stackable.tech/repository/m2/tech/stackable/nif
     patches/apply_patches.sh ${PRODUCT} && \
     # Build NiFi
     cd /stackable/nifi-${PRODUCT}-src/ && \
-    mvn clean install -DskipTests && \
+    mvn clean install -DskipTests -DargLine="-Xmx6144m" && \
     # Copy the binaries to the /stackable folder
     mv /stackable/nifi-${PRODUCT}-src/nifi-assembly/target/nifi-${PRODUCT}-bin/nifi-${PRODUCT} /stackable/nifi-${PRODUCT} && \
     # Remove the unzipped sources


### PR DESCRIPTION
# Description


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
