### PR TITLE
Reduce heap usage in nifi source build

### DIFF
--- a/nifi/Dockerfile
+++ b/nifi/Dockerfile
@@ -36,7 +36,7 @@ RUN curl --fail -L 'https://repo.stackable.tech/repository/m2/tech/stackable/nif
     patches/apply_patches.sh ${PRODUCT} && \
     # Build NiFi
     cd /stackable/nifi-${PRODUCT}-src/ && \
-    mvn clean install -DskipTests && \
+    mvn clean install -Dmaven.javadoc.skip=true -DskipTests && \
     # Copy the binaries to the /stackable folder
     mv /stackable/nifi-${PRODUCT}-src/nifi-assembly/target/nifi-${PRODUCT}-bin/nifi-${PRODUCT} /stackable/nifi-${PRODUCT} && \
     # Remove the unzipped sources

--- a/nifi/stackable/patches/1.21.0/002-NIFI-bump-assembly-plugin-3.6.patch
+++ b/nifi/stackable/patches/1.21.0/002-NIFI-bump-assembly-plugin-3.6.patch
@@ -1,0 +1,13 @@
+diff --git a/pom.xml b/pom.xml
+index 1f739a27b7..1018651563 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -783,7 +783,7 @@
+                 <plugin>
+                     <groupId>org.apache.maven.plugins</groupId>
+                     <artifactId>maven-assembly-plugin</artifactId>
+-                    <version>3.5.0</version>
++                    <version>3.6.0</version>
+                     <configuration>
+                         <tarLongFileMode>gnu</tarLongFileMode>
+                     </configuration>


### PR DESCRIPTION
# Description


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
