### PR TITLE
chore: change loglevel input format for opa process-logs script to uppercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file.
 - stackable-base: Mitigate CVE-2023-37920 by removing e-Tugra root certificates ([#673]).
 - hdfs: Exclude unused jars and mitigate snappy-java CVEs by bumping dependency ([#682]).
 - druid: Build from source ([#684], [#696]).
-- opa: Add log processing script to opa for decision logging ([#695]).
+- opa: Add log processing script to opa for decision logging ([#695], [#704]).
 
 ### Changed
 
@@ -92,6 +92,7 @@ All notable changes to this project will be documented in this file.
 [#696]: https://github.com/stackabletech/docker-images/pull/696
 [#695]: https://github.com/stackabletech/docker-images/pull/695
 [#703]: https://github.com/stackabletech/docker-images/pull/703
+[#704]: https://github.com/stackabletech/docker-images/pull/704
 
 ## [24.3.0] - 2024-03-20
 

--- a/opa/stackable/bin/process-logs
+++ b/opa/stackable/bin/process-logs
@@ -50,17 +50,17 @@ fi
 
 get_levels() {
     case $1 in
-        fatal)
+        FATAL)
             echo '["fatal"]' ;;
-        error)
+        ERROR)
             echo '["error","fatal"]' ;;
-        warn)
+        WARN)
             echo '["warn","error","fatal"]' ;;
-        info)
+        INFO)
             echo '["info","warn","error","fatal"]' ;;
-        debug)
+        DEBUG)
             echo '["debug","info","warn","error","fatal"]' ;;
-        trace)
+        TRACE)
             echo '["trace","debug","info","warn","error","fatal"]' ;;
         *)
             echo '[]' ;;


### PR DESCRIPTION
# Description

Change log level input format for opa `process-logs` script to uppercase to make it more consistent with the format in the OpaCluster CRD.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
