### PR TITLE
chore(kafka): Add 3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ All notable changes to this project will be documented in this file.
 - opa: Add version `0.67.1` ([#797]).
 - vector: Add version `0.40.0` ([#802]).
 - airflow: Add version `2.9.3` ([#809]).
+- kafka: Add version `3.8.0` ([#813]).
 
 ### Removed
 
 - opa: Remove version `0.61.0` ([#797]).
 - vector: Remove version `0.39.0` ([#802]).
 - airflow: Remove versions `2.6.3`, `2.8.1`, `2.8.4` ([#809]).
+- kafka: Remove versions `3.4.1`, `3.6.1`, `3.6.2` ([#813]).
 
 ### Fixed
 
@@ -24,6 +26,7 @@ All notable changes to this project will be documented in this file.
 [#802]: https://github.com/stackabletech/docker-images/pull/802
 [#809]: https://github.com/stackabletech/docker-images/pull/809
 [#811]: https://github.com/stackabletech/docker-images/pull/811
+[#813]: https://github.com/stackabletech/docker-images/pull/813
 
 ## [24.7.0] - 2024-07-24
 

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -22,6 +22,7 @@ RUN curl --fail -L "https://repo.stackable.tech/repository/packages/kafka/kafka-
     rm -rf /stackable/kafka_${SCALA}-${PRODUCT}/site-docs/ && \
     rm -rf /stackable/kafka-${PRODUCT}-src
 
+# TODO (@NickLarsenNZ): Compile from source: https://github.com/StyraInc/opa-kafka-plugin
 RUN curl --fail -L https://repo.stackable.tech/repository/packages/kafka-opa-authorizer/opa-authorizer-${OPA_AUTHORIZER}-all.jar \
     -o /stackable/kafka_${SCALA}-${PRODUCT}/libs/opa-authorizer-${OPA_AUTHORIZER}-all.jar
 

--- a/kafka/kubernetes.repo
+++ b/kafka/kubernetes.repo
@@ -1,7 +1,7 @@
 # Copied from https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management
 [kubernetes]
 name=Kubernetes
-baseurl=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.31/rpm/
 enabled=1
 gpgcheck=1
-gpgkey=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/repodata/repomd.xml.key
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.31/rpm/repodata/repomd.xml.key

--- a/kafka/versions.py
+++ b/kafka/versions.py
@@ -1,32 +1,5 @@
 versions = [
     {
-        "product": "3.4.1",
-        "java-base": "11",
-        "java-devel": "11",
-        "scala": "2.13",
-        "kcat": "1.7.0",
-        "opa_authorizer": "1.5.1",
-        "jmx_exporter": "1.0.1",
-    },
-    {
-        "product": "3.6.1",
-        "java-base": "11",
-        "java-devel": "11",
-        "scala": "2.13",
-        "kcat": "1.7.0",
-        "opa_authorizer": "1.5.1",
-        "jmx_exporter": "1.0.1",
-    },
-    {
-        "product": "3.6.2",
-        "java-base": "11",
-        "java-devel": "11",
-        "scala": "2.13",
-        "kcat": "1.7.0",
-        "opa_authorizer": "1.5.1",
-        "jmx_exporter": "1.0.1",
-    },
-    {
         "product": "3.7.1",
         "java-base": "21",
         "java-devel": "21",

--- a/kafka/versions.py
+++ b/kafka/versions.py
@@ -8,4 +8,13 @@ versions = [
         "opa_authorizer": "1.5.1",
         "jmx_exporter": "1.0.1",
     },
+    {
+        "product": "3.8.0",
+        "java-base": "21",
+        "java-devel": "21",
+        "scala": "2.13",
+        "kcat": "1.7.0",
+        "opa_authorizer": "1.5.1",
+        "jmx_exporter": "1.0.1",
+    },
 ]


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/issues/issues/626

- Add `3.8.0`
- Remove `3.4.1`, `3.6.1`, `3.6.2`

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
- [x] Add an entry to the CHANGELOG.md file
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>

Tests pass

```
--- PASS: kuttl (161.84s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_kafka-3.7.1_zookeeper-3.9.2_use-client-tls-false_openshift-false (90.91s)
        --- PASS: kuttl/harness/smoke_kafka-3.8.0_zookeeper-3.9.2_use-client-tls-false_openshift-false (92.26s)
        --- PASS: kuttl/harness/smoke_kafka-3.7.1_zookeeper-3.9.2_use-client-tls-true_openshift-false (66.18s)
        --- PASS: kuttl/harness/smoke_kafka-3.8.0_zookeeper-3.9.2_use-client-tls-true_openshift-false (69.57s)
PASS
```