### PR TITLE
fix: dependencies for Druid 30.0.0

### DIFF
--- a/druid/stackable/patches/30.0.0/04-update-patch-dependencies.patch
+++ b/druid/stackable/patches/30.0.0/04-update-patch-dependencies.patch
@@ -7,7 +7,7 @@ From: Lars Francke <git@lars-francke.de>
  0 files changed
 
 diff --git a/extensions-core/druid-pac4j/pom.xml b/extensions-core/druid-pac4j/pom.xml
-index b48171d192..282e0e5b15 100644
+index 282e0e5b15..1d149399c6 100644
 --- a/extensions-core/druid-pac4j/pom.xml
 +++ b/extensions-core/druid-pac4j/pom.xml
 @@ -38,7 +38,7 @@
@@ -15,7 +15,7 @@ index b48171d192..282e0e5b15 100644
      <!-- Following must be updated along with any updates to pac4j version. One can find the compatible version of nimbus libraries in org.pac4j:pac4j-oidc dependencies-->
      <nimbus.lang.tag.version>1.7</nimbus.lang.tag.version>
 -    <nimbus.jose.jwt.version>9.37.2</nimbus.jose.jwt.version>
-+    <nimbus.jose.jwt.version>9.37.3</nimbus.jose.jwt.version>
++    <nimbus.jose.jwt.version>8.22.1</nimbus.jose.jwt.version>
      <oauth2.oidc.sdk.version>8.22</oauth2.oidc.sdk.version>
    </properties>
  
@@ -82,7 +82,7 @@ index 38e0ddc61a..73fb14c1fc 100644
 +        <dropwizard.metrics.version>4.2.26</dropwizard.metrics.version>
          <errorprone.version>2.20.0</errorprone.version>
 -        <fastutil.version>8.5.4</fastutil.version>
-+        <fastutil.version>8.5.13</fastutil.version>
++        <fastutil.version>8.5.6</fastutil.version>
          <guava.version>32.0.1-jre</guava.version>
          <guice.version>4.1.0</guice.version>
          <hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
# Description

This fixes two separate issues that were encountered while testing Druid 30.0.0.

```
java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:209) ~[?:?]
	at it.unimi.dsi.fastutil.objects.Object2IntRBTreeMap.add(Object2IntRBTreeMap.java:273) ~[fastutil-8.5.13.jar:?]
        [...]
``` 
The root cause was an additional null check that was introduced in `fastutils 8.5.7`:
https://github.com/vigna/fastutil/commit/598a4fd064e193be69ea324aa86947477c82ede8

```
2024-08-14T15:01:43,208 WARN [qtp1268743900-74] org.eclipse.jetty.server.HttpChannel - /druid-ext/druid-pac4j/callback
java.lang.NoSuchMethodError: 'net.minidev.json.JSONObject com.nimbusds.jwt.JWTClaimsSet.toJSONObject()'
    at com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet.<init>(IDTokenClaimsSet.java:238) ~[?:?]
    [...]
```
The root cause is a breaking change introduced in `nimbus-jose-jwt 9.0` where `net.minidev.json.JSONObject` method arguments and return types were replaced:
https://bitbucket.org/connect2id/nimbus-jose-jwt/src/9.0/CHANGELOG.txt

A local nightly integration test run and the nifi-kafka-druid-earthquake demo were both successful.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
