### PR TITLE
ci(dev): Extract digests from structured output

### DIFF
--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -59,69 +59,124 @@ runs:
         echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
         echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
 
+    # TODO (@NickLarsenNZ): Make this a reusable action in .github/actions/push-and-sign/action.yml
     - name: Push Image to repo.stackable.tech and sign via cosign
       shell: bash
       run: |
         set -euo pipefail
-        # Store the output of `docker image push` into a variable, so we can
-        # parse it for the digest
-        PUSH_OUTPUT=$(docker image push "$(< bake-target-tags)" 2>&1)
-        echo "$PUSH_OUTPUT"
-        # Obtain the digest of the pushed image from the output of `docker image
-        # push`, because signing by tag is deprecated and will be removed from
-        # cosign in the future
-        DIGEST=$(echo "$PUSH_OUTPUT" | awk "/: digest: sha256:[a-f0-9]{64} size: [0-9]+$/ { print \$3 }")
-        echo "DIGEST=$DIGEST" >> $GITHUB_ENV
+        TARGET_TAG="$(< bake-target-tags)"
+        docker image push "$TARGET_TAG"
+        # Obtain the digest of the image, because signing by tag is deprecated and will be removed from cosign in the future
+        # This must be done after a push, otherwise the repo digest is empty.
+        # Find the digest for the image. Notice the architecture at the end of TAG
+        # IMAGE_VERSION does not contain the architecture (otherwise we could have used ${IMAGE_NAME}:${IMAGE_VERSION})
+        # Given:
+        # IMAGE_NAME: docker.stackable.tech/stackable/hello-world
+        # TARGET_TAG: docker.stackable.tech/stackable/hello-world:0.0.1-SNAPSHOT-stackable0.0.0-dev-arm64
+        # Expect:
+        # STDOUT:     docker.stackable.tech/stackable/hello-world@sha256:917f800259ef4915f976e93987b752fd64debf347568610d7f685d20220fc88a
+        REPO_DIGEST=$(
+          docker inspect "$TARGET_TAG" --format json | \
+          jq -r \
+          --arg IMAGE_NAME "$IMAGE_NAME" \
+          --arg TARGET_TAG "$TARGET_TAG" \
+          '
+              map(select(.RepoTags[] | contains($TARGET_TAG)))[0]
+              | .RepoDigests[]
+              | select(. | startswith($IMAGE_NAME))
+          '
+        )
+        # Ensure REPO_DIGEST is not empty
+        if [[ -z "$REPO_DIGEST" ]]; then
+            >&2 echo "Repo Digest is empty, but is required for signing"
+            exit 1
+        fi
+
+        # Needed by future steps
+        echo "REPO_DIGEST=$REPO_DIGEST" | tee -a $GITHUB_ENV
+
         # Refer to image via its digest (docker.stackable.tech/stackable/airflow@sha256:0a1b2c...)
         # This generates a signature and publishes it to the registry, next to the image
         # Uses the keyless signing flow with Github Actions as identity provider
-        cosign sign -y "$IMAGE_NAME@$DIGEST"
+        cosign sign -y "${REPO_DIGEST}"
 
     - name: Generate SBOM for the Nexus Image
       shell: bash
       run: |
         set -euo pipefail
-        syft scan --output cyclonedx-json=sbom.json --select-catalogers "-cargo-auditable-binary-cataloger" --scope all-layers --source-name "${{ inputs.product }}" --source-version "$TAG_NAME" "$IMAGE_NAME@$DIGEST";
+        syft scan --output cyclonedx-json=sbom.json --select-catalogers "-cargo-auditable-binary-cataloger" --scope all-layers --source-name "${{ inputs.product }}" --source-version "$TAG_NAME" "${REPO_DIGEST}";
+        # The DIGEST is the right side of `REPO_DIGEST` (split by '@')
+        DIGEST=${REPO_DIGEST#*@}
         # Determine the PURL for the image
         PURL="pkg:docker/stackable/${{ inputs.product }}@$DIGEST?repository_url=docker.stackable.tech";
         # Get metadata from the image
-        IMAGE_METADATA_DESCRIPTION=$(docker inspect --format='{{.Config.Labels.description}}' "$IMAGE_NAME@$DIGEST");
-        IMAGE_METADATA_NAME=$(docker inspect --format='{{.Config.Labels.name}}' "$IMAGE_NAME@$DIGEST");
+        IMAGE_METADATA_DESCRIPTION=$(docker inspect --format='{{.Config.Labels.description}}' "${REPO_DIGEST}");
+        IMAGE_METADATA_NAME=$(docker inspect --format='{{.Config.Labels.name}}' "${REPO_DIGEST}");
         # Merge the SBOM with the metadata for the image
         jq -s '{"metadata":{"component":{"description":"'"$IMAGE_METADATA_NAME. $IMAGE_METADATA_DESCRIPTION"'","supplier":{"name":"Stackable GmbH","url":["https://stackable.tech/"]},"author":"Stackable GmbH","purl":"'"$PURL"'","publisher":"Stackable GmbH"}}} * .[0]' sbom.json > sbom.merged.json;
         # Attest the SBOM to the image
-        cosign attest -y --predicate sbom.merged.json --type cyclonedx "$IMAGE_NAME@$DIGEST"
+        cosign attest -y --predicate sbom.merged.json --type cyclonedx "${REPO_DIGEST}"
 
+    # TODO (@NickLarsenNZ): Make this a reusable action in .github/actions/push-and-sign/action.yml
     - name: Push Image to oci.stackable.tech and sign via cosign
       shell: bash
       run: |
         set -euo pipefail
+        # Update the registry
         IMAGE_NAME=oci.stackable.tech/sdp/${{ inputs.product }}
-        echo "image: $IMAGE_NAME"
-        docker tag "$(< bake-target-tags)" "$IMAGE_NAME:$TAG_NAME"
-        # Store the output of `docker image push` into a variable, so we can parse it for the digest
-        PUSH_OUTPUT=$(docker image push "$IMAGE_NAME:$TAG_NAME" 2>&1)
-        echo "$PUSH_OUTPUT"
-        # Obtain the digest of the pushed image from the output of `docker image push`, because signing by tag is deprecated and will be removed from cosign in the future
-        DIGEST=$(echo "$PUSH_OUTPUT" | awk "/: digest: sha256:[a-f0-9]{64} size: [0-9]+$/ { print \$3 }")
-        echo "DIGEST=$DIGEST" >> $GITHUB_ENV
+        # IMAGE_NAME is needed by future steps
+        echo "IMAGE_NAME=$IMAGE_NAME" | tee -a $GITHUB_ENV
+        OLD_TARGET_TAG="$(< bake-target-tags)"
+        TARGET_TAG="$IMAGE_NAME:$TAG_NAME"
+        docker tag "$OLD_TARGET_TAG" "$TARGET_TAG"
+        docker image push "$TARGET_TAG"
+        # Obtain the digest of the image, because signing by tag is deprecated and will be removed from cosign in the future
+        # This must be done after a push, otherwise the repo digest is empty.
+        # Find the digest for the image. Notice the architecture at the end of TAG
+        # IMAGE_VERSION does not contain the architecture (otherwise we could have used ${IMAGE_NAME}:${IMAGE_VERSION})
+        # Given:
+        # IMAGE_NAME: oci.stackable.tech/sdp/hello-world
+        # TARGET_TAG: oci.stackable.tech/sdp/hello-world:0.0.1-SNAPSHOT-stackable0.0.0-dev-arm64
+        # Expect:
+        # STDOUT:     oci.stackable.tech/sdp/hello-world@sha256:917f800259ef4915f976e93987b752fd64debf347568610d7f685d20220fc88a
+        REPO_DIGEST=$(
+          docker inspect "$TARGET_TAG" --format json | \
+          jq -r \
+          --arg IMAGE_NAME "$IMAGE_NAME" \
+          --arg TARGET_TAG "$TARGET_TAG" \
+          '
+              map(select(.RepoTags[] | contains($TARGET_TAG)))[0]
+              | .RepoDigests[]
+              | select(. | startswith($IMAGE_NAME))
+          '
+        )
+        # Ensure REPO_DIGEST is not empty
+        if [[ -z "$REPO_DIGEST" ]]; then
+            >&2 echo "Repo Digest is empty, but is required for signing"
+            exit 1
+        fi
+
+        # REPO_DIGEST is needed by future steps
+        echo "REPO_DIGEST=$REPO_DIGEST" | tee -a $GITHUB_ENV
+
         # Refer to image via its digest (oci.stackable.tech/sdp/airflow@sha256:0a1b2c...)
         # This generates a signature and publishes it to the registry, next to the image
         # Uses the keyless signing flow with Github Actions as identity provider
-        cosign sign -y "$IMAGE_NAME@$DIGEST"
+        cosign sign -y "${REPO_DIGEST}"
 
     - name: Generate SBOM for the Harbor Image
       shell: bash
       run: |
         set -euo pipefail
-        IMAGE_NAME=oci.stackable.tech/sdp/${{ inputs.product }}
-        syft scan --output cyclonedx-json=sbom.json --select-catalogers "-cargo-auditable-binary-cataloger" --scope all-layers --source-name "${{ inputs.product }}" --source-version "$TAG_NAME" "$IMAGE_NAME@$DIGEST";
+        syft scan --output cyclonedx-json=sbom.json --select-catalogers "-cargo-auditable-binary-cataloger" --scope all-layers --source-name "${{ inputs.product }}" --source-version "$TAG_NAME" "${REPO_DIGEST}";
+        # The DIGEST is the right side of `REPO_DIGEST` (split by '@')
+        DIGEST=${REPO_DIGEST#*@}
         # Determine the PURL for the image
         PURL="pkg:docker/sdp/${{ inputs.product }}@$DIGEST?repository_url=oci.stackable.tech";
         # Get metadata from the image
-        IMAGE_METADATA_DESCRIPTION=$(docker inspect --format='{{.Config.Labels.description}}' "$IMAGE_NAME@$DIGEST");
-        IMAGE_METADATA_NAME=$(docker inspect --format='{{.Config.Labels.name}}' "$IMAGE_NAME@$DIGEST");
+        IMAGE_METADATA_DESCRIPTION=$(docker inspect --format='{{.Config.Labels.description}}' "${REPO_DIGEST}");
+        IMAGE_METADATA_NAME=$(docker inspect --format='{{.Config.Labels.name}}' "${REPO_DIGEST}");
         # Merge the SBOM with the metadata for the image
         jq -s '{"metadata":{"component":{"description":"'"$IMAGE_METADATA_NAME. $IMAGE_METADATA_DESCRIPTION"'","supplier":{"name":"Stackable GmbH","url":["https://stackable.tech/"]},"author":"Stackable GmbH","purl":"'"$PURL"'","publisher":"Stackable GmbH"}}} * .[0]' sbom.json > sbom.merged.json;
         # Attest the SBOM to the image
-        cosign attest -y --predicate sbom.merged.json --type cyclonedx "$IMAGE_NAME@$DIGEST"
+        cosign attest -y --predicate sbom.merged.json --type cyclonedx "${REPO_DIGEST}"

--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -63,9 +63,14 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        docker image push "$(< bake-target-tags)"
-        # Obtain the digest of the image, because signing by tag is deprecated and will be removed from cosign in the future
-        DIGEST=$(docker images --digests "$(< bake-target-tags)" --format '{{.Digest}}')
+        # Store the output of `docker image push` into a variable, so we can
+        # parse it for the digest
+        PUSH_OUTPUT=$(docker image push "$(< bake-target-tags)" 2>&1)
+        echo "$PUSH_OUTPUT"
+        # Obtain the digest of the pushed image from the output of `docker image
+        # push`, because signing by tag is deprecated and will be removed from
+        # cosign in the future
+        DIGEST=$(echo "$PUSH_OUTPUT" | awk "/: digest: sha256:[a-f0-9]{64} size: [0-9]+$/ { print \$3 }")
         echo "DIGEST=$DIGEST" >> $GITHUB_ENV
         # Refer to image via its digest (docker.stackable.tech/stackable/airflow@sha256:0a1b2c...)
         # This generates a signature and publishes it to the registry, next to the image
@@ -94,9 +99,11 @@ runs:
         IMAGE_NAME=oci.stackable.tech/sdp/${{ inputs.product }}
         echo "image: $IMAGE_NAME"
         docker tag "$(< bake-target-tags)" "$IMAGE_NAME:$TAG_NAME"
-        docker image push "$(< bake-target-tags)"
-        # Obtain the digest of the image, because signing by tag is deprecated and will be removed from cosign in the future
-        DIGEST=$(docker images --digests "$(< bake-target-tags)" --format '{{.Digest}}')
+        # Store the output of `docker image push` into a variable, so we can parse it for the digest
+        PUSH_OUTPUT=$(docker image push "$IMAGE_NAME:$TAG_NAME" 2>&1)
+        echo "$PUSH_OUTPUT"
+        # Obtain the digest of the pushed image from the output of `docker image push`, because signing by tag is deprecated and will be removed from cosign in the future
+        DIGEST=$(echo "$PUSH_OUTPUT" | awk "/: digest: sha256:[a-f0-9]{64} size: [0-9]+$/ { print \$3 }")
         echo "DIGEST=$DIGEST" >> $GITHUB_ENV
         # Refer to image via its digest (oci.stackable.tech/sdp/airflow@sha256:0a1b2c...)
         # This generates a signature and publishes it to the registry, next to the image

--- a/.github/actions/publish-manifest/action.yml
+++ b/.github/actions/publish-manifest/action.yml
@@ -53,6 +53,7 @@ runs:
         # --amend because the manifest list would be updated since we use the same tag: 0.0.0-dev
         docker manifest create "$MANIFEST_NAME" --amend "${MANIFEST_NAME}-amd64" --amend "${MANIFEST_NAME}-arm64"
         DIGEST=$(docker manifest push $MANIFEST_NAME)
+        echo "docker manifest push output is $DIGEST" # todo: remove me
 
         # Refer to image via its digest (oci.stackable.tech/sdp/airflow@sha256:0a1b2c...)
         # This generates a signature and publishes it to the registry, next to the image

--- a/.github/actions/publish-manifest/action.yml
+++ b/.github/actions/publish-manifest/action.yml
@@ -52,7 +52,7 @@ runs:
         # Note: `docker manifest push` currently outputs the same hash, but `manifest` is experimental and the
         # STDOUT is more likely to change than the structured output.
         function index_digest {
-          docker buildx imagetools inspect --format '{{json .Manifest}}' "$1" | jq -r '.digest'
+          docker buildx imagetools inspect --format '{{println .Manifest.Digest}}' "$1"
         }
 
         MANIFEST_NAME="docker.stackable.tech/stackable/${{ inputs.product }}:$IMAGE_VERSION"

--- a/.github/actions/publish-manifest/action.yml
+++ b/.github/actions/publish-manifest/action.yml
@@ -45,6 +45,16 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+
+        # Get the image index digest
+        # Eg: index_digest docker.stackable.tech/stackable/hello-world:0.0.1-SNAPSHOT-stackable0.0.0-dev
+        #
+        # Note: `docker manifest push` currently outputs the same hash, but `manifest` is experimental and the
+        # STDOUT is more likely to change than the structured output.
+        function index_digest {
+          docker buildx imagetools inspect --format '{{json .Manifest}}' "$1" | jq -r '.digest'
+        }
+
         MANIFEST_NAME="docker.stackable.tech/stackable/${{ inputs.product }}:$IMAGE_VERSION"
         # Create and push to Stackable Nexus
         # `docker manifest push` directly returns the digest of the manifest list
@@ -52,8 +62,8 @@ runs:
         # Further reading: https://docs.docker.com/reference/cli/docker/manifest/push/
         # --amend because the manifest list would be updated since we use the same tag: 0.0.0-dev
         docker manifest create "$MANIFEST_NAME" --amend "${MANIFEST_NAME}-amd64" --amend "${MANIFEST_NAME}-arm64"
-        DIGEST=$(docker manifest push $MANIFEST_NAME)
-        echo "docker manifest push output is $DIGEST" # todo: remove me
+        docker manifest push "$MANIFEST_NAME"
+        DIGEST=$(index_digest "$MANIFEST_NAME")
 
         # Refer to image via its digest (oci.stackable.tech/sdp/airflow@sha256:0a1b2c...)
         # This generates a signature and publishes it to the registry, next to the image
@@ -63,5 +73,6 @@ runs:
         # Push to oci.stackable.tech as well
         MANIFEST_NAME="oci.stackable.tech/sdp/${{ inputs.product }}:$IMAGE_VERSION"
         docker manifest create "$MANIFEST_NAME" --amend "${MANIFEST_NAME}-amd64" --amend "${MANIFEST_NAME}-arm64"
-        DIGEST=$(docker manifest push $MANIFEST_NAME)
+        docker manifest push $MANIFEST_NAME
+        DIGEST=$(index_digest "$MANIFEST_NAME")
         cosign sign -y "$MANIFEST_NAME@$DIGEST"

--- a/.github/workflows/dev_airflow.yaml
+++ b/.github/workflows/dev_airflow.yaml
@@ -55,12 +55,6 @@ jobs:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-nexus-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
-      - name: debug
-        run: |
-          set -x
-          cat bake-target-tags
-          DIGEST=$(docker images --digests "$(< bake-target-tags)" --format '{{.Digest}}')
-          echo "DIGEST=$DIGEST"
       - name: Publish Product Image
         uses: ./.github/actions/publish-image
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,9 +113,11 @@ jobs:
             TAG_NAME=$(cut -d ":" -f 2 < bake-target-tags)
             echo "image: $IMAGE_NAME"
             echo "tag: $TAG_NAME"
-            docker image push "$(< bake-target-tags)"
-            # Obtain the digest of the image, because signing by tag is deprecated and will be removed from cosign in the future
-            DIGEST=$(docker images --digests "$(< bake-target-tags)" --format '{{.Digest}}')
+            # Store the output of `docker image push` into a variable, so we can parse it for the digest
+            PUSH_OUTPUT=$(docker image push "$(< bake-target-tags)" 2>&1)
+            echo "$PUSH_OUTPUT"
+            # Obtain the digest of the pushed image from the output of `docker image push`, because signing by tag is deprecated and will be removed from cosign in the future
+            DIGEST=$(echo "$PUSH_OUTPUT" | awk "/: digest: sha256:[a-f0-9]{64} size: [0-9]+$/ { print \$3 }")
             # Refer to image via its digest (docker.stackable.tech/stackable/airflow@sha256:0a1b2c...)
             # This generates a signature and publishes it to the registry, next to the image
             # Uses the keyless signing flow with Github Actions as identity provider
@@ -137,9 +139,11 @@ jobs:
             IMAGE_NAME=oci.stackable.tech/sdp/${{ matrix.product }}
             echo "image: $IMAGE_NAME"
             docker tag "$(< bake-target-tags)" "$IMAGE_NAME:$TAG_NAME"
-            docker image push "$IMAGE_NAME:$TAG_NAME"
-            # Obtain the digest of the image, because signing by tag is deprecated and will be removed from cosign in the future
-            DIGEST=$(docker images --digests "$(< bake-target-tags)" --format '{{.Digest}}')
+            # Store the output of `docker image push` into a variable, so we can parse it for the digest
+            PUSH_OUTPUT=$(docker image push "$IMAGE_NAME:$TAG_NAME" 2>&1)
+            echo "$PUSH_OUTPUT"
+            # Obtain the digest of the pushed image from the output of `docker image push`, because signing by tag is deprecated and will be removed from cosign in the future
+            DIGEST=$(echo "$PUSH_OUTPUT" | awk "/: digest: sha256:[a-f0-9]{64} size: [0-9]+$/ { print \$3 }")
             # Refer to image via its digest (oci.stackable.tech/sdp/airflow@sha256:0a1b2c...)
             # This generates a signature and publishes it to the registry, next to the image
             # Uses the keyless signing flow with Github Actions as identity provider


### PR DESCRIPTION
# Description

- Revert bad `release.yml` workflow from #790.
  - The digest is empty, even after push (works on my machine though).
  - I have decided not to update it in this PR, as it can be improved when it uses the reusable actions. Mostly because some variable names were used that have different meanings, and it would be an easy place for errors to creep in.
- Revert bad `publish-image` action from #790.
  - The digest is empty, even after push (works on my machine though).
- Revert debug change from #800
- Extract repo digest from structured data (for the `publish-image` action).
  - It is only available after push
- Extract repo digest from structured data (for the `publish-manifest` action).
  - It _might_ only be available after push
  - Uses `docker buildx imagetools inspect` to get the digest. I checked that it matched when doing this process locally.

<details>
<summary>🔴 → 🟢</summary>

![image](https://github.com/user-attachments/assets/b96addd6-56ea-4991-a478-0d2844e377bd)

</details>

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
