### PR TITLE
chore: Bump Rust to 1.80.0 in ubi8/9-rust-builder

### DIFF
--- a/spark-k8s/versions.py
+++ b/spark-k8s/versions.py
@@ -30,7 +30,7 @@ versions = [
         "vector": "0.39.0",
         "jmx_exporter": "1.0.1",
         "tini": "0.19.0",
-    },    
+    },
     {
         "product": "3.5.1",
         "java-base": "17",

--- a/ubi8-rust-builder/Dockerfile
+++ b/ubi8-rust-builder/Dockerfile
@@ -9,7 +9,7 @@ FROM registry.access.redhat.com/ubi8-minimal@sha256:de2a0a20c1c3b39c3de829196de9
 LABEL maintainer="Stackable GmbH"
 
 # This SHOULD be kept in sync with operator-templating and other tools to reduce build times
-ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.79.0
+ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.80.0
 ENV CARGO_CYCLONEDX_CRATE_VERSION=0.4.0
 ENV CARGO_AUDITABLE_CRATE_VERSION=0.6.4
 ENV PROTOC_VERSION=27.2

--- a/ubi9-rust-builder/Dockerfile
+++ b/ubi9-rust-builder/Dockerfile
@@ -6,7 +6,7 @@ FROM registry.access.redhat.com/ubi9-minimal@sha256:a7d837b00520a32502ada85ae339
 LABEL maintainer="Stackable GmbH"
 
 # This SHOULD to be kept in sync with operator-templating and other tools to reduce build times
-ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.79.0
+ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.80.0
 ENV CARGO_CYCLONEDX_CRATE_VERSION=0.4.0
 ENV CARGO_AUDITABLE_CRATE_VERSION=0.6.4
 ENV PROTOC_VERSION=27.2


### PR DESCRIPTION
Part of https://github.com/stackabletech/operator-templating/issues/415