### PR TITLE
feat: Add config-utils to stackable-base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - hdfs: Exclude unused jars and mitigate snappy-java CVEs by bumping dependency ([#682]).
 - druid: Build from source ([#684], [#696]).
 - opa: Add log processing script to opa for decision logging ([#695], [#704]).
+- stackable-base: Add [config-utils](https://github.com/stackabletech/config-utils) ([#XXX]).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to this project will be documented in this file.
 - hdfs: Exclude unused jars and mitigate snappy-java CVEs by bumping dependency ([#682]).
 - druid: Build from source ([#684], [#696]).
 - opa: Add log processing script to opa for decision logging ([#695], [#704]).
-- stackable-base: Add [config-utils](https://github.com/stackabletech/config-utils) ([#XXX]).
+- stackable-base: Add [config-utils](https://github.com/stackabletech/config-utils) ([#706]).
 
 ### Changed
 
@@ -94,6 +94,7 @@ All notable changes to this project will be documented in this file.
 [#695]: https://github.com/stackabletech/docker-images/pull/695
 [#703]: https://github.com/stackabletech/docker-images/pull/703
 [#704]: https://github.com/stackabletech/docker-images/pull/704
+[#706]: https://github.com/stackabletech/docker-images/pull/706
 
 ## [24.3.0] - 2024-03-20
 

--- a/stackable-base/Dockerfile
+++ b/stackable-base/Dockerfile
@@ -4,7 +4,24 @@
 # https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5?image=6633b5136d81a5634a616c41&architecture=amd64
 
 # Manifest list digest because of multi architecture builds ( https://www.redhat.com/architect/pull-container-image#:~:text=A%20manifest%20list%20exists%20to,system%20on%20a%20specific%20architecture )
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:2636170dc55a0931d013014a72ae26c0c2521d4b61a28354b3e2e5369fa335a3 AS builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:2636170dc55a0931d013014a72ae26c0c2521d4b61a28354b3e2e5369fa335a3 AS product-utils-builder
+
+ARG CONFIG_UTILS_VERSION=main
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+RUN microdnf update --assumeyes && \
+    microdnf --assumeyes install \
+    # Needed to fetch source
+    git \
+    # Needed for compilation
+    gcc
+
+RUN git clone --depth 1 --branch ${CONFIG_UTILS_VERSION} https://github.com/stackabletech/config-utils
+RUN cd ./config-utils && . $HOME/.cargo/env && cargo build --release
+
+# Manifest list digest because of multi architecture builds ( https://www.redhat.com/architect/pull-container-image#:~:text=A%20manifest%20list%20exists%20to,system%20on%20a%20specific%20architecture )
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:2636170dc55a0931d013014a72ae26c0c2521d4b61a28354b3e2e5369fa335a3 AS final
 
 # intentionally unused
 ARG PRODUCT
@@ -84,3 +101,6 @@ RUN update-ca-trust && \
     echo "Still found E-Tugra root certificates, this should not happen!" && \
     exit 1; \
   fi
+
+COPY --from=product-utils-builder --chown=stackable:stackable /config-utils/target/release/config-utils /stackable/config-utils
+ENV PATH "${PATH}:/stackable"

--- a/stackable-base/Dockerfile
+++ b/stackable-base/Dockerfile
@@ -7,7 +7,7 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:a7d837b00520a32502ada85ae339e33510cdfdbc8d2ddf460cc838e12ec5fa5a AS product-utils-builder
 
 ENV CONFIG_UTILS_VERSION=0.1.0
-# This SHOULD to be kept in sync with operator-templating and other tools to reduce build times
+# This SHOULD be kept in sync with operator-templating and other tools to reduce build times
 ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.78.0
 ENV CARGO_CYCLONEDX_CRATE_VERSION=0.5.3
 ENV CARGO_AUDITABLE_CRATE_VERSION=0.6.4

--- a/stackable-base/Dockerfile
+++ b/stackable-base/Dockerfile
@@ -13,7 +13,8 @@ RUN microdnf update --assumeyes && \
     # Needed to fetch source
     git \
     # Needed for compilation
-    gcc
+    gcc && \
+    microdnf clean all
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.78.0 && \
     . "$HOME/.cargo/env" && cargo install cargo-cyclonedx@0.4.0 cargo-auditable@0.6.2

--- a/stackable-base/Dockerfile
+++ b/stackable-base/Dockerfile
@@ -6,7 +6,14 @@
 # Manifest list digest because of multi architecture builds ( https://www.redhat.com/architect/pull-container-image#:~:text=A%20manifest%20list%20exists%20to,system%20on%20a%20specific%20architecture )
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:a7d837b00520a32502ada85ae339e33510cdfdbc8d2ddf460cc838e12ec5fa5a AS product-utils-builder
 
-ARG CONFIG_UTILS_VERSION=0.1.0
+# renovate: datasource=github-tags packageName=stackabletech/config-utils
+ENV CONFIG_UTILS_VERSION=0.1.0
+# This SHOULD to be kept in sync with operator-templating and other tools to reduce build times
+ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.78.0
+# renovate: datasource=crate packageName=cargo-cyclonedx
+ENV CARGO_CYCLONEDX_CRATE_VERSION=0.5.3
+# renovate: datasource=crate packageName=cargo-auditable
+ENV CARGO_AUDITABLE_CRATE_VERSION=0.6.4
 
 RUN microdnf update --assumeyes && \
     microdnf --assumeyes install \
@@ -16,13 +23,13 @@ RUN microdnf update --assumeyes && \
     gcc && \
     microdnf clean all
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.78.0 && \
-    . "$HOME/.cargo/env" && cargo install cargo-cyclonedx@0.4.0 cargo-auditable@0.6.2
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUST_DEFAULT_TOOLCHAIN_VERSION && \
+    . "$HOME/.cargo/env" && cargo install cargo-cyclonedx@$CARGO_CYCLONEDX_CRATE_VERSION cargo-auditable@$CARGO_AUDITABLE_CRATE_VERSION
 
 RUN git clone --depth 1 --branch ${CONFIG_UTILS_VERSION} https://github.com/stackabletech/config-utils
 RUN cd ./config-utils && \
     . $HOME/.cargo/env && \
-    cargo auditable build --release && cargo cyclonedx --output-pattern package --all --output-cdx
+    cargo auditable build --release && cargo cyclonedx --all --format xml
 
 # Manifest list digest because of multi architecture builds ( https://www.redhat.com/architect/pull-container-image#:~:text=A%20manifest%20list%20exists%20to,system%20on%20a%20specific%20architecture )
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:a7d837b00520a32502ada85ae339e33510cdfdbc8d2ddf460cc838e12ec5fa5a AS final

--- a/stackable-base/Dockerfile
+++ b/stackable-base/Dockerfile
@@ -9,7 +9,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:a7d837b00520a32502ada85a
 ENV CONFIG_UTILS_VERSION=0.1.0
 # This SHOULD be kept in sync with operator-templating and other tools to reduce build times
 ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.78.0
-ENV CARGO_CYCLONEDX_CRATE_VERSION=0.5.3
+ENV CARGO_CYCLONEDX_CRATE_VERSION=0.4.0
 ENV CARGO_AUDITABLE_CRATE_VERSION=0.6.4
 
 RUN microdnf update --assumeyes && \
@@ -26,7 +26,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --de
 RUN git clone --depth 1 --branch ${CONFIG_UTILS_VERSION} https://github.com/stackabletech/config-utils
 RUN cd ./config-utils && \
     . $HOME/.cargo/env && \
-    cargo auditable build --release && cargo cyclonedx --all --format xml
+    cargo auditable build --release && cargo cyclonedx --output-pattern package --all --output-cdx
 
 # Manifest list digest because of multi architecture builds ( https://www.redhat.com/architect/pull-container-image#:~:text=A%20manifest%20list%20exists%20to,system%20on%20a%20specific%20architecture )
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:a7d837b00520a32502ada85ae339e33510cdfdbc8d2ddf460cc838e12ec5fa5a AS final

--- a/stackable-base/Dockerfile
+++ b/stackable-base/Dockerfile
@@ -17,8 +17,13 @@ RUN microdnf update --assumeyes && \
     # Needed for compilation
     gcc
 
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.78.0 && \
+    . "$HOME/.cargo/env" && cargo install cargo-cyclonedx@0.4.0 cargo-auditable@0.6.2
+
 RUN git clone --depth 1 --branch ${CONFIG_UTILS_VERSION} https://github.com/stackabletech/config-utils
-RUN cd ./config-utils && . $HOME/.cargo/env && cargo build --release
+RUN cd ./config-utils && \
+    . $HOME/.cargo/env && \
+    cargo auditable build --release && cargo cyclonedx --output-pattern package --all --output-cdx
 
 # Manifest list digest because of multi architecture builds ( https://www.redhat.com/architect/pull-container-image#:~:text=A%20manifest%20list%20exists%20to,system%20on%20a%20specific%20architecture )
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:2636170dc55a0931d013014a72ae26c0c2521d4b61a28354b3e2e5369fa335a3 AS final
@@ -103,4 +108,5 @@ RUN update-ca-trust && \
   fi
 
 COPY --from=product-utils-builder --chown=stackable:stackable /config-utils/target/release/config-utils /stackable/config-utils
+COPY --from=product-utils-builder --chown=stackable:stackable /config-utils/config-utils.cdx.xml /stackable/config-utils.cdx.xml
 ENV PATH "${PATH}:/stackable"

--- a/stackable-base/Dockerfile
+++ b/stackable-base/Dockerfile
@@ -6,13 +6,10 @@
 # Manifest list digest because of multi architecture builds ( https://www.redhat.com/architect/pull-container-image#:~:text=A%20manifest%20list%20exists%20to,system%20on%20a%20specific%20architecture )
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:a7d837b00520a32502ada85ae339e33510cdfdbc8d2ddf460cc838e12ec5fa5a AS product-utils-builder
 
-# renovate: datasource=github-tags packageName=stackabletech/config-utils
 ENV CONFIG_UTILS_VERSION=0.1.0
 # This SHOULD to be kept in sync with operator-templating and other tools to reduce build times
 ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.78.0
-# renovate: datasource=crate packageName=cargo-cyclonedx
 ENV CARGO_CYCLONEDX_CRATE_VERSION=0.5.3
-# renovate: datasource=crate packageName=cargo-auditable
 ENV CARGO_AUDITABLE_CRATE_VERSION=0.6.4
 
 RUN microdnf update --assumeyes && \

--- a/stackable-base/Dockerfile
+++ b/stackable-base/Dockerfile
@@ -6,7 +6,7 @@
 # Manifest list digest because of multi architecture builds ( https://www.redhat.com/architect/pull-container-image#:~:text=A%20manifest%20list%20exists%20to,system%20on%20a%20specific%20architecture )
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:a7d837b00520a32502ada85ae339e33510cdfdbc8d2ddf460cc838e12ec5fa5a AS product-utils-builder
 
-ARG CONFIG_UTILS_VERSION=main
+ARG CONFIG_UTILS_VERSION=0.1.0
 
 RUN microdnf update --assumeyes && \
     microdnf --assumeyes install \

--- a/stackable-base/Dockerfile
+++ b/stackable-base/Dockerfile
@@ -8,8 +8,6 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:2636170dc55a0931d013014a
 
 ARG CONFIG_UTILS_VERSION=main
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-
 RUN microdnf update --assumeyes && \
     microdnf --assumeyes install \
     # Needed to fetch source

--- a/ubi8-rust-builder/Dockerfile
+++ b/ubi8-rust-builder/Dockerfile
@@ -16,7 +16,7 @@ LABEL maintainer="Stackable GmbH"
 ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.77.2
 ENV CARGO_CYCLONEDX_CRATE_VERSION=0.5.3
 ENV CARGO_AUDITABLE_CRATE_VERSION=0.6.4
-ENV PROTOC_VERSION=26.1
+ENV PROTOC_VERSION=27.1
 
 # Sets the default shell to Bash with strict error handling and robust pipeline processing.
 # "-e": Exits immediately if a command exits with a non-zero status

--- a/ubi8-rust-builder/Dockerfile
+++ b/ubi8-rust-builder/Dockerfile
@@ -12,7 +12,7 @@ FROM registry.access.redhat.com/ubi8-minimal@sha256:5f1cd3422d5d46aea35dac80825d
 
 LABEL maintainer="Stackable GmbH"
 
-# This SHOULD to be kept in sync with operator-templating and other tools to reduce build times
+# This SHOULD be kept in sync with operator-templating and other tools to reduce build times
 ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.77.2
 ENV CARGO_CYCLONEDX_CRATE_VERSION=0.5.3
 ENV CARGO_AUDITABLE_CRATE_VERSION=0.6.4

--- a/ubi8-rust-builder/Dockerfile
+++ b/ubi8-rust-builder/Dockerfile
@@ -14,7 +14,7 @@ LABEL maintainer="Stackable GmbH"
 
 # This SHOULD be kept in sync with operator-templating and other tools to reduce build times
 ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.77.2
-ENV CARGO_CYCLONEDX_CRATE_VERSION=0.5.3
+ENV CARGO_CYCLONEDX_CRATE_VERSION=0.4.0
 ENV CARGO_AUDITABLE_CRATE_VERSION=0.6.4
 ENV PROTOC_VERSION=27.1
 
@@ -83,7 +83,7 @@ ONBUILD WORKDIR /src
 ONBUILD COPY . /src
 
 # hadolint ignore=SC1091
-ONBUILD RUN . "$HOME/.cargo/env" && cargo auditable build --release --workspace && cargo cyclonedx --all --format xml
+ONBUILD RUN . "$HOME/.cargo/env" && cargo auditable build --release --workspace && cargo cyclonedx --output-pattern package --all --output-cdx
 
 # Copy the "interesting" files into /app.
 ONBUILD RUN find /src/target/release \

--- a/ubi8-rust-builder/Dockerfile
+++ b/ubi8-rust-builder/Dockerfile
@@ -12,6 +12,12 @@ FROM registry.access.redhat.com/ubi8-minimal@sha256:5f1cd3422d5d46aea35dac80825d
 
 LABEL maintainer="Stackable GmbH"
 
+# This SHOULD to be kept in sync with operator-templating and other tools to reduce build times
+ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.77.2
+ENV CARGO_CYCLONEDX_CRATE_VERSION=0.5.3
+ENV CARGO_AUDITABLE_CRATE_VERSION=0.6.4
+ENV PROTOC_VERSION=26.1
+
 # Sets the default shell to Bash with strict error handling and robust pipeline processing.
 # "-e": Exits immediately if a command exits with a non-zero status
 # "-u": Treats unset variables as an error, preventing unexpected behavior from undefined variables.
@@ -54,8 +60,7 @@ RUN microdnf update \
 WORKDIR /opt/protoc
 # Prost does not document which version of protoc it expects (https://docs.rs/prost-build/0.12.4/prost_build/), so this should be the latest upstream version
 # (within reason).
-RUN PROTOC_VERSION=26.1 \
-  ARCH=$(arch | sed 's/^aarch64$/aarch_64/') \
+RUN ARCH=$(arch | sed 's/^aarch64$/aarch_64/') \
   && curl --location --output protoc.zip "https://repo.stackable.tech/repository/packages/protoc/protoc-${PROTOC_VERSION}-linux-${ARCH}.zip" \
   && unzip protoc.zip \
   && rm protoc.zip
@@ -66,8 +71,8 @@ WORKDIR /
 # If you change the toolchain version here, make sure to also change the "rust_version"
 # property in operator-templating/config/rust.yaml
 # hadolint ignore=SC1091
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.77.2 \
- && . "$HOME/.cargo/env" && cargo install cargo-cyclonedx@0.4.0 cargo-auditable@0.6.2
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUST_DEFAULT_TOOLCHAIN_VERSION \
+ && . "$HOME/.cargo/env" && cargo install cargo-cyclonedx@$CARGO_CYCLONEDX_CRATE_VERSION cargo-auditable@$CARGO_AUDITABLE_CRATE_VERSION
 
 # Build artifacts will be available in /app.
 RUN mkdir /app
@@ -78,7 +83,7 @@ ONBUILD WORKDIR /src
 ONBUILD COPY . /src
 
 # hadolint ignore=SC1091
-ONBUILD RUN . "$HOME/.cargo/env" && cargo auditable build --release --workspace && cargo cyclonedx --output-pattern package --all --output-cdx
+ONBUILD RUN . "$HOME/.cargo/env" && cargo auditable build --release --workspace && cargo cyclonedx --all --format xml
 
 # Copy the "interesting" files into /app.
 ONBUILD RUN find /src/target/release \

--- a/ubi9-rust-builder/Dockerfile
+++ b/ubi9-rust-builder/Dockerfile
@@ -11,7 +11,7 @@ LABEL maintainer="Stackable GmbH"
 
 # This SHOULD to be kept in sync with operator-templating and other tools to reduce build times
 ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.77.2
-ENV CARGO_CYCLONEDX_CRATE_VERSION=0.5.3
+ENV CARGO_CYCLONEDX_CRATE_VERSION=0.4.0
 ENV CARGO_AUDITABLE_CRATE_VERSION=0.6.4
 ENV PROTOC_VERSION=27.1
 
@@ -82,7 +82,7 @@ ONBUILD WORKDIR /src
 ONBUILD COPY . /src
 
 # hadolint ignore=SC1091
-ONBUILD RUN . "$HOME/.cargo/env" && cargo auditable build --release --workspace && cargo cyclonedx --all --format xml
+ONBUILD RUN . "$HOME/.cargo/env" && cargo auditable build --release --workspace && cargo cyclonedx --output-pattern package --all --output-cdx
 
 # Copy the "interesting" files into /app.
 ONBUILD RUN find /src/target/release \

--- a/ubi9-rust-builder/Dockerfile
+++ b/ubi9-rust-builder/Dockerfile
@@ -9,6 +9,12 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:a7d837b00520a32502ada85a
 
 LABEL maintainer="Stackable GmbH"
 
+# This SHOULD to be kept in sync with operator-templating and other tools to reduce build times
+ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.77.2
+ENV CARGO_CYCLONEDX_CRATE_VERSION=0.5.3
+ENV CARGO_AUDITABLE_CRATE_VERSION=0.6.4
+ENV PROTOC_VERSION=26.1
+
 # Sets the default shell to Bash with strict error handling and robust pipeline processing.
 # "-e": Exits immediately if a command exits with a non-zero status
 # "-u": Treats unset variables as an error, preventing unexpected behavior from undefined variables.
@@ -53,8 +59,7 @@ RUN microdnf update \
 WORKDIR /opt/protoc
 # Prost does not document which version of protoc it expects (https://docs.rs/prost-build/0.12.4/prost_build/), so this should be the latest upstream version
 # (within reason).
-RUN PROTOC_VERSION=26.1 \
-  ARCH=$(arch | sed 's/^aarch64$/aarch_64/') \
+RUN ARCH=$(arch | sed 's/^aarch64$/aarch_64/') \
   && curl --location --output protoc.zip "https://repo.stackable.tech/repository/packages/protoc/protoc-${PROTOC_VERSION}-linux-${ARCH}.zip" \
   && unzip protoc.zip \
   && rm protoc.zip
@@ -65,8 +70,8 @@ WORKDIR /
 # If you change the toolchain version here, make sure to also change the "rust_version"
 # property in operator-templating/config/rust.yaml
 # hadolint ignore=SC1091
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.77.2 \
- && . "$HOME/.cargo/env" && cargo install cargo-cyclonedx@0.4.0 cargo-auditable@0.6.2
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUST_DEFAULT_TOOLCHAIN_VERSION \
+&& . "$HOME/.cargo/env" && cargo install cargo-cyclonedx@$CARGO_CYCLONEDX_CRATE_VERSION cargo-auditable@$CARGO_AUDITABLE_CRATE_VERSION
 
 # Build artifacts will be available in /app.
 RUN mkdir /app
@@ -77,7 +82,7 @@ ONBUILD WORKDIR /src
 ONBUILD COPY . /src
 
 # hadolint ignore=SC1091
-ONBUILD RUN . "$HOME/.cargo/env" && cargo auditable build --release --workspace && cargo cyclonedx --output-pattern package --all --output-cdx
+ONBUILD RUN . "$HOME/.cargo/env" && cargo auditable build --release --workspace && cargo cyclonedx --all --format xml
 
 # Copy the "interesting" files into /app.
 ONBUILD RUN find /src/target/release \

--- a/ubi9-rust-builder/Dockerfile
+++ b/ubi9-rust-builder/Dockerfile
@@ -13,7 +13,7 @@ LABEL maintainer="Stackable GmbH"
 ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.77.2
 ENV CARGO_CYCLONEDX_CRATE_VERSION=0.5.3
 ENV CARGO_AUDITABLE_CRATE_VERSION=0.6.4
-ENV PROTOC_VERSION=26.1
+ENV PROTOC_VERSION=27.1
 
 # Sets the default shell to Bash with strict error handling and robust pipeline processing.
 # "-e": Exits immediately if a command exits with a non-zero status


### PR DESCRIPTION
# Description

We use `cargo cyclonedx` to place the SBOM alongside the binary, similar to what we do with the operators

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
