### PR TITLE
Cleanup

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -63,15 +63,6 @@ products = [
                 "authorizer": "0.5.0",
             },
             {
-                "product": "27.0.0",
-                "java-base": "11",
-                "java-devel": "11",
-                "jackson_dataformat_xml": "2.10.5",
-                "stax2_api": "4.2.1",
-                "woodstox_core": "6.2.1",
-                "authorizer": "0.5.0",
-            },
-            {
                 "product": "28.0.1",
                 # Java 17 should be fully supported as of 27.0.0 https://github.com/apache/druid/releases#27.0.0-highlights-java-17-support
                 # Did not work in a quick test due to reflection error:

--- a/druid/Dockerfile
+++ b/druid/Dockerfile
@@ -36,7 +36,11 @@ RUN curl --fail -L "https://repo.stackable.tech/repository/packages/druid/apache
     mvn clean install -Pdist -pl '!extensions-core/druid-ranger-security' -DskipTests -Dmaven.javadoc.skip=true && \
     tar -xzf /stackable/apache-druid-${PRODUCT}-src/distribution/target/apache-druid-${PRODUCT}-bin.tar.gz && \
     mv /stackable/apache-druid-${PRODUCT}-src/apache-druid-${PRODUCT} /stackable/apache-druid-${PRODUCT} && \
-    rm -rf /stackable/apache-druid-${PRODUCT}-src
+    rm -rf /stackable/apache-druid-${PRODUCT}-src && \
+    rm -rf /stackable/.m2 && \
+    rm -rf /stackable/.npm && \
+    rm -rf /stackable/.cache
+
     #  Do not remove the /stackable/apache-druid-${PRODUCT}/quickstart folder, it is needed for loading the Wikipedia
     # testdata in kuttl tests and the getting started guide.
 
@@ -91,8 +95,8 @@ RUN microdnf update && \
 USER stackable
 WORKDIR /stackable
 
-COPY --from=druid-builder /stackable /stackable
-COPY --chown=stackable:stackable druid/stackable /stackable
+COPY --from=druid-builder /stackable/apache-druid-${PRODUCT} /stackable/apache-druid-${PRODUCT}
+COPY --chown=stackable:stackable druid/stackable/bin /stackable/bin
 COPY --chown=stackable:stackable druid/licenses /licenses
 
 RUN ln -s /stackable/apache-druid-${PRODUCT} /stackable/druid && \


### PR DESCRIPTION
# Description

- Cleans various caches after build to minimize size of intermediate images
- Only copy necessary stuff over (e.g. the "patches" directory was there as well as other things like maven directory)
- Removes Druid 27.0.0 which we will not support in SDP 24.7 anymore

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
