### PR TITLE
Fixing arch selection for kubectl

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -6,6 +6,7 @@ ARG PRODUCT
 ARG KUBECTL_VERSION
 ARG RELEASE
 ARG JQ_VERSION
+ARG TARGETARCH
 
 LABEL name="Stackable Tools" \
     maintainer="info@stackable.tech" \
@@ -33,7 +34,7 @@ WORKDIR /stackable/bin
 ENV PATH=/stackable/bin:$PATH
 
 # Get latest stable version from curl -L -s https://dl.k8s.io/release/stable.txt
-RUN	curl -L https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
+RUN	curl -L https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl \
     -o /stackable/bin/kubectl && chmod +x /stackable/bin/kubectl
 
 RUN	curl -L https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 \


### PR DESCRIPTION
# Description

Fixing architecture sensitivity of the tools image build.

Added `TARGETARCH` as variable and use it to pull correct `kubectl` binary

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
