### PR TITLE
fix(airflow): path to libstdc++.so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ All notable changes to this project will be documented in this file.
 - hive: Fix compilation of x86 in CI due to lower disk usage to prevent disk running full ([#619]).
 - hive: Provide logging dependency previously bundled with the hadoop yarn client ([#688]).
 - all: Use correct hbase versions ([#734])
+- airflow: fix missing libstdc++.so.6 error message when running the image ([#778])
 
 ### Removed
 
@@ -137,6 +138,7 @@ All notable changes to this project will be documented in this file.
 [#768]: https://github.com/stackabletech/docker-images/pull/768
 [#771]: https://github.com/stackabletech/docker-images/pull/771
 [#777]: https://github.com/stackabletech/docker-images/pull/777
+[#778]: https://github.com/stackabletech/docker-images/pull/778
 
 ## [24.3.0] - 2024-03-20
 

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -77,13 +77,11 @@ LABEL name="Apache Airflow" \
 COPY airflow/licenses /licenses
 
 # Update image and install python
-# g++ is required for libstdc++ that is preloaded in entrypoint.sh
 RUN microdnf update && \
     microdnf install \
     ca-certificates \
     cyrus-sasl \
     git \
-    g++ \
     libpq \
     openldap \
     openldap-clients \

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -77,11 +77,13 @@ LABEL name="Apache Airflow" \
 COPY airflow/licenses /licenses
 
 # Update image and install python
+# g++ is required for libstdc++ that is preloaded in entrypoint.sh
 RUN microdnf update && \
-    microdnf install  \
+    microdnf install -y \
     ca-certificates \
     cyrus-sasl \
     git \
+    g++ \
     libpq \
     openldap \
     openldap-clients \

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -79,7 +79,7 @@ COPY airflow/licenses /licenses
 # Update image and install python
 # g++ is required for libstdc++ that is preloaded in entrypoint.sh
 RUN microdnf update && \
-    microdnf install -y \
+    microdnf install \
     ca-certificates \
     cyrus-sasl \
     git \

--- a/airflow/stackable/utils/entrypoint.sh
+++ b/airflow/stackable/utils/entrypoint.sh
@@ -35,7 +35,7 @@ set -euo pipefail
 # binary started and a little memory used for Heap allocated by initialization of libstdc++
 # This overhead is not happening for binaries that already link dynamically libstdc++
 # LD_PRELOAD="/usr/lib/$(uname -m)-linux-gnu/libstdc++.so.6"
-# Stackable: this requires the g++ dnf package to be installed in the image.
+# Stackable: The path to this file is different on UBI
 LD_PRELOAD=/usr/lib64/libstdc++.so.6
 export LD_PRELOAD
 

--- a/airflow/stackable/utils/entrypoint.sh
+++ b/airflow/stackable/utils/entrypoint.sh
@@ -34,7 +34,9 @@ set -euo pipefail
 # The side effect of this is slightly (in the range of 100s of milliseconds) slower load for any
 # binary started and a little memory used for Heap allocated by initialization of libstdc++
 # This overhead is not happening for binaries that already link dynamically libstdc++
-LD_PRELOAD="/usr/lib/$(uname -m)-linux-gnu/libstdc++.so.6"
+# LD_PRELOAD="/usr/lib/$(uname -m)-linux-gnu/libstdc++.so.6"
+# Stackable: this requires the g++ dnf package to be installed in the image.
+LD_PRELOAD=/usr/lib64/libstdc++.so.6
 export LD_PRELOAD
 
 function run_check_with_retries {


### PR DESCRIPTION
# Description

When starting a container from the Airflow image, the following error is shown:

```shell
$ docker run -ti -u 1000:0 --rm docker.stackable.tech/sandbox/airflow:2.9.2-stackable0.0.0-dev bash
ERROR: ld.so: object '/usr/lib/x86_64-linux-gnu/libstdc++.so.6' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
...
```

The problem is that on UBI that path wrong and that the g++ package needs to be installed.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
