### PR TITLE
Add the package util-linux to the OPA image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to this project will be documented in this file.
 - hdfs: Exclude unused jars and mitigate snappy-java CVEs by bumping dependency ([#682]).
 - druid: Build from source ([#684], [#696]).
 - opa: Add log processing script to opa for decision logging ([#695], [#704]).
+- opa: Add the package util-linux containing the command logger which
+  allows to enter messages into the system log ([#728]).
 - stackable-base: Add [config-utils](https://github.com/stackabletech/config-utils) ([#706]).
 - omid: Include Apache Omid Examples to simplify testing ([#721]).
 
@@ -102,6 +104,7 @@ All notable changes to this project will be documented in this file.
 [#706]: https://github.com/stackabletech/docker-images/pull/706
 [#721]: https://github.com/stackabletech/docker-images/pull/721
 [#727]: https://github.com/stackabletech/docker-images/pull/727
+[#728]: https://github.com/stackabletech/docker-images/pull/728
 
 ## [24.3.0] - 2024-03-20
 

--- a/opa/Dockerfile
+++ b/opa/Dockerfile
@@ -23,6 +23,10 @@ RUN microdnf update \
     pkg-config \
     systemd-devel \
     unzip \
+    # To add the command logger which allows to enter messages into the system log
+    # cpe:2.3:a:kernel:util-linux:*:*:*:*:*:*:*:*
+    # https://nvd.nist.gov/vuln/search/results?isCpeNameSearch=true&query=cpe%3A2.3%3Aa%3Akernel%3Autil-linux%3A*%3A*%3A*%3A*%3A*%3A*%3A*%3A*
+    util-linux \
   && rm -rf /var/cache/yum
 
 WORKDIR /


### PR DESCRIPTION
# Description

Add the package util-linux to the OPA image. It contains the command `logger` which allows to enter messages into the system log.

Net redirection (`> /dev/udp/<syslog-server>/514`) cannot be used because bash is not compiled with `--enable-net-redirections`.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
