### PR TITLE
chore: move product versions into product directory in preparation for individual product build workflows

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Set up syft
         uses: anchore/sbom-action/download-syft@e8d2a6937ecead383dfe75190d104edd1f9c5751 # v0.16.0
       - name: Install image-tools-stackabletech
-        run: pip install image-tools-stackabletech==0.0.5
+        run: pip install image-tools-stackabletech==0.0.8
       - uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
         with:
           registry: docker.stackable.tech

--- a/.github/workflows/preflight.yaml
+++ b/.github/workflows/preflight.yaml
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: '3.x'
-      - run: pip install image-tools-stackabletech
+      - run: pip install image-tools-stackabletech==0.0.8
       - name: Install preflight
         run: |
           wget https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.9.1/preflight-linux-amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up syft
         uses: anchore/sbom-action/download-syft@e8d2a6937ecead383dfe75190d104edd1f9c5751 # v0.16.0
       - name: Install image-tools-stackabletech
-        run: pip install image-tools-stackabletech==0.0.5
+        run: pip install image-tools-stackabletech==0.0.8
       - uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
         with:
           registry: docker.stackable.tech

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to this project will be documented in this file.
 - trino: Build from source ([#687]).
 - spark: Build from source ([#679])
 - all: Moved the LOG4J_FORMAT_MSG_NO_LOOKUPS env variable from the individual Dockerfiles to `java-base` and `java-devel` ([#727])
+- all: move product versions into product directory in preparation for individual product build workflows ([#732])
 
 ### Fixed
 
@@ -102,6 +103,7 @@ All notable changes to this project will be documented in this file.
 [#706]: https://github.com/stackabletech/docker-images/pull/706
 [#721]: https://github.com/stackabletech/docker-images/pull/721
 [#727]: https://github.com/stackabletech/docker-images/pull/727
+[#732]: https://github.com/stackabletech/docker-images/pull/732
 
 ## [24.3.0] - 2024-03-20
 

--- a/airflow/versions.py
+++ b/airflow/versions.py
@@ -1,0 +1,42 @@
+versions = [
+    {
+        "product": "2.6.3",
+        "python": "3.9",
+        "git_sync": "v4.2.1",
+        "statsd_exporter": "0.26.0",
+        "tini": "0.19.0",
+        "vector": "0.35.0",
+    },
+    {
+        "product": "2.7.2",
+        "python": "3.9",
+        "git_sync": "v4.2.1",
+        "statsd_exporter": "0.26.0",
+        "tini": "0.19.0",
+        "vector": "0.35.0",
+    },
+    {
+        "product": "2.7.3",
+        "python": "3.9",
+        "git_sync": "v4.2.1",
+        "statsd_exporter": "0.26.0",
+        "tini": "0.19.0",
+        "vector": "0.35.0",
+    },
+    {
+        "product": "2.8.1",
+        "python": "3.9",
+        "git_sync": "v4.2.1",
+        "statsd_exporter": "0.26.0",
+        "tini": "0.19.0",
+        "vector": "0.35.0",
+    },
+    {
+        "product": "2.8.3",
+        "python": "3.9",
+        "git_sync": "v4.2.1",
+        "statsd_exporter": "0.26.0",
+        "tini": "0.19.0",
+        "vector": "0.35.0",
+    },
+]

--- a/conf.py
+++ b/conf.py
@@ -4,499 +4,131 @@ Configuration file for the Stackable image-tools: https://github.com/stackablete
 Application images will be created for products and associated versions configured here.
 """
 
+# NOTE (@NickLarsenNZ): Unfortunately, some directories have hyphens, so they need
+# importing in a special way. For consistency, we'll do them all the same way.
+import importlib
+
+airflow = importlib.import_module("airflow.versions")
+druid = importlib.import_module("druid.versions")
+hadoop = importlib.import_module("hadoop.versions")
+hbase = importlib.import_module("hbase.versions")
+hello_world = importlib.import_module("hello-world.versions")
+hive = importlib.import_module("hive.versions")
+java_base = importlib.import_module("java-base.versions")
+java_devel = importlib.import_module("java-devel.versions")
+kafka = importlib.import_module("kafka.versions")
+krb5 = importlib.import_module("krb5.versions")
+vector = importlib.import_module("vector.versions")
+nifi = importlib.import_module("nifi.versions")
+omid = importlib.import_module("omid.versions")
+opa = importlib.import_module("opa.versions")
+spark_k8s = importlib.import_module("spark-k8s.versions")
+stackable_base = importlib.import_module("stackable-base.versions")
+superset = importlib.import_module("superset.versions")
+trino_cli = importlib.import_module("trino-cli.versions")
+trino = importlib.import_module("trino.versions")
+kafka_testing_tools = importlib.import_module("kafka-testing-tools.versions")
+kcat = importlib.import_module("kcat.versions")
+testing_tools = importlib.import_module("testing-tools.versions")
+zookeeper = importlib.import_module("zookeeper.versions")
+tools = importlib.import_module("tools.versions")
+
 products = [
     {
         "name": "airflow",
-        "versions": [
-            {
-                "product": "2.6.3",
-                "python": "3.9",
-                "git_sync": "v4.2.1",
-                "statsd_exporter": "0.26.0",
-                "tini": "0.19.0",
-                "vector": "0.35.0",
-            },
-            {
-                "product": "2.7.2",
-                "python": "3.9",
-                "git_sync": "v4.2.1",
-                "statsd_exporter": "0.26.0",
-                "tini": "0.19.0",
-                "vector": "0.35.0",
-            },
-            {
-                "product": "2.7.3",
-                "python": "3.9",
-                "git_sync": "v4.2.1",
-                "statsd_exporter": "0.26.0",
-                "tini": "0.19.0",
-                "vector": "0.35.0",
-            },
-            {
-                "product": "2.8.1",
-                "python": "3.9",
-                "git_sync": "v4.2.1",
-                "statsd_exporter": "0.26.0",
-                "tini": "0.19.0",
-                "vector": "0.35.0",
-            },
-            {
-                "product": "2.8.3",
-                "python": "3.9",
-                "git_sync": "v4.2.1",
-                "statsd_exporter": "0.26.0",
-                "tini": "0.19.0",
-                "vector": "0.35.0",
-            },
-        ],
+        "versions": airflow.versions,
     },
     {
         "name": "druid",
-        "versions": [
-            {
-                "product": "26.0.0",
-                "java-base": "11",
-                "java-devel": "11",
-                "jackson_dataformat_xml": "2.10.5",
-                "stax2_api": "4.2.1",
-                "woodstox_core": "6.2.1",
-                "authorizer": "0.5.0",
-            },
-            {
-                "product": "28.0.1",
-                # Java 17 should be fully supported as of 27.0.0 https://github.com/apache/druid/releases#27.0.0-highlights-java-17-support
-                # Did not work in a quick test due to reflection error:
-                # Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make protected final java.lang.Class
-                # java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain) throws java.lang.ClassFormatError
-                "java-base": "11",
-                "java-devel": "11",
-                "jackson_dataformat_xml": "2.12.7",  # from https://github.com/apache/druid/blob/b8201e31aa6b124049a61764309145baaad78db7/pom.xml#L100
-                "stax2_api": "4.2.2",
-                "woodstox_core": "6.6.0",
-                "authorizer": "0.5.0",
-            },
-        ],
+        "versions": druid.versions,
     },
     {
         "name": "hadoop",
-        "versions": [
-            {
-                "product": "3.3.4",
-                "java-base": "11",
-                "java-devel": "11",
-                "async_profiler": "2.9",
-                "jmx_exporter": "0.20.0",
-                "protobuf": "3.7.1",
-                "hdfs_utils": "0.2.1",
-                "topology_provider": "0.3.0",
-            },
-            {
-                "product": "3.3.6",
-                "java-base": "11",
-                "java-devel": "11",
-                "async_profiler": "2.9",
-                "jmx_exporter": "0.20.0",
-                "protobuf": "3.7.1",
-                "hdfs_utils": "0.2.1",
-                "topology_provider": "0.3.0",
-            },
-        ],
+        "versions": hadoop.versions,
     },
     {
         "name": "hbase",
-        "versions": [
-            # Also do not merge java-base with java below as "JAVA-BASE is not a valid identifier" in Dockerfiles, it's unfortunate but to fix this would require a bigger refactoring of names or the image tools
-            # hbase-thirdparty is used to build the hbase-operator-tools and should be set to the version defined in the POM of HBase.
-            {
-                "product": "2.4.17",
-                "hbase_thirdparty": "4.1.5",
-                "hbase_operator_tools": "1.2.0",
-                "java-base": "11",
-                "java-devel": "11",
-                "async_profiler": "2.9",
-                "phoenix": "5.2.0",
-                "hbase_profile": "2.4",
-                "hadoop": "3.3.6",
-                "jmx_exporter": "0.20.0",
-            },
-        ],
+        "versions": hadoop.versions,
     },
     {
         "name": "hello-world",
-        "versions": [
-            {
-                "product": "0.0.1-SNAPSHOT",
-                "java-base": "17",
-            },
-        ],
+        "versions": hello_world.versions,
     },
     {
         "name": "hive",
-        "versions": [
-            {
-                "product": "3.1.3",
-                "jmx_exporter": "0.20.0",
-                # Hive must be bult with Java 8 but will run on Java 11
-                "java-base": "11",
-                "java-devel": "1.8.0",
-                "hadoop": "3.3.4",
-                "jackson_dataformat_xml": "2.12.3",
-                # No longer bundled with the hadoop-yarn/mapreduce libraries (2.12.7 corresponds to the hadoop build for 3.3.4).
-                "jackson_jaxb_annotations": "2.12.7",
-                # Normally Hive 3.1.3 ships with "postgresql-9.4.1208.jre7.jar", but as this is old enough it does only support
-                # MD5 based authentication. Because of this, it does not work against more recent PostgresQL versions.
-                # See https://github.com/stackabletech/hive-operator/issues/170 for details.
-                "postgres_driver": "42.7.2",
-                "aws_java_sdk_bundle": "1.12.262",
-                "azure_storage": "7.0.1",
-                "azure_keyvault_core": "1.0.0",
-            },
-        ],
+        "versions": hive.versions,
     },
     {
         "name": "java-base",
-        "versions": [
-            {
-                "product": "1.8.0",
-                "vector": "0.35.0",
-            },
-            {
-                "product": "11",
-                "vector": "0.35.0",
-            },
-            {
-                "product": "17",
-                "vector": "0.35.0",
-            },
-            {
-                "product": "21",
-                "vector": "0.35.0",
-            },
-        ],
+        "versions": java_base.versions,
     },
     {
         "name": "java-devel",
-        "versions": [
-            {
-                "product": "1.8.0",
-                "stackable-base": "1.0.0",
-            },
-            {
-                "product": "11",
-                "stackable-base": "1.0.0",
-            },
-            {
-                "product": "17",
-                "stackable-base": "1.0.0",
-            },
-            {
-                "product": "21",
-                "stackable-base": "1.0.0",
-            },
-        ],
+        "versions": java_devel.versions,
     },
     {
         "name": "kafka",
-        "versions": [
-            {
-                "product": "3.4.1",
-                "java-base": "11",
-                "java-devel": "11",
-                "scala": "2.13",
-                "kcat": "1.7.0",
-                "opa_authorizer": "1.5.1",
-                "jmx_exporter": "0.20.0",
-            },
-            {
-                "product": "3.5.2",
-                "java-base": "11",
-                "java-devel": "11",
-                "scala": "2.13",
-                "kcat": "1.7.0",
-                "opa_authorizer": "1.5.1",
-                "jmx_exporter": "0.20.0",
-            },
-            {
-                "product": "3.6.1",
-                "java-base": "11",
-                "java-devel": "11",
-                "scala": "2.13",
-                "kcat": "1.7.0",
-                "opa_authorizer": "1.5.1",
-                "jmx_exporter": "0.20.0",
-            },
-        ],
+        "versions": kafka.versions,
     },
     {
         "name": "krb5",
-        "versions": [{"product": "1.21.1"}],
+        "versions": krb5.versions,
     },
     {
         "name": "vector",
-        "versions": [
-            {
-                "product": "0.35.0",
-                "rpm_release": "1",
-                "stackable-base": "1.0.0",
-                "inotify_tools": "3.14-19.el8",
-            }
-        ],
+        "versions": vector.versions,
     },
     {
         "name": "nifi",
-        "versions": [
-            {
-                "product": "1.21.0",
-                "java-base": "11",
-                "java-devel": "11"
-            },
-            {
-                "product": "1.23.2",
-                "java-base": "11",
-                "java-devel": "11"
-            },
-            {
-                "product": "1.25.0",
-                "java-base": "21",
-                "java-devel": "11"
-            },
-        ],
+        "versions": nifi.versions,
     },
     {
         "name": "omid",
-        "versions": [
-            {
-                "product": "1.1.0",
-                "java-base": "11",
-                "java-devel": "11",
-                "jmx_exporter": "0.20.0",
-            },
-        ],
+        "versions": omid.versions,
     },
     {
         "name": "opa",
-        "versions": [
-            {
-                "product": "0.57.0",
-                "vector": "0.35.0",
-                "bundle_builder_version": "1.1.2",
-                "stackable-base": "1.0.0",
-            },
-            {
-                "product": "0.61.0",
-                "vector": "0.35.0",
-                "bundle_builder_version": "1.1.2",
-                "stackable-base": "1.0.0",
-            },
-        ],
+        "versions": opa.versions,
     },
     {
         "name": "spark-k8s",
-        "versions": [
-            {
-                "product": "3.4.1",
-                "java-base": "11",
-                "java-devel": "11",
-                "python": "3.11",
-                "hadoop_long_version": "3.3.4",  # https://github.com/apache/spark/blob/1db2f5c36b120c213432fc658c9fd24fc73cb45e/pom.xml#L122
-                "aws_java_sdk_bundle": "1.12.262",  # https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-aws/3.3.4
-                "azure_storage": "7.0.1",  # https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-azure/3.3.4
-                "azure_keyvault_core": "1.0.0",  # https://mvnrepository.com/artifact/com.microsoft.azure/azure-storage/7.0.1
-                "jackson_dataformat_xml": "2.14.2",  # https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.13/3.4.1
-                "stax2_api": "4.2.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.14.2
-                "woodstox_core": "6.5.0",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.14.2
-                "vector": "0.35.0",
-                "jmx_exporter": "0.20.0",
-                "tini": "0.19.0",
-            },
-            {
-                "product": "3.4.2",
-                "java-base": "11",
-                "java-devel": "11",
-                "python": "3.11",
-                "hadoop_long_version": "3.3.4",  # https://github.com/apache/spark/blob/1db2f5c36b120c213432fc658c9fd24fc73cb45e/pom.xml#L122
-                "aws_java_sdk_bundle": "1.12.262",  # https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-aws/3.3.4
-                "azure_storage": "7.0.1",  # https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-azure/3.3.4
-                "azure_keyvault_core": "1.0.0",  # https://mvnrepository.com/artifact/com.microsoft.azure/azure-storage/7.0.1
-                "jackson_dataformat_xml": "2.14.2",  # https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.13/3.4.2
-                "stax2_api": "4.2.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.14.2
-                "woodstox_core": "6.5.0",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.14.2
-                "vector": "0.35.0",
-                "jmx_exporter": "0.20.0",
-                "tini": "0.19.0",
-            },
-            {
-                "product": "3.5.0",
-                "java-base": "11",
-                "java-devel": "11",
-                "python": "3.11",
-                "hadoop_long_version": "3.3.4",  # https://github.com/apache/spark/blob/6a5747d66e53ed0d934cdd9ca5c9bd9fde6868e6/pom.xml#L125
-                "aws_java_sdk_bundle": "1.12.262",  # https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-aws/3.3.4
-                "azure_storage": "7.0.1",  # https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-azure/3.3.4
-                "azure_keyvault_core": "1.0.0",  # https://mvnrepository.com/artifact/com.microsoft.azure/azure-storage/7.0.1
-                "jackson_dataformat_xml": "2.15.2",  # https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.13/3.5.0
-                "stax2_api": "4.2.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.2
-                "woodstox_core": "6.5.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.2
-                "vector": "0.35.0",
-                "jmx_exporter": "0.20.0",
-                "tini": "0.19.0",
-            },
-            {
-                "product": "3.5.1",
-                "spark": "3.5.1",
-                "java-base": "11",
-                "java-devel": "11",
-                "python": "3.11",
-                "hadoop_long_version": "3.3.4",  # https://github.com/apache/spark/blob/6a5747d66e53ed0d934cdd9ca5c9bd9fde6868e6/pom.xml#L125
-                "aws_java_sdk_bundle": "1.12.262",  # https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-aws/3.3.4
-                "azure_storage": "7.0.1",  # https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-azure/3.3.4
-                "azure_keyvault_core": "1.0.0",  # https://mvnrepository.com/artifact/com.microsoft.azure/azure-storage/7.0.1
-                "jackson_dataformat_xml": "2.15.2",  # https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.13/3.5.1
-                "stax2_api": "4.2.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.2
-                "woodstox_core": "6.5.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.2
-                "vector": "0.35.0",
-                "jmx_exporter": "0.20.0",
-                "tini": "0.19.0",
-            },
-        ],
+        "versions": spark_k8s.versions,
     },
     {
         "name": "stackable-base",
-        "versions": [{"product": "1.0.0"}],
+        "versions": stackable_base.versions,
     },
     {
         "name": "superset",
-        "versions": [
-            {
-                "product": "2.1.1",
-                "python": "3.9",
-                "vector": "0.35.0",
-                "statsd_exporter": "0.26.0",
-                "authlib": "0.15.4",  # https://github.com/dpgaspar/Flask-AppBuilder/blob/v4.3.0/requirements-extra.txt#L10
-            },
-            {
-                "product": "2.1.3",
-                "python": "3.9",
-                "vector": "0.35.0",
-                "statsd_exporter": "0.26.0",
-                "authlib": "0.15.4",  # https://github.com/dpgaspar/Flask-AppBuilder/blob/v4.3.0/requirements-extra.txt#L10
-            },
-            {
-                "product": "3.0.1",
-                "python": "3.9",
-                "vector": "0.35.0",
-                "statsd_exporter": "0.26.0",
-                "authlib": "0.15.4",  # https://github.com/dpgaspar/Flask-AppBuilder/blob/v4.3.7/requirements-extra.txt#L7
-            },
-            {
-                "product": "3.0.3",
-                "python": "3.9",
-                "vector": "0.35.0",
-                "statsd_exporter": "0.26.0",
-                "authlib": "1.2.1",  # https://github.com/dpgaspar/Flask-AppBuilder/blob/v4.3.10/requirements-extra.txt#L7
-            },
-            {
-                "product": "3.1.0",
-                "python": "3.9",
-                "vector": "0.35.0",
-                "statsd_exporter": "0.26.0",
-                "authlib": "1.2.1",  # https://github.com/dpgaspar/Flask-AppBuilder/blob/v4.3.10/requirements-extra.txt#L7
-            },
-        ],
+        "versions": superset.versions,
     },
     {
         "name": "trino-cli",
-        "versions": [
-            {
-                "product": "442",
-                "java-base": "21",
-            },
-        ],
+        "versions": trino_cli.versions,
     },
     {
         "name": "trino",
-        "versions": [
-            {
-                "product": "414",
-                "java-base": "17",
-                "java-devel": "17",
-                "opa_authorizer": "stackable0.2.0",
-                "jmx_exporter": "0.20.0",
-                "storage_connector": "413",
-            },
-            {
-                "product": "442",
-                "java-base": "21",
-                "java-devel": "21",
-                "jmx_exporter": "0.20.0",
-                "storage_connector": "442",
-                "opa_authorizer": "",
-            },
-        ],
+        "versions": trino.versions,
     },
     {
         "name": "kafka-testing-tools",
-        "versions": [
-            {
-                "product": "1.0.0",
-                "kcat": "1.7.0",
-                "java-base": "11",
-                "stackable-base": "1.0.0",
-            }
-        ],
+        "versions": kafka_testing_tools.versions,
     },
     {
         "name": "kcat",
-        "versions": [
-            {
-                "product": "1.7.0",
-                "java-base": "11",
-                "stackable-base": "1.0.0",
-            }
-        ],
+        "versions": kcat.versions,
     },
     {
         "name": "testing-tools",
-        "versions": [
-            {
-                "product": "0.2.0",
-                "keycloak_version": "23.0.0",
-            }
-        ],
+        "versions": testing_tools.versions,
     },
     {
         "name": "zookeeper",
-        "versions": [
-            {
-                "product": "3.8.3",
-                "java-base": "11",
-                "java-devel": "11",
-                "jmx_exporter": "0.20.0",
-            },
-            {
-                "product": "3.8.4",
-                "java-base": "11",
-                "java-devel": "11",
-                "jmx_exporter": "0.20.0",
-            },
-            {
-                "product": "3.9.2",
-                "java-base": "11",
-                "java-devel": "11",
-                "jmx_exporter": "0.20.0",
-            },
-        ],
+        "versions": zookeeper.versions,
     },
     {
         "name": "tools",
-        "versions": [
-            {
-                "product": "1.0.0",
-                "kubectl_version": "1.26.2",
-                "jq_version": "1.6",
-                "stackable-base": "1.0.0",
-            },
-        ],
+        "versions": tools.versions,
     },
 ]
 

--- a/druid/versions.py
+++ b/druid/versions.py
@@ -1,0 +1,24 @@
+versions = [
+    {
+        "product": "26.0.0",
+        "java-base": "11",
+        "java-devel": "11",
+        "jackson_dataformat_xml": "2.10.5",
+        "stax2_api": "4.2.1",
+        "woodstox_core": "6.2.1",
+        "authorizer": "0.5.0",
+    },
+    {
+        "product": "28.0.1",
+        # Java 17 should be fully supported as of 27.0.0 https://github.com/apache/druid/releases#27.0.0-highlights-java-17-support
+        # Did not work in a quick test due to reflection error:
+        # Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make protected final java.lang.Class
+        # java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain) throws java.lang.ClassFormatError
+        "java-base": "11",
+        "java-devel": "11",
+        "jackson_dataformat_xml": "2.12.7",  # from https://github.com/apache/druid/blob/b8201e31aa6b124049a61764309145baaad78db7/pom.xml#L100
+        "stax2_api": "4.2.2",
+        "woodstox_core": "6.6.0",
+        "authorizer": "0.5.0",
+    },
+]

--- a/hadoop/versions.py
+++ b/hadoop/versions.py
@@ -1,0 +1,22 @@
+versions = [
+    {
+        "product": "3.3.4",
+        "java-base": "11",
+        "java-devel": "11",
+        "async_profiler": "2.9",
+        "jmx_exporter": "0.20.0",
+        "protobuf": "3.7.1",
+        "hdfs_utils": "0.2.1",
+        "topology_provider": "0.3.0",
+    },
+    {
+        "product": "3.3.6",
+        "java-base": "11",
+        "java-devel": "11",
+        "async_profiler": "2.9",
+        "jmx_exporter": "0.20.0",
+        "protobuf": "3.7.1",
+        "hdfs_utils": "0.2.1",
+        "topology_provider": "0.3.0",
+    },
+]

--- a/hbase/versions.py
+++ b/hbase/versions.py
@@ -1,0 +1,16 @@
+versions = [
+    # Also do not merge java-base with java below as "JAVA-BASE is not a valid identifier" in Dockerfiles, it's unfortunate but to fix this would require a bigger refactoring of names or the image tools
+    # hbase-thirdparty is used to build the hbase-operator-tools and should be set to the version defined in the POM of HBase.
+    {
+        "product": "2.4.17",
+        "hbase_thirdparty": "4.1.5",
+        "hbase_operator_tools": "1.2.0",
+        "java-base": "11",
+        "java-devel": "11",
+        "async_profiler": "2.9",
+        "phoenix": "5.2.0",
+        "hbase_profile": "2.4",
+        "hadoop": "3.3.6",
+        "jmx_exporter": "0.20.0",
+    },
+]

--- a/hello-world/versions.py
+++ b/hello-world/versions.py
@@ -1,0 +1,6 @@
+versions = [
+    {
+        "product": "0.0.1-SNAPSHOT",
+        "java-base": "17"
+    }
+]

--- a/hive/versions.py
+++ b/hive/versions.py
@@ -1,0 +1,20 @@
+versions = [
+    {
+        "product": "3.1.3",
+        "jmx_exporter": "0.20.0",
+        # Hive must be built with Java 8 but will run on Java 11
+        "java-base": "11",
+        "java-devel": "1.8.0",
+        "hadoop": "3.3.4",
+        "jackson_dataformat_xml": "2.12.3",
+        # No longer bundled with the hadoop-yarn/mapreduce libraries (2.12.7 corresponds to the hadoop build for 3.3.4).
+        "jackson_jaxb_annotations": "2.12.7",
+        # Normally Hive 3.1.3 ships with "postgresql-9.4.1208.jre7.jar", but as this is old enough it does only support
+        # MD5 based authentication. Because of this, it does not work against more recent PostgresQL versions.
+        # See https://github.com/stackabletech/hive-operator/issues/170 for details.
+        "postgres_driver": "42.7.2",
+        "aws_java_sdk_bundle": "1.12.262",
+        "azure_storage": "7.0.1",
+        "azure_keyvault_core": "1.0.0",
+    },
+]

--- a/java-base/versions.py
+++ b/java-base/versions.py
@@ -1,0 +1,18 @@
+versions = [
+    {
+        "product": "1.8.0",
+        "vector": "0.35.0",
+    },
+    {
+        "product": "11",
+        "vector": "0.35.0",
+    },
+    {
+        "product": "17",
+        "vector": "0.35.0",
+    },
+    {
+        "product": "21",
+        "vector": "0.35.0",
+    },
+]

--- a/java-devel/versions.py
+++ b/java-devel/versions.py
@@ -1,0 +1,18 @@
+versions = [
+    {
+        "product": "1.8.0",
+        "stackable-base": "1.0.0",
+    },
+    {
+        "product": "11",
+        "stackable-base": "1.0.0",
+    },
+    {
+        "product": "17",
+        "stackable-base": "1.0.0",
+    },
+    {
+        "product": "21",
+        "stackable-base": "1.0.0",
+    },
+]

--- a/kafka-testing-tools/versions.py
+++ b/kafka-testing-tools/versions.py
@@ -1,0 +1,8 @@
+versions = [
+    {
+        "product": "1.0.0",
+        "kcat": "1.7.0",
+        "java-base": "11",
+        "stackable-base": "1.0.0",
+    }
+]

--- a/kafka/versions.py
+++ b/kafka/versions.py
@@ -1,0 +1,29 @@
+versions = [
+    {
+        "product": "3.4.1",
+        "java-base": "11",
+        "java-devel": "11",
+        "scala": "2.13",
+        "kcat": "1.7.0",
+        "opa_authorizer": "1.5.1",
+        "jmx_exporter": "0.20.0",
+    },
+    {
+        "product": "3.5.2",
+        "java-base": "11",
+        "java-devel": "11",
+        "scala": "2.13",
+        "kcat": "1.7.0",
+        "opa_authorizer": "1.5.1",
+        "jmx_exporter": "0.20.0",
+    },
+    {
+        "product": "3.6.1",
+        "java-base": "11",
+        "java-devel": "11",
+        "scala": "2.13",
+        "kcat": "1.7.0",
+        "opa_authorizer": "1.5.1",
+        "jmx_exporter": "0.20.0",
+    },
+]

--- a/kcat/versions.py
+++ b/kcat/versions.py
@@ -1,0 +1,7 @@
+versions = [
+    {
+        "product": "1.7.0",
+        "java-base": "11",
+        "stackable-base": "1.0.0",
+    }
+]

--- a/krb5/versions.py
+++ b/krb5/versions.py
@@ -1,0 +1,5 @@
+versions = [
+    {
+        "product": "1.21.1"
+    }
+]

--- a/nifi/versions.py
+++ b/nifi/versions.py
@@ -1,0 +1,17 @@
+versions = [
+    {
+        "product": "1.21.0",
+        "java-base": "11",
+        "java-devel": "11",
+    },
+    {
+        "product": "1.23.2",
+        "java-base": "11",
+        "java-devel": "11",
+    },
+    {
+        "product": "1.25.0",
+        "java-base": "21",
+        "java-devel": "11", # There is an error when trying to use java-devel 21 (for nifi 1.25.0):
+    },
+]

--- a/omid/versions.py
+++ b/omid/versions.py
@@ -1,0 +1,8 @@
+versions = [
+    {
+        "product": "1.1.0",
+        "java-base": "11",
+        "java-devel": "11",
+        "jmx_exporter": "0.20.0",
+    },
+]

--- a/opa/versions.py
+++ b/opa/versions.py
@@ -1,0 +1,14 @@
+versions = [
+    {
+        "product": "0.57.0",
+        "vector": "0.35.0",
+        "bundle_builder_version": "1.1.2",
+        "stackable-base": "1.0.0",
+    },
+    {
+        "product": "0.61.0",
+        "vector": "0.35.0",
+        "bundle_builder_version": "1.1.2",
+        "stackable-base": "1.0.0",
+    },
+]

--- a/spark-k8s/versions.py
+++ b/spark-k8s/versions.py
@@ -1,0 +1,67 @@
+versions = [
+    {
+        "product": "3.4.1",
+        "java-base": "11",
+        "java-devel": "11",
+        "python": "3.11",
+        "hadoop_long_version": "3.3.4",  # https://github.com/apache/spark/blob/1db2f5c36b120c213432fc658c9fd24fc73cb45e/pom.xml#L122
+        "aws_java_sdk_bundle": "1.12.262",  # https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-aws/3.3.4
+        "azure_storage": "7.0.1",  # https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-azure/3.3.4
+        "azure_keyvault_core": "1.0.0",  # https://mvnrepository.com/artifact/com.microsoft.azure/azure-storage/7.0.1
+        "jackson_dataformat_xml": "2.14.2",  # https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.13/3.4.1
+        "stax2_api": "4.2.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.14.2
+        "woodstox_core": "6.5.0",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.14.2
+        "vector": "0.35.0",
+        "jmx_exporter": "0.20.0",
+        "tini": "0.19.0",
+    },
+    {
+        "product": "3.4.2",
+        "java-base": "11",
+        "java-devel": "11",
+        "python": "3.11",
+        "hadoop_long_version": "3.3.4",  # https://github.com/apache/spark/blob/1db2f5c36b120c213432fc658c9fd24fc73cb45e/pom.xml#L122
+        "aws_java_sdk_bundle": "1.12.262",  # https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-aws/3.3.4
+        "azure_storage": "7.0.1",  # https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-azure/3.3.4
+        "azure_keyvault_core": "1.0.0",  # https://mvnrepository.com/artifact/com.microsoft.azure/azure-storage/7.0.1
+        "jackson_dataformat_xml": "2.14.2",  # https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.13/3.4.2
+        "stax2_api": "4.2.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.14.2
+        "woodstox_core": "6.5.0",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.14.2
+        "vector": "0.35.0",
+        "jmx_exporter": "0.20.0",
+        "tini": "0.19.0",
+    },
+    {
+        "product": "3.5.0",
+        "java-base": "11",
+        "java-devel": "11",
+        "python": "3.11",
+        "hadoop_long_version": "3.3.4",  # https://github.com/apache/spark/blob/6a5747d66e53ed0d934cdd9ca5c9bd9fde6868e6/pom.xml#L125
+        "aws_java_sdk_bundle": "1.12.262",  # https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-aws/3.3.4
+        "azure_storage": "7.0.1",  # https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-azure/3.3.4
+        "azure_keyvault_core": "1.0.0",  # https://mvnrepository.com/artifact/com.microsoft.azure/azure-storage/7.0.1
+        "jackson_dataformat_xml": "2.15.2",  # https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.13/3.5.0
+        "stax2_api": "4.2.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.2
+        "woodstox_core": "6.5.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.2
+        "vector": "0.35.0",
+        "jmx_exporter": "0.20.0",
+        "tini": "0.19.0",
+    },
+    {
+        "product": "3.5.1",
+        "spark": "3.5.1",
+        "java-base": "11",
+        "java-devel": "11",
+        "python": "3.11",
+        "hadoop_long_version": "3.3.4",  # https://github.com/apache/spark/blob/6a5747d66e53ed0d934cdd9ca5c9bd9fde6868e6/pom.xml#L125
+        "aws_java_sdk_bundle": "1.12.262",  # https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-aws/3.3.4
+        "azure_storage": "7.0.1",  # https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-azure/3.3.4
+        "azure_keyvault_core": "1.0.0",  # https://mvnrepository.com/artifact/com.microsoft.azure/azure-storage/7.0.1
+        "jackson_dataformat_xml": "2.15.2",  # https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.13/3.5.1
+        "stax2_api": "4.2.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.2
+        "woodstox_core": "6.5.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.2
+        "vector": "0.35.0",
+        "jmx_exporter": "0.20.0",
+        "tini": "0.19.0",
+    },
+]

--- a/stackable-base/versions.py
+++ b/stackable-base/versions.py
@@ -1,0 +1,5 @@
+versions = [
+    {
+        "product": "1.0.0"
+    }
+]

--- a/superset/versions.py
+++ b/superset/versions.py
@@ -1,0 +1,37 @@
+versions = [
+    {
+        "product": "2.1.1",
+        "python": "3.9",
+        "vector": "0.35.0",
+        "statsd_exporter": "0.26.0",
+        "authlib": "0.15.4",  # https://github.com/dpgaspar/Flask-AppBuilder/blob/v4.3.0/requirements-extra.txt#L10
+    },
+    {
+        "product": "2.1.3",
+        "python": "3.9",
+        "vector": "0.35.0",
+        "statsd_exporter": "0.26.0",
+        "authlib": "0.15.4",  # https://github.com/dpgaspar/Flask-AppBuilder/blob/v4.3.0/requirements-extra.txt#L10
+    },
+    {
+        "product": "3.0.1",
+        "python": "3.9",
+        "vector": "0.35.0",
+        "statsd_exporter": "0.26.0",
+        "authlib": "0.15.4",  # https://github.com/dpgaspar/Flask-AppBuilder/blob/v4.3.7/requirements-extra.txt#L7
+    },
+    {
+        "product": "3.0.3",
+        "python": "3.9",
+        "vector": "0.35.0",
+        "statsd_exporter": "0.26.0",
+        "authlib": "1.2.1",  # https://github.com/dpgaspar/Flask-AppBuilder/blob/v4.3.10/requirements-extra.txt#L7
+    },
+    {
+        "product": "3.1.0",
+        "python": "3.9",
+        "vector": "0.35.0",
+        "statsd_exporter": "0.26.0",
+        "authlib": "1.2.1",  # https://github.com/dpgaspar/Flask-AppBuilder/blob/v4.3.10/requirements-extra.txt#L7
+    },
+]

--- a/testing-tools/versions.py
+++ b/testing-tools/versions.py
@@ -1,0 +1,6 @@
+versions = [
+    {
+        "product": "0.2.0",
+        "keycloak_version": "23.0.0",
+    }
+]

--- a/tools/versions.py
+++ b/tools/versions.py
@@ -1,0 +1,8 @@
+versions = [
+    {
+        "product": "1.0.0",
+        "kubectl_version": "1.26.2",
+        "jq_version": "1.6",
+        "stackable-base": "1.0.0",
+    },
+]

--- a/trino-cli/versions.py
+++ b/trino-cli/versions.py
@@ -1,0 +1,6 @@
+versions = [
+    {
+        "product": "442",
+        "java-base": "21",
+    },
+]

--- a/trino/versions.py
+++ b/trino/versions.py
@@ -1,0 +1,18 @@
+versions = [
+    {
+        "product": "414",
+        "java-base": "17",
+        "java-devel": "17",
+        "opa_authorizer": "stackable0.2.0",
+        "jmx_exporter": "0.20.0",
+        "storage_connector": "413",
+    },
+    {
+        "product": "442",
+        "java-base": "21",
+        "java-devel": "21",
+        "jmx_exporter": "0.20.0",
+        "storage_connector": "442",
+        "opa_authorizer": "",
+    },
+]

--- a/vector/versions.py
+++ b/vector/versions.py
@@ -1,0 +1,8 @@
+versions = [
+    {
+        "product": "0.35.0",
+        "rpm_release": "1",
+        "stackable-base": "1.0.0",
+        "inotify_tools": "3.14-19.el8",
+    }
+]

--- a/zookeeper/versions.py
+++ b/zookeeper/versions.py
@@ -1,0 +1,20 @@
+versions = [
+    {
+        "product": "3.8.3",
+        "java-base": "11",
+        "java-devel": "11",
+        "jmx_exporter": "0.20.0",
+    },
+    {
+        "product": "3.8.4",
+        "java-base": "11",
+        "java-devel": "11",
+        "jmx_exporter": "0.20.0",
+    },
+    {
+        "product": "3.9.2",
+        "java-base": "11",
+        "java-devel": "11",
+        "jmx_exporter": "0.20.0",
+    },
+]


### PR DESCRIPTION
# Description

- Update image-tools to 0.0.8 (to support importing python modules via conf.py)
- Move each products version list to a file in the product directory, and import it in the main configuration.
  This will allow us to only build the relevant images based on the change paths (future PR).

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
