### PR TITLE
fix(ci): Re-add free-disk-space action

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -29,7 +29,7 @@ runs:
         # This might remove tools that are actually needed, if set to "true" but
         # frees about 6 GB.
         tool-cache: false
-        
+
         # All of these default to true, but feel free to set to "false" if
         # necessary for your workflow.
         android: true

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -23,6 +23,22 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+      with:
+        # This might remove tools that are actually needed, if set to "true" but
+        # frees about 6 GB.
+        tool-cache: false
+        
+        # All of these default to true, but feel free to set to "false" if
+        # necessary for your workflow.
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: true
+        swap-storage: true
+
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@4fd812986e6c8c2a69e18311145f9371337f27d4 # v3.4.0
 


### PR DESCRIPTION
This cleans up some space on the runner to be able to build products which produce a bunch of data during build. This action was present before, but accidentally removed in #733. This now re-adds the action to fix the larger failing builds.
