### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,7 @@ jobs:
             echo "Python script failed"
             exit 1
           fi
-          
+
           for product_and_version in $product_and_versions; do
             PRODUCT="$(echo "$product_and_version" | cut -d '#' -f 1)"
             VERSION="$(echo "$product_and_version" | cut -d '#' -f 2)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,10 +97,10 @@ jobs:
           # Bake images and load them to local docker repo for signing
           # TODO: buildx cannot --load and --push at the same time
           # Tagging images with the architecture they were build on
-          ARCH_FOR_DOCKER="$(arch | sed -e 's#x86_64#amd64#' | sed -e 's#aarch64#arm64#')"
+          ARCH="$(uname -m | sed -e 's#x86_64#amd64#' | sed -e 's#aarch64#arm64#')"
           bake --product "${{ matrix.product }}" \
-          --image-version "${GITHUB_REF_NAME}-${ARCH_FOR_DOCKER}" \
-          --architecture "linux/${ARCH_FOR_DOCKER}" \
+          --image-version "${GITHUB_REF_NAME}-${ARCH}" \
+          --architecture "linux/${ARCH}" \
           --organization stackable \
           --shard-count "${{matrix.shard_count}}" \
           --shard-index "${{matrix.shard_index}}" \
@@ -187,7 +187,12 @@ jobs:
           DOCKER_USER: github
           DOCKER_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
         run: |
-          for product_and_version in $(python3 .scripts/enumerate-product-versions.py); do
+          if ! product_and_versions=$(python3 .scripts/enumerate-product-versions.py); then
+            echo "Python script failed"
+            exit 1
+          fi
+          
+          for product_and_version in $product_and_versions; do
             PRODUCT="$(echo "$product_and_version" | cut -d '#' -f 1)"
             VERSION="$(echo "$product_and_version" | cut -d '#' -f 2)"
 

--- a/.scripts/enumerate-product-versions.py
+++ b/.scripts/enumerate-product-versions.py
@@ -1,3 +1,9 @@
+import sys
+import os
+
+# Add parent directory to the sys.path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 import conf
 
 PRODUCTS = [

--- a/.scripts/enumerate-product-versions.py
+++ b/.scripts/enumerate-product-versions.py
@@ -1,6 +1,7 @@
 import sys
 import os
 
+# NOTE: This script (used in the release workflow as of 2024-07-23) relies on conf.py being in its parent folder. Should either file be moved or the structure changed in any way remember to update this script as well.
 # Add parent directory to the sys.path
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 

--- a/conf.py
+++ b/conf.py
@@ -4,6 +4,8 @@ Configuration file for the Stackable image-tools: https://github.com/stackablete
 Application images will be created for products and associated versions configured here.
 """
 
+# NOTE: The .scripts/enumerate-product-versions.py script (used in the release workflow as of 2024-07-23) imports this file and it relies on conf.py being in its parent folder. Should this file be moved or the structure changed in any way remember to update that script as well!
+
 # NOTE (@NickLarsenNZ): Unfortunately, some directories have hyphens, so they need
 # importing in a special way. For consistency, we'll do them all the same way.
 import importlib


### PR DESCRIPTION
# Description

- The enumerate-product-versions.py would not work because it can't find the module "conf" since it was moved to the .scripts subfolder

- Changes the release workflow to fail when the enumerate script fails. It used to just swallow the error