### PR TITLE
fix: Fix Hadoop build by re-installing EPEL

### DIFF
--- a/hadoop/Dockerfile
+++ b/hadoop/Dockerfile
@@ -45,10 +45,10 @@ RUN curl --fail -L -s -S https://repo.stackable.tech/repository/packages/protobu
     make install && \
     rm -rf /opt/protobuf-src
 
-ENV PROTOBUF_HOME /opt/protobuf
-ENV PATH "${PATH}:/opt/protobuf/bin"
+ENV PROTOBUF_HOME=/opt/protobuf
+ENV PATH="${PATH}:/opt/protobuf/bin"
 
-RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+RUN rpm --install --replacepkgs https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 RUN microdnf update && \
     microdnf install \
     # boost is a build dependency starting in Hadoop 3.4.0 if compiling native code

--- a/java-base/Dockerfile
+++ b/java-base/Dockerfile
@@ -20,7 +20,7 @@ LABEL name="Stackable image for OpenJDK" \
     description="This image is the base image for all Stackable Java product images."
 
 # We need to use EPEL, as openjdk 22 is not shipped with UBI9
-RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+RUN rpm --install --replacepkgs https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 
 RUN microdnf update && \
     microdnf install \

--- a/java-devel/Dockerfile
+++ b/java-devel/Dockerfile
@@ -8,7 +8,7 @@ FROM stackable/image/stackable-base
 ARG PRODUCT
 
 # We need to use EPEL, as openjdk 22 is not shipped with UBI9
-RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+RUN rpm --install --replacepkgs https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 
 # hadolint ignore=DL3041
 RUN microdnf update && \


### PR DESCRIPTION
# Description

*Please add a description here.*


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
