### PR TITLE
Move the Log4j ENV variable to the java-base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable changes to this project will be documented in this file.
 - opa: Build from source ([#676])
 - trino: Build from source ([#687]).
 - spark: Build from source ([#679])
+- all: Moved the LOG4J_FORMAT_MSG_NO_LOOKUPS env variable from the individual Dockerfiles to `java-base` and `java-devel` ([#727])
 
 ### Fixed
 
@@ -100,6 +101,7 @@ All notable changes to this project will be documented in this file.
 [#704]: https://github.com/stackabletech/docker-images/pull/704
 [#706]: https://github.com/stackabletech/docker-images/pull/706
 [#721]: https://github.com/stackabletech/docker-images/pull/721
+[#727]: https://github.com/stackabletech/docker-images/pull/727
 
 ## [24.3.0] - 2024-03-20
 

--- a/druid/Dockerfile
+++ b/druid/Dockerfile
@@ -101,11 +101,5 @@ RUN ln -s /stackable/apache-druid-${PRODUCT} /stackable/druid && \
 
 ENV PATH="${PATH}":/stackable/druid/bin
 
-# ===
-# Mitigation for CVE-2021-44228 (Log4Shell)
-# This variable is supported as of Log4j version 2.10 and
-# disables the vulnerable feature
-ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true
-
 WORKDIR /stackable/druid
 CMD ["bin/run-druid", "coordinator", "conf/druid/cluster/master/coordinator-overlord/"]

--- a/hadoop/Dockerfile
+++ b/hadoop/Dockerfile
@@ -65,12 +65,6 @@ RUN curl --fail -L "https://repo.stackable.tech/repository/packages/hadoop/hadoo
     cp hadoop-hdfs-project/hadoop-hdfs-native-client/target/main/native/fuse-dfs/fuse_dfs /stackable/hadoop-${PRODUCT}/bin && \
     rm -rf /stackable/hadoop-${PRODUCT}-src
 
-# ===
-# Mitigation for CVE-2021-44228 (Log4Shell)
-# This variable is supported as of Log4j version 2.10 and
-# disables the vulnerable feature
-ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true
-
 # For earlier versions this script removes the .class file that contains the
 # vulnerable code.
 # TODO: This can be restricted to target only versions which do not honor the environment

--- a/hbase/Dockerfile
+++ b/hbase/Dockerfile
@@ -167,10 +167,5 @@ ENV HOME=/stackable
 ENV PATH="${PATH}:/stackable/bin:/stackable/hbase/bin"
 ENV ASYNC_PROFILER_HOME=/stackable/async-profiler
 
-# Mitigation for CVE-2021-44228 (Log4Shell)
-# This variable is supported as of Log4j version 2.10 and
-# disables the vulnerable feature
-ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true
-
 WORKDIR /stackable/hbase
 CMD ["./bin/hbase", "master", "start" ]

--- a/hive/Dockerfile
+++ b/hive/Dockerfile
@@ -128,11 +128,6 @@ RUN ln -s /stackable/hadoop-${HADOOP}/ /stackable/hadoop
 COPY --chown=stackable:stackable --from=builder /stackable/jmx /stackable/jmx
 COPY hive/licenses /licenses
 
-# Mitigation for CVE-2021-44228 (Log4Shell)
-# This variable is supported as of Log4j version 2.10 and
-# disables the vulnerable feature
-ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true
-
 ENV HADOOP_HOME=/stackable/hadoop
 ENV HIVE_HOME=/stackable/hive-metastore
 ENV PATH="${PATH}":/stackable/hadoop/bin:/stackable/hive-metastore/bin

--- a/java-base/Dockerfile
+++ b/java-base/Dockerfile
@@ -42,3 +42,8 @@ ENV JAVA_HOME=/usr/lib/jvm/jre-${PRODUCT}
 # microdnf install java-${JAVA_VERSION}-openjdk-devel
 #
 ENV JAVA_VERSION=$PRODUCT
+
+# Mitigation for CVE-2021-44228 (Log4Shell)
+# This variable is supported as of Log4j version 2.10 and
+# disables the vulnerable feature
+ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true

--- a/java-devel/Dockerfile
+++ b/java-devel/Dockerfile
@@ -44,3 +44,7 @@ RUN microdnf update && \
 
 ENV JAVA_HOME=/usr/lib/jvm/jre-${PRODUCT}
 
+# Mitigation for CVE-2021-44228 (Log4Shell)
+# This variable is supported as of Log4j version 2.10 and
+# disables the vulnerable feature
+ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -33,7 +33,7 @@ RUN curl --fail -L "https://repo.stackable.tech/repository/packages/kafka/kafka-
 RUN curl --fail -L https://repo.stackable.tech/repository/packages/kafka-opa-authorizer/opa-authorizer-${OPA_AUTHORIZER}-all.jar \
     -o /stackable/kafka_${SCALA}-${PRODUCT}/libs/opa-authorizer-${OPA_AUTHORIZER}-all.jar
 
-COPY --chown=stackable:stackable kafka/stackable/jmx/ /stackable/jmx/    
+COPY --chown=stackable:stackable kafka/stackable/jmx/ /stackable/jmx/
 RUN curl --fail -L https://repo.stackable.tech/repository/packages/jmx-exporter/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar \
     -o /stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar && \
     chmod +x /stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar && \
@@ -100,12 +100,6 @@ RUN ln -s /stackable/bin/kcat-${KCAT} /stackable/bin/kcat && \
     # kcat was located in /stackable/kcat - legacy
     ln -s /stackable/bin/kcat /stackable/kcat && \
     ln -s /stackable/kafka_${SCALA}-${PRODUCT} /stackable/kafka
-
-# ===
-# Mitigation for CVE-2021-44228 (Log4Shell)
-# This variable is supported as of Log4j version 2.10 and
-# disables the vulnerable feature
-ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true
 
 ENV PATH="${PATH}:/stackable/bin:/stackable/kafka/bin"
 

--- a/nifi/Dockerfile
+++ b/nifi/Dockerfile
@@ -20,10 +20,10 @@ WORKDIR /stackable
 COPY --chown=stackable:stackable nifi/stackable/patches /stackable/patches
 
 # NOTE: NiFi 1.21.0 source build does not work with the current arm64 git runners due to java heap issues:
-#     
-# [ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:3.5.0:single (make shared resource) on project nifi-registry-assembly: 
+#
+# [ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:3.5.0:single (make shared resource) on project nifi-registry-assembly:
 # Failed to create assembly: Error creating assembly archive bin: Problem creating zip: Execution exception: Java heap space
-# 
+#
 # Since this will be deprecated in the release 24.7 and then removed we copy the NiFi 1.21.0 binaries instead
 # of building from source. The if condition can be removed once 1.21.0 is no longer supported and only the
 # else branch is required to build from source.
@@ -47,7 +47,7 @@ RUN if [[ "${PRODUCT}" == "1.21.0" ]] ; then \
         unzip "nifi-${PRODUCT}-source-release.zip" && \
         # Clean up downloaded source after unzipping
         rm -rf "nifi-${PRODUCT}-source-release.zip" && \
-        # The NiFi "binary" ends up in a folder named "nifi-${PRODUCT}" which should be copied to /stackable 
+        # The NiFi "binary" ends up in a folder named "nifi-${PRODUCT}" which should be copied to /stackable
         # from /stackable/nifi-${PRODUCT}-src/nifi-assembly/target/nifi-${PRODUCT}-bin/nifi-${PRODUCT} (see later steps)
         # Therefore we add the suffix "-src" to be able to copy the binary and remove the unzipped sources afterwards.
         mv nifi-${PRODUCT} nifi-${PRODUCT}-src && \
@@ -132,13 +132,6 @@ RUN ln -s /stackable/nifi-${PRODUCT} /stackable/nifi
 ENV HOME=/stackable
 ENV NIFI_HOME=/stackable/nifi
 ENV PATH="${PATH}":/stackable/nifi/bin
-
-# ===
-# Mitigation for CVE-2021-44228 (Log4Shell)
-# This variable is supported as of Log4j version 2.10 and
-# disables the vulnerable feature
-ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true
-# ===
 
 WORKDIR /stackable/nifi
 CMD ["bin/nifi.sh", "run"]

--- a/omid/Dockerfile
+++ b/omid/Dockerfile
@@ -20,11 +20,6 @@ RUN mvn package -Phbase-2 -DskipTests && \
     tar -xf examples/target/omid-examples-${PRODUCT}-bin.tar.gz -C /stackable
 
 # ===
-# Mitigation for CVE-2021-44228 (Log4Shell)
-# This variable is supported as of Log4j version 2.10 and
-# disables the vulnerable feature
-ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true
-
 # For earlier versions this script removes the .class file that contains the
 # vulnerable code.
 # TODO: This can be restricted to target only versions which do not honor the environment

--- a/spark-k8s/Dockerfile
+++ b/spark-k8s/Dockerfile
@@ -64,7 +64,7 @@ RUN curl -L --fail -O https://repo.stackable.tech/repository/packages/jackson-da
 
 WORKDIR /stackable/jmx
 
-RUN curl --fail -L -O "https://repo.stackable.tech/repository/packages/jmx-exporter/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar" 
+RUN curl --fail -L -O "https://repo.stackable.tech/repository/packages/jmx-exporter/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar"
 
 # ===
 # Mitigation for CVE-2021-44228 (Log4Shell)
@@ -128,11 +128,6 @@ ENV SPARK_HOME=/stackable/spark
 ENV PATH=$SPARK_HOME:$PATH:/bin:$JAVA_HOME/bin:$JAVA_HOME/jre/bin:$HOME/.local/bin
 ENV PYSPARK_PYTHON=/usr/bin/python
 ENV PYTHONPATH=$SPARK_HOME/python:$PYTHONPATH
-# This variable is supported as of Log4j version 2.10 and
-# disables the vulnerable feature
-ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true
-
-
 
 COPY --chown=stackable:stackable --from=builder /stackable/spark-${PRODUCT}/dist /stackable/spark
 COPY --chown=stackable:stackable --from=builder /stackable/jmx /stackable/jmx

--- a/trino/Dockerfile
+++ b/trino/Dockerfile
@@ -136,11 +136,5 @@ COPY --from=jmx-exporter-builder /stackable/jmx_prometheus-${JMX_EXPORTER}-src/j
 RUN ln -s /stackable/trino-server-${PRODUCT} /stackable/trino-server && \
     ln -s /stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar /stackable/jmx/jmx_prometheus_javaagent.jar
 
-# ===
-# Mitigation for CVE-2021-44228 (Log4Shell)
-# This variable is supported as of Log4j version 2.10 and
-# disables the vulnerable feature
-ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true
-
 WORKDIR /stackable/trino-server
 CMD ["bin/launcher", "run", "--etc-dir=/stackable/conf"]

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -94,11 +94,6 @@ COPY zookeeper/licenses /licenses
 # to preserve the folder name with the version.
 RUN ln -s /stackable/apache-zookeeper-${PRODUCT}-bin/ /stackable/zookeeper
 
-# Mitigation for CVE-2021-44228 (Log4Shell)
-# This variable is supported as of Log4j version 2.10 and
-# disables the vulnerable feature
-ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true
-
 ENV ZOOKEEPER_HOME=/stackable/zookeeper
 ENV PATH="${PATH}":/stackable/zookeeper/bin
 


### PR DESCRIPTION
# Description

ENV variables are inherited by images if they come from a parent image. This ENV variable disables the Log4j feature that caused CVE-2021-4428 (Log4Shell). Even though this probably has been disabled everywhere already it doesn't hurt to set this variable