### PR TITLE
Switching to ubicloud arm runner

### DIFF
--- a/.actionlint.yaml
+++ b/.actionlint.yaml
@@ -1,0 +1,5 @@
+---
+self-hosted-runner:
+  # Ubicloud machines we are using
+  labels:
+    - ubicloud-standard-8-arm

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -19,7 +19,7 @@ jobs:
       # This setting can be changed to throttle the build load
       # max-parallel: 1
       matrix:
-        runner: ["ubuntu-latest", "buildjet-4vcpu-ubuntu-2204-arm"]
+        runner: ["ubuntu-latest", "ubicloud-standard-8-arm"]
         product:
           - airflow
           - druid

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       # max-parallel: 1
       # If we want more parallelism we can schedule a dedicated task for every tuple (product, product version)
       matrix:
-        runner: ["ubuntu-latest", "buildjet-4vcpu-ubuntu-2204-arm"]
+        runner: ["ubuntu-latest", "ubicloud-standard-8-arm"]
         product:
           - airflow
           - druid

--- a/.github/workflows/ubi-rust-builder.yml
+++ b/.github/workflows/ubi-rust-builder.yml
@@ -15,7 +15,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        runner: ["ubuntu-latest", "buildjet-2vcpu-ubuntu-2204-arm"]
+        runner: ["ubuntu-latest", "ubicloud-standard-8-arm"]
         ubi-version: ["ubi8", "ubi9"]
     runs-on: ${{ matrix.runner }}
     steps:


### PR DESCRIPTION
# Description

Replaces BuildJet with UbiCloud arm runners.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
