### PR TITLE
fix(druid): Re-add needed quickstart folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to this project will be documented in this file.
 - hdfs: Exclude YARN and Mapreduce projects from build ([#667]).
 - stackable-base: Mitigate CVE-2023-37920 by removing e-Tugra root certificates ([#673]).
 - hdfs: Exclude unused jars and mitigate snappy-java CVEs by bumping dependency ([#682]).
-- druid: Build from source ([#684]).
+- druid: Build from source ([#684], [#XXX]).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to this project will be documented in this file.
 - hdfs: Exclude YARN and Mapreduce projects from build ([#667]).
 - stackable-base: Mitigate CVE-2023-37920 by removing e-Tugra root certificates ([#673]).
 - hdfs: Exclude unused jars and mitigate snappy-java CVEs by bumping dependency ([#682]).
-- druid: Build from source ([#684], [#XXX]).
+- druid: Build from source ([#684], [#696]).
 
 ### Changed
 
@@ -87,6 +87,7 @@ All notable changes to this project will be documented in this file.
 [#684]: https://github.com/stackabletech/docker-images/pull/684
 [#685]: https://github.com/stackabletech/docker-images/pull/685
 [#688]: https://github.com/stackabletech/docker-images/pull/688
+[#696]: https://github.com/stackabletech/docker-images/pull/696
 
 ## [24.3.0] - 2024-03-20
 

--- a/druid/Dockerfile
+++ b/druid/Dockerfile
@@ -32,7 +32,7 @@ RUN curl --fail -L "https://repo.stackable.tech/repository/packages/druid/apache
     mv /stackable/apache-druid-${PRODUCT}-src/apache-druid-${PRODUCT} /stackable/apache-druid-${PRODUCT} && \
     rm -rf /stackable/apache-druid-${PRODUCT}-src
 # Do not remove the /stackable/apache-druid-${PRODUCT}/quickstart folder, it is needed for loading the Wikipedia
-# testdate in kuttl tests and the getting started guide.
+# testdata in kuttl tests and the getting started guide.
 
     # Install the Prometheus emitter extension. This bundle contains the emitter and all jar dependencies.
 RUN curl --fail "https://repo.stackable.tech/repository/packages/druid/druid-prometheus-emitter-${PRODUCT}.tar.gz" | tar -xzC /stackable/apache-druid-${PRODUCT}/extensions && \

--- a/druid/Dockerfile
+++ b/druid/Dockerfile
@@ -30,8 +30,9 @@ RUN curl --fail -L "https://repo.stackable.tech/repository/packages/druid/apache
     mvn clean install -Pdist -DskipTests -Dmaven.javadoc.skip=true && \
     tar -xzf /stackable/apache-druid-${PRODUCT}-src/distribution/target/apache-druid-${PRODUCT}-bin.tar.gz && \
     mv /stackable/apache-druid-${PRODUCT}-src/apache-druid-${PRODUCT} /stackable/apache-druid-${PRODUCT} && \
-    rm -rf /stackable/apache-druid-${PRODUCT}-src \
-    /stackable/apache-druid-${PRODUCT}/quickstart
+    rm -rf /stackable/apache-druid-${PRODUCT}-src
+# Do not remove the /stackable/apache-druid-${PRODUCT}/quickstart folder, it is needed for loading the Wikipedia
+# testdate in kuttl tests and the getting started guide.
 
     # Install the Prometheus emitter extension. This bundle contains the emitter and all jar dependencies.
 RUN curl --fail "https://repo.stackable.tech/repository/packages/druid/druid-prometheus-emitter-${PRODUCT}.tar.gz" | tar -xzC /stackable/apache-druid-${PRODUCT}/extensions && \


### PR DESCRIPTION
# Description

With the merge of https://github.com/stackabletech/docker-images/pull/684 integration tests started failing.
This is due to error message below.

Did not run the integration tests for this change as the images build forever and the fix seems straight forward.

```
2024-05-27T08:20:12,366 ERROR [task-runner-0-priority-0] org.apache.druid.indexing.common.task.IndexTask - Encountered exception in DETERMINE_PARTITIONS.
java.io.UncheckedIOException: /stackable/apache-druid-28.0.1/quickstart/tutorial
	at org.apache.commons.io.FileUtils.listFiles(FileUtils.java:2135) ~[commons-io-2.11.0.jar:2.11.0]
	at org.apache.commons.io.FileUtils.iterateFiles(FileUtils.java:1904) ~[commons-io-2.11.0.jar:2.11.0]
	at org.apache.druid.data.input.impl.LocalInputSource.getDirectoryListingIterator(LocalInputSource.java:204) ~[druid-processing-28.0.1.jar:28.0.1]
	at org.apache.druid.data.input.impl.LocalInputSource.getFileIterator(LocalInputSource.java:181) ~[druid-processing-28.0.1.jar:28.0.1]
	at org.apache.druid.data.input.impl.LocalInputSource.formattableReader(LocalInputSource.java:250) ~[druid-processing-28.0.1.jar:28.0.1]
	at org.apache.druid.data.input.AbstractInputSource.reader(AbstractInputSource.java:42) ~[druid-processing-28.0.1.jar:28.0.1]
	at org.apache.druid.indexing.common.task.AbstractBatchIndexTask.inputSourceReader(AbstractBatchIndexTask.java:215) ~[druid-indexing-service-28.0.1.jar:28.0.1]
	at org.apache.druid.indexing.common.task.IndexTask.collectIntervalsAndShardSpecs(IndexTask.java:784) ~[druid-indexing-service-28.0.1.jar:28.0.1]
	at org.apache.druid.indexing.common.task.IndexTask.createShardSpecsFromInput(IndexTask.java:708) ~[druid-indexing-service-28.0.1.jar:28.0.1]
	at org.apache.druid.indexing.common.task.IndexTask.determineShardSpecs(IndexTask.java:671) ~[druid-indexing-service-28.0.1.jar:28.0.1]
	at org.apache.druid.indexing.common.task.IndexTask.runTask(IndexTask.java:516) ~[druid-indexing-service-28.0.1.jar:28.0.1]
	at org.apache.druid.indexing.common.task.AbstractTask.run(AbstractTask.java:178) ~[druid-indexing-service-28.0.1.jar:28.0.1]
	at org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTask.runSequential(ParallelIndexSupervisorTask.java:1212) ~[druid-indexing-service-28.0.1.jar:28.0.1]
	at org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTask.runTask(ParallelIndexSupervisorTask.java:551) ~[druid-indexing-service-28.0.1.jar:28.0.1]
	at org.apache.druid.indexing.common.task.AbstractTask.run(AbstractTask.java:178) ~[druid-indexing-service-28.0.1.jar:28.0.1]
	at org.apache.druid.indexing.overlord.SingleTaskBackgroundRunner$SingleTaskBackgroundRunnerCallable.call(SingleTaskBackgroundRunner.java:478) ~[druid-indexing-service-28.0.1.jar:28.0.1]
	at org.apache.druid.indexing.overlord.SingleTaskBackgroundRunner$SingleTaskBackgroundRunnerCallable.call(SingleTaskBackgroundRunner.java:450) ~[druid-indexing-service-28.0.1.jar:28.0.1]
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:131) ~[guava-31.1-jre.jar:?]
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:74) ~[guava-31.1-jre.jar:?]
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:82) ~[guava-31.1-jre.jar:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
Caused by: java.nio.file.NoSuchFileException: /stackable/apache-druid-28.0.1/quickstart/tutorial
	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:92) ~[?:?]
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111) ~[?:?]
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116) ~[?:?]
	at sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:55) ~[?:?]
	at sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:149) ~[?:?]
	at sun.nio.fs.LinuxFileSystemProvider.readAttributes(LinuxFileSystemProvider.java:99) ~[?:?]
	at java.nio.file.Files.readAttributes(Files.java:1764) ~[?:?]
	at java.nio.file.FileTreeWalker.getAttributes(FileTreeWalker.java:219) ~[?:?]
	at java.nio.file.FileTreeWalker.visit(FileTreeWalker.java:276) ~[?:?]
	at java.nio.file.FileTreeWalker.walk(FileTreeWalker.java:322) ~[?:?]
	at java.nio.file.Files.walkFileTree(Files.java:2717) ~[?:?]
	at org.apache.commons.io.FileUtils.listAccumulate(FileUtils.java:2076) ~[commons-io-2.11.0.jar:2.11.0]
	at org.apache.commons.io.FileUtils.listFiles(FileUtils.java:2132) ~[commons-io-2.11.0.jar:2.11.0]
	... 22 more
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
