### PR TITLE
chore(spark): version 4.0.0-preview

### DIFF
--- a/spark-k8s/versions.py
+++ b/spark-k8s/versions.py
@@ -47,4 +47,20 @@ versions = [
         "jmx_exporter": "1.0.1",
         "tini": "0.19.0",
     },
+    {
+        "product": "4.0.0-preview1",
+        "java-base": "17",
+        "java-devel": "17",
+        "python": "3.11",
+        "hadoop_long_version": "3.4.0",
+        "aws_java_sdk_bundle": "2.24.6",
+        "azure_storage": "7.0.1",  # https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-azure/3.3.4
+        "azure_keyvault_core": "1.0.0",  # https://mvnrepository.com/artifact/com.microsoft.azure/azure-storage/7.0.1
+        "jackson_dataformat_xml": "2.15.2",  # https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.13/3.5.1
+        "stax2_api": "4.2.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.2
+        "woodstox_core": "6.5.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.2
+        "vector": "0.40.0",
+        "jmx_exporter": "1.0.1",
+        "tini": "0.19.0",
+    },
 ]


### PR DESCRIPTION
# Description

Part of: https://github.com/stackabletech/issues/issues/622

Required changes:

- Hadoop 3.3.4 not supported anymore: https://github.com/apache/spark/pull/45583
- AWS SDK version 1 not supported anymore: https://github.com/apache/spark/commit/d8dc0c3e5e8a586f0761cc548e98e8b7ab859e64
- AWS SDK bundle 2.24.6 from https://mvnrepository.com/artifact/software.amazon.awssdk/bundle/2.24.6

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
