### PR TITLE
fix(hbase): link to phoenix server jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,12 @@ All notable changes to this project will be documented in this file.
 
 - opa: Remove version 0.61.0 ([#797]).
 
+### Fixed
+
+- hbase: link to phoenix server jar. ([#811])
+
 [#797]: https://github.com/stackabletech/docker-images/pull/797
+[#811]: https://github.com/stackabletech/docker-images/pull/811
 
 ## [24.7.0] - 2024-07-24
 

--- a/hbase/Dockerfile
+++ b/hbase/Dockerfile
@@ -323,9 +323,9 @@ microdnf clean all
 rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}\n" | sort > /stackable/package_manifest.txt
 rm -rf /var/cache/yum
 
-ln -s /stackable/hbase-${PRODUCT} /stackable/hbase
-ln -s /stackable/hbase-operator-tools-${HBASE_OPERATOR_TOOLS} /stackable/hbase-operator-tools
-ln -s "/stackable/phoenix/phoenix-server-hbase-${HBASE_PROFILE}.jar" "/stackable/hbase/lib/phoenix-server-hbase-${HBASE_PROFILE}.jar"
+ln --symbolic --logical --verbose "/stackable/hbase-${PRODUCT}" /stackable/hbase
+ln --symbolic --logical --verbose "/stackable/hbase-operator-tools-${HBASE_OPERATOR_TOOLS}" /stackable/hbase-operator-tools
+ln --symbolic --logical --verbose "/stackable/phoenix/phoenix-server-hbase-${HBASE_PROFILE}.jar" "/stackable/hbase/lib/phoenix-server-hbase-${HBASE_PROFILE}.jar"
 EOF
 
 USER stackable

--- a/hbase/Dockerfile
+++ b/hbase/Dockerfile
@@ -325,7 +325,7 @@ rm -rf /var/cache/yum
 
 ln -s /stackable/hbase-${PRODUCT} /stackable/hbase
 ln -s /stackable/hbase-operator-tools-${HBASE_OPERATOR_TOOLS} /stackable/hbase-operator-tools
-ln -s "/stackable/phoenix/phoenix-server-hbase-${HBASE_PROFILE}-${PHOENIX}.jar" "/stackable/hbase/lib/phoenix-server-hbase-${HBASE_PROFILE}-${PHOENIX}.jar"
+ln -s "/stackable/phoenix/phoenix-server-hbase-${HBASE_PROFILE}.jar" "/stackable/hbase/lib/phoenix-server-hbase-${HBASE_PROFILE}.jar"
 EOF
 
 USER stackable


### PR DESCRIPTION
# Description


A link is added to `/stackable/hbase/lib` that points to the Phoenix server jar file. It is assumed that that the jar file has the same version as the Phoenix source zip file.

This is not the case for Hbase 2.6 where the source file is called `phoenix-5.3.0-4afe457-src.tar.gz` but the artifact is called `phoenix-server-hbase-2.6-5.3.0-SNAPSHOT.jar` and it leads to `ClassNotFoundException` when trying to start the Phoenix server.

This fix changes the link to point to the more generic file that doesn't include the actual Phoenix version.

For the 2.4 images this is:

```shell
root@2051a2f8df93 /stackable/hbase-2.4.18 # ls -l /stackable/phoenix/
lrwxrwxrwx. 1 stackable stackable        34 Jun 11  2023 phoenix-server-hbase-2.4.jar -> phoenix-server-hbase-2.4-5.2.0.jar
...
```

While for the 2.6 images this is:

```shell
➜  ~ ls -l /stackable/phoenix/
lrwxrwxrwx. 1 razvan razvan        43 Jun 11  2023 phoenix-server-hbase-2.6.jar -> phoenix-server-hbase-2.6-5.3.0-SNAPSHOT.jar
...
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
