### PR TITLE
Fix the ownership of the Druid directory in the Druid image

### DIFF
--- a/druid/Dockerfile
+++ b/druid/Dockerfile
@@ -95,7 +95,7 @@ RUN microdnf update && \
 USER stackable
 WORKDIR /stackable
 
-COPY --from=druid-builder /stackable/apache-druid-${PRODUCT} /stackable/apache-druid-${PRODUCT}
+COPY --chown=stackable:stackable --from=druid-builder /stackable/apache-druid-${PRODUCT} /stackable/apache-druid-${PRODUCT}
 COPY --chown=stackable:stackable druid/stackable/bin /stackable/bin
 COPY --chown=stackable:stackable druid/licenses /licenses
 


### PR DESCRIPTION
# Description

Fix the ownership of the Druid directory in the Druid image

The ownership was changed from `root` to `stackable`.

The tests failed because `/stackable/apache-druid-${PRODUCT}/var/druid/metadata.db` could not be created due to the ownership. While it is debatable if this file should be stored in a directory below the application directory, all directories and files in `/stackable` should be owned by `stackable` nevertheless.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] ~~Add an entry to the CHANGELOG.md file~~ not required
- [x] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
