### PR TITLE
Remove druid-ranger-security extension from Druid image

### DIFF
--- a/druid/Dockerfile
+++ b/druid/Dockerfile
@@ -23,10 +23,12 @@ RUN microdnf update && \
     rm -rf /var/cache/yum && \
     # pyyaml is required for the compile Druid
     pip install --no-cache-dir pyyaml==6.0.1
+
+USER stackable
 WORKDIR /stackable
 
-COPY druid/stackable/patches/apply_patches.sh /stackable/apache-druid-${PRODUCT}-src/patches/apply_patches.sh
-COPY druid/stackable/patches/${PRODUCT} /stackable/apache-druid-${PRODUCT}-src/patches/${PRODUCT}
+COPY --chown=stackable:stackable druid/stackable/patches/apply_patches.sh /stackable/apache-druid-${PRODUCT}-src/patches/apply_patches.sh
+COPY --chown=stackable:stackable druid/stackable/patches/${PRODUCT} /stackable/apache-druid-${PRODUCT}-src/patches/${PRODUCT}
 
 RUN curl --fail -L "https://repo.stackable.tech/repository/packages/druid/apache-druid-${PRODUCT}-src.tar.gz" | tar -xzC . && \
     cd apache-druid-${PRODUCT}-src && \

--- a/druid/Dockerfile
+++ b/druid/Dockerfile
@@ -37,8 +37,6 @@ RUN curl --fail -L "https://repo.stackable.tech/repository/packages/druid/apache
     tar -xzf /stackable/apache-druid-${PRODUCT}-src/distribution/target/apache-druid-${PRODUCT}-bin.tar.gz && \
     mv /stackable/apache-druid-${PRODUCT}-src/apache-druid-${PRODUCT} /stackable/apache-druid-${PRODUCT} && \
     rm -rf /stackable/apache-druid-${PRODUCT}-src
-# Do not remove the /stackable/apache-druid-${PRODUCT}/quickstart folder, it is needed for loading the Wikipedia
-# testdata in kuttl tests and the getting started guide.
 
     # Install the Prometheus emitter extension. This bundle contains the emitter and all jar dependencies.
 RUN curl --fail "https://repo.stackable.tech/repository/packages/druid/druid-prometheus-emitter-${PRODUCT}.tar.gz" | tar -xzC /stackable/apache-druid-${PRODUCT}/extensions && \

--- a/druid/Dockerfile
+++ b/druid/Dockerfile
@@ -16,18 +16,22 @@ ARG AUTHORIZER
 RUN microdnf update && \
     microdnf install \
     # Required to install pyyaml
-    python-pip && \
+    python-pip \
+    # Required to patch druid
+    patch && \
     microdnf clean all && \
     rm -rf /var/cache/yum && \
     # pyyaml is required for the compile Druid
     pip install --no-cache-dir pyyaml==6.0.1
-
-USER stackable
 WORKDIR /stackable
+
+COPY druid/stackable/patches/apply_patches.sh /stackable/apache-druid-${PRODUCT}-src/patches/apply_patches.sh
+COPY druid/stackable/patches/${PRODUCT} /stackable/apache-druid-${PRODUCT}-src/patches/${PRODUCT}
 
 RUN curl --fail -L "https://repo.stackable.tech/repository/packages/druid/apache-druid-${PRODUCT}-src.tar.gz" | tar -xzC . && \
     cd apache-druid-${PRODUCT}-src && \
-    mvn clean install -Pdist -DskipTests -Dmaven.javadoc.skip=true && \
+    ./patches/apply_patches.sh ${PRODUCT} && \
+    mvn clean install -Pdist -pl '!extensions-core/druid-ranger-security' -DskipTests -Dmaven.javadoc.skip=true && \
     tar -xzf /stackable/apache-druid-${PRODUCT}-src/distribution/target/apache-druid-${PRODUCT}-bin.tar.gz && \
     mv /stackable/apache-druid-${PRODUCT}-src/apache-druid-${PRODUCT} /stackable/apache-druid-${PRODUCT} && \
     rm -rf /stackable/apache-druid-${PRODUCT}-src

--- a/druid/Dockerfile
+++ b/druid/Dockerfile
@@ -37,6 +37,8 @@ RUN curl --fail -L "https://repo.stackable.tech/repository/packages/druid/apache
     tar -xzf /stackable/apache-druid-${PRODUCT}-src/distribution/target/apache-druid-${PRODUCT}-bin.tar.gz && \
     mv /stackable/apache-druid-${PRODUCT}-src/apache-druid-${PRODUCT} /stackable/apache-druid-${PRODUCT} && \
     rm -rf /stackable/apache-druid-${PRODUCT}-src
+    #  Do not remove the /stackable/apache-druid-${PRODUCT}/quickstart folder, it is needed for loading the Wikipedia
+    # testdata in kuttl tests and the getting started guide.
 
     # Install the Prometheus emitter extension. This bundle contains the emitter and all jar dependencies.
 RUN curl --fail "https://repo.stackable.tech/repository/packages/druid/druid-prometheus-emitter-${PRODUCT}.tar.gz" | tar -xzC /stackable/apache-druid-${PRODUCT}/extensions && \

--- a/druid/stackable/patches/26.0.0/001-remove-druid-ranger-security.patch
+++ b/druid/stackable/patches/26.0.0/001-remove-druid-ranger-security.patch
@@ -1,0 +1,13 @@
+diff --git a/distribution/pom.xml b/distribution/pom.xml
+index 14013a7a5f..58fd00009e 100644
+--- a/distribution/pom.xml
++++ b/distribution/pom.xml
+@@ -252,8 +252,6 @@
+                                         <argument>-c</argument>
+                                         <argument>org.apache.druid.extensions:druid-pac4j</argument>
+                                         <argument>-c</argument>
+-                                        <argument>org.apache.druid.extensions:druid-ranger-security</argument>
+-                                        <argument>-c</argument>
+                                         <argument>org.apache.druid.extensions:druid-kubernetes-extensions</argument>
+                                         <argument>-c</argument>
+                                         <argument>org.apache.druid.extensions:druid-catalog</argument>

--- a/druid/stackable/patches/27.0.0/001-remove-druid-ranger-security.patch
+++ b/druid/stackable/patches/27.0.0/001-remove-druid-ranger-security.patch
@@ -1,0 +1,13 @@
+diff --git a/distribution/pom.xml b/distribution/pom.xml
+index 14013a7a5f..58fd00009e 100644
+--- a/distribution/pom.xml
++++ b/distribution/pom.xml
+@@ -252,8 +252,6 @@
+                                         <argument>-c</argument>
+                                         <argument>org.apache.druid.extensions:druid-pac4j</argument>
+                                         <argument>-c</argument>
+-                                        <argument>org.apache.druid.extensions:druid-ranger-security</argument>
+-                                        <argument>-c</argument>
+                                         <argument>org.apache.druid.extensions:druid-kubernetes-extensions</argument>
+                                         <argument>-c</argument>
+                                         <argument>org.apache.druid.extensions:druid-catalog</argument>

--- a/druid/stackable/patches/28.0.1/001-remove-druid-ranger-security.patch
+++ b/druid/stackable/patches/28.0.1/001-remove-druid-ranger-security.patch
@@ -1,0 +1,13 @@
+diff --git a/distribution/pom.xml b/distribution/pom.xml
+index 14013a7a5f..58fd00009e 100644
+--- a/distribution/pom.xml
++++ b/distribution/pom.xml
+@@ -252,8 +252,6 @@
+                                         <argument>-c</argument>
+                                         <argument>org.apache.druid.extensions:druid-pac4j</argument>
+                                         <argument>-c</argument>
+-                                        <argument>org.apache.druid.extensions:druid-ranger-security</argument>
+-                                        <argument>-c</argument>
+                                         <argument>org.apache.druid.extensions:druid-kubernetes-extensions</argument>
+                                         <argument>-c</argument>
+                                         <argument>org.apache.druid.extensions:druid-catalog</argument>

--- a/druid/stackable/patches/apply_patches.sh
+++ b/druid/stackable/patches/apply_patches.sh
@@ -35,7 +35,7 @@ echo "Found ${#patch_files[@]} patches, applying now"
 for patch_file in "${patch_files[@]}"; do
   echo "Applying $patch_file"
   # We can not use Git here, as we are not within a Git repo
-  cat "$patch_file" | patch --directory "." --strip=1 || {
+  patch --directory "." --strip=1 < "$patch_file" || {
     echo "Failed to apply $patch_file"
     exit 1
   }

--- a/druid/stackable/patches/apply_patches.sh
+++ b/druid/stackable/patches/apply_patches.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Enable error handling and unset variable checking
+set -eu
+set -o pipefail
+
+# Check if $1 (VERSION) is provided
+if [ -z "${1-}" ]; then
+  echo "Please provide a value for VERSION as the first argument."
+  exit 1
+fi
+
+VERSION="$1"
+PATCH_DIR="patches/$VERSION"
+
+# Check if version-specific patches directory exists
+if [ ! -d "$PATCH_DIR" ]; then
+  echo "Patches directory '$PATCH_DIR' does not exist."
+  exit 1
+fi
+
+# Create an array to hold the patches in sorted order
+declare -a patch_files=()
+
+echo "Applying patches from ${PATCH_DIR}" now
+
+# Read the patch files into the array
+while IFS= read -r -d $'\0' file; do
+  patch_files+=("$file")
+done < <(find "$PATCH_DIR" -name "*.patch" -print0 | sort -zV)
+
+echo "Found ${#patch_files[@]} patches, applying now"
+
+# Iterate through sorted patch files
+for patch_file in "${patch_files[@]}"; do
+  echo "Applying $patch_file"
+  # We can not use Git here, as we are not within a Git repo
+  cat "$patch_file" | patch --directory "." --strip=1 || {
+    echo "Failed to apply $patch_file"
+    exit 1
+  }
+done
+
+echo "All patches applied successfully."


### PR DESCRIPTION
# Description

- Stop building the `druid-ranger-security` module
- Remove `druid-ranger-security` from the maven profile `dist` using a patch 

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
