### PR TITLE
Use NiFi 1.21.0 binaries

### DIFF
--- a/nifi/Dockerfile
+++ b/nifi/Dockerfile
@@ -19,30 +19,51 @@ WORKDIR /stackable
 
 COPY --chown=stackable:stackable nifi/stackable/patches /stackable/patches
 
-RUN curl --fail -L 'https://repo.stackable.tech/repository/m2/tech/stackable/nifi/stackable-bcrypt/1.0-SNAPSHOT/stackable-bcrypt-1.0-20240508.153334-1-jar-with-dependencies.jar' \
-    # This used to be located in /bin/stackable-bcrypt.jar. We create a softlink for /bin/stackable-bcrypt.jar in the main container for backwards compatibility.
-    -o /stackable/stackable-bcrypt.jar && \
-    # Get the source release from nexus
-    curl --fail -L "https://repo.stackable.tech/repository/packages/nifi/nifi-${PRODUCT}-source-release.zip" -o "/stackable/nifi-${PRODUCT}-source-release.zip" && \
-    unzip "nifi-${PRODUCT}-source-release.zip" && \
-    # Clean up downloaded source after unzipping
-    rm -rf "nifi-${PRODUCT}-source-release.zip" && \
-    # The NiFi "binary" ends up in a folder named "nifi-${PRODUCT}" which should be copied to /stackable 
-    # from /stackable/nifi-${PRODUCT}-src/nifi-assembly/target/nifi-${PRODUCT}-bin/nifi-${PRODUCT} (see later steps)
-    # Therefore we add the suffix "-src" to be able to copy the binary and remove the unzipped sources afterwards.
-    mv nifi-${PRODUCT} nifi-${PRODUCT}-src && \
-    # Apply patches
-    chmod +x patches/apply_patches.sh && \
-    patches/apply_patches.sh ${PRODUCT} && \
-    # Build NiFi
-    cd /stackable/nifi-${PRODUCT}-src/ && \
-    mvn clean install -DskipTests && \
-    # Copy the binaries to the /stackable folder
-    mv /stackable/nifi-${PRODUCT}-src/nifi-assembly/target/nifi-${PRODUCT}-bin/nifi-${PRODUCT} /stackable/nifi-${PRODUCT} && \
-    # Remove the unzipped sources
-    rm -rf /stackable/nifi-${PRODUCT}-src && \
-    # Remove generated docs in binary
-    rm -rf /stackable/nifi-${PRODUCT}/docs
+# NOTE: NiFi 1.21.0 source build does not work with the current arm64 git runners due to java heap issues:
+#     
+# [ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:3.5.0:single (make shared resource) on project nifi-registry-assembly: 
+# Failed to create assembly: Error creating assembly archive bin: Problem creating zip: Execution exception: Java heap space
+# 
+# Since this will be deprecated in the release 24.7 and then removed we copy the NiFi 1.21.0 binaries instead
+# of building from source. The if condition can be removed once 1.21.0 is no longer supported and only the
+# else branch is required to build from source.
+#
+RUN if [[ "${PRODUCT}" == "1.21.0" ]] ; then \
+        curl --fail -L 'https://repo.stackable.tech/repository/m2/tech/stackable/nifi/stackable-bcrypt/1.0-SNAPSHOT/stackable-bcrypt-1.0-20240508.153334-1-jar-with-dependencies.jar' \
+        # This used to be located in /bin/stackable-bcrypt.jar. We create a softlink for /bin/stackable-bcrypt.jar in the main container for backwards compatibility.
+        -o /stackable/stackable-bcrypt.jar && \
+        # zip is different than tar and cannot be just piped, therefore the intermediate save and remove step to unzip
+        curl --fail -L https://repo.stackable.tech/repository/packages/nifi/nifi-${PRODUCT}-bin.zip -o /stackable/nifi-${PRODUCT}-bin.zip && \
+        unzip /stackable/nifi-${PRODUCT}-bin.zip && \
+        rm /stackable/nifi-${PRODUCT}-bin.zip && \
+        # Remove generated docs in binary
+        rm -rf /stackable/nifi-${PRODUCT}/docs ; \
+    else \
+        curl --fail -L 'https://repo.stackable.tech/repository/m2/tech/stackable/nifi/stackable-bcrypt/1.0-SNAPSHOT/stackable-bcrypt-1.0-20240508.153334-1-jar-with-dependencies.jar' \
+        # This used to be located in /bin/stackable-bcrypt.jar. We create a softlink for /bin/stackable-bcrypt.jar in the main container for backwards compatibility.
+        -o /stackable/stackable-bcrypt.jar && \
+        # Get the source release from nexus
+        curl --fail -L "https://repo.stackable.tech/repository/packages/nifi/nifi-${PRODUCT}-source-release.zip" -o "/stackable/nifi-${PRODUCT}-source-release.zip" && \
+        unzip "nifi-${PRODUCT}-source-release.zip" && \
+        # Clean up downloaded source after unzipping
+        rm -rf "nifi-${PRODUCT}-source-release.zip" && \
+        # The NiFi "binary" ends up in a folder named "nifi-${PRODUCT}" which should be copied to /stackable 
+        # from /stackable/nifi-${PRODUCT}-src/nifi-assembly/target/nifi-${PRODUCT}-bin/nifi-${PRODUCT} (see later steps)
+        # Therefore we add the suffix "-src" to be able to copy the binary and remove the unzipped sources afterwards.
+        mv nifi-${PRODUCT} nifi-${PRODUCT}-src && \
+        # Apply patches
+        chmod +x patches/apply_patches.sh && \
+        patches/apply_patches.sh ${PRODUCT} && \
+        # Build NiFi
+        cd /stackable/nifi-${PRODUCT}-src/ && \
+        mvn clean install -Dmaven.javadoc.skip=true -DskipTests && \
+        # Copy the binaries to the /stackable folder
+        mv /stackable/nifi-${PRODUCT}-src/nifi-assembly/target/nifi-${PRODUCT}-bin/nifi-${PRODUCT} /stackable/nifi-${PRODUCT} && \
+        # Remove the unzipped sources
+        rm -rf /stackable/nifi-${PRODUCT}-src && \
+        # Remove generated docs in binary
+        rm -rf /stackable/nifi-${PRODUCT}/docs ; \
+    fi
 
 # Add Iceberg extensions as they are not included by default and are important enough
 # They need to be build from source, as https://mvnrepository.com/artifact/org.apache.nifi/nifi-iceberg-processors-nar does not ship the org.apache.hadoop.fs.s3a.S3AFileSystem (see https://github.com/apache/nifi/pull/6368#issuecomment-1502175258)


### PR DESCRIPTION
# Description

Due to java heap problems with NiFi 1.21.0 on arm runners, we continue to use the binaries for 1.21.0.
The builder step is kept. 


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
