### PR TITLE
Change the dev workflow so that manifest lists are built and pushed immediately

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       # There is value to see which builds are working and which are actually broken
-      # The images will be pushed, but the (effective) manifest-list is only updated when *all* builds succeed.
       fail-fast: false
       # This setting can be changed to throttle the build load
       # max-parallel: 1
@@ -41,7 +40,7 @@ jobs:
           - zookeeper
         shard_count:
           - 5
-        shard_index: [0, 1, 2, 3, 4] # between 0 and shard_count-1
+        shard_index: [0, 1, 2, 3, 4]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
@@ -62,7 +61,8 @@ jobs:
         uses: anchore/sbom-action/download-syft@e8d2a6937ecead383dfe75190d104edd1f9c5751 # v0.16.0
       - name: Install image-tools-stackabletech
         run: pip install image-tools-stackabletech==0.0.5
-      - uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
+      - name: Login to Stackable Nexus
+        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
         with:
           registry: docker.stackable.tech
           username: github
@@ -145,33 +145,13 @@ jobs:
               cosign attest -y --predicate sbom.merged.json --type cyclonedx "$IMAGE_NAME@$DIGEST"
             fi
           fi
-  create_manifests:
-    permissions:
-      id-token: write
-    runs-on: ubuntu-latest
-    needs: ["build_and_push"]
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
-        with:
-          registry: docker.stackable.tech
-          username: github
-          password: ${{ secrets.NEXUS_PASSWORD }}
-      - name: Login to Stackable Harbor
-        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
-        with:
-          registry: oci.stackable.tech
-          username: robot$sdp+github-action-build
-          password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
-      - name: Set up Cosign
-        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
       - name: Build Manifest List
         shell: bash
         env:
           DOCKER_USER: github
           DOCKER_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
         run: |
-          for product_and_version in $(python3 enumerate-product-versions.py); do
+          for product_and_version in $(python3 enumerate-product-versions.py ${{ matrix.product }}); do
             PRODUCT="$(echo "$product_and_version" | cut -d '#' -f 1)"
             VERSION="$(echo "$product_and_version" | cut -d '#' -f 2)"
 

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -40,7 +40,7 @@ jobs:
           - zookeeper
         shard_count:
           - 5
-        shard_index: [0, 1, 2, 3, 4]
+        shard_index: [0, 1, 2, 3, 4] # between 0 and shard_count-1
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0

--- a/enumerate-product-versions.py
+++ b/enumerate-product-versions.py
@@ -1,4 +1,5 @@
 import conf
+import sys
 
 PRODUCTS = [
     "airflow",
@@ -21,9 +22,18 @@ PRODUCTS = [
     "zookeeper",
 ]
 
+single_product = None
+if len(sys.argv) > 1:
+    single_product = sys.argv[1]
+    if single_product not in PRODUCTS:
+        print(f"Error: {single_product} is not a valid product.")
+        sys.exit(1)
+
 for product in conf.products:
     product_name = product['name']
     if product_name not in PRODUCTS:
+        continue
+    if single_product and product_name != single_product:
         continue
 
     for version in product['versions']:


### PR DESCRIPTION
# Description

Change the dev workflow so that manifest lists are built and pushed right after the images are built
If needed this can be split out even further to build every product version separately
