### PR TITLE
Fix integration tests - Copy jmx broker config to builder image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
   image to the HBase image. The script `export-snapshot-to-s3` makes
   exporting easier ([#621]).
 - kafka: Build from source ([#659], [#661]).
+- kafka: Add jmx broker config to builder image ([#703]).
 - nifi: Build from source ([#678]).
 - omid: Include Apache Omid in all workflows such as building and releasing images ([#635]).
 - java-devel: New image to serve as base layer for builder stages ([#665]).
@@ -90,6 +91,7 @@ All notable changes to this project will be documented in this file.
 [#688]: https://github.com/stackabletech/docker-images/pull/688
 [#696]: https://github.com/stackabletech/docker-images/pull/696
 [#695]: https://github.com/stackabletech/docker-images/pull/695
+[#703]: https://github.com/stackabletech/docker-images/pull/703
 
 ## [24.3.0] - 2024-03-20
 

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -97,6 +97,8 @@ COPY --chown=stackable:stackable --from=kcat /stackable/kcat-${KCAT}/kcat /stack
 COPY --chown=stackable:stackable --from=kcat /licenses /licenses
 
 RUN ln -s /stackable/bin/kcat-${KCAT} /stackable/bin/kcat && \
+    # kcat was located in /stackable/kcat - legacy
+    ln -s /stackable/bin/kcat /stackable/kcat && \
     ln -s /stackable/kafka_${SCALA}-${PRODUCT} /stackable/kafka
 
 # ===

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -33,8 +33,8 @@ RUN curl --fail -L "https://repo.stackable.tech/repository/packages/kafka/kafka-
 RUN curl --fail -L https://repo.stackable.tech/repository/packages/kafka-opa-authorizer/opa-authorizer-${OPA_AUTHORIZER}-all.jar \
     -o /stackable/kafka_${SCALA}-${PRODUCT}/libs/opa-authorizer-${OPA_AUTHORIZER}-all.jar
 
-RUN mkdir -p /stackable/jmx/ && \
-    curl --fail -L https://repo.stackable.tech/repository/packages/jmx-exporter/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar \
+COPY --chown=stackable:stackable kafka/stackable/jmx/ /stackable/jmx/    
+RUN curl --fail -L https://repo.stackable.tech/repository/packages/jmx-exporter/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar \
     -o /stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar && \
     chmod +x /stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar && \
     ln -s /stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar /stackable/jmx/jmx_prometheus_javaagent.jar


### PR DESCRIPTION
# Description

This adds the jmx broker.config to the kafka builder image and adds a softlink for the kcat binary to the location the operator uses.

Kafka container did not come up due to:
```
kafka Caused by: java.io.FileNotFoundException: /stackable/jmx/broker.yaml (No such file or directory)
```

Kcat sidecar did not get ready due to wrong bin path, and did not output any logs...

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [x] Add an entry to the CHANGELOG.md file
- [x] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
