### PR TITLE
ci(release): Add free-disk-space action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,22 @@ jobs:
     env:
       GITHUB_REF_NAME: ${{ github.ref_name }}
     steps:
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          # This might remove tools that are actually needed, if set to "true" but
+          # frees about 6 GB.
+          tool-cache: false
+
+          # All of these default to true, but feel free to set to "false" if
+          # necessary for your workflow.
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: docker/setup-buildx-action@4fd812986e6c8c2a69e18311145f9371337f27d4 # v3.4.0
       # As of 2024-04-08 this throws


### PR DESCRIPTION
This was missing in release, and NiFi (et al) can't build without it.