### PR TITLE
chore(vector): Bump to 0.40.1

### DIFF
--- a/airflow/versions.py
+++ b/airflow/versions.py
@@ -5,7 +5,7 @@ versions = [
         "git_sync": "v4.2.4",
         "statsd_exporter": "0.26.1",
         "tini": "0.19.0",
-        "vector": "0.40.0",
+        "vector": "0.40.1",
     },
     {
         "product": "2.9.3",
@@ -13,6 +13,6 @@ versions = [
         "git_sync": "v4.2.4",
         "statsd_exporter": "0.26.1",
         "tini": "0.19.0",
-        "vector": "0.40.0",
+        "vector": "0.40.1",
     },
 ]

--- a/java-base/versions.py
+++ b/java-base/versions.py
@@ -1,22 +1,22 @@
 versions = [
     {
         "product": "1.8.0",
-        "vector": "0.40.0",
+        "vector": "0.40.1",
     },
     {
         "product": "11",
-        "vector": "0.40.0",
+        "vector": "0.40.1",
     },
     {
         "product": "17",
-        "vector": "0.40.0",
+        "vector": "0.40.1",
     },
     {
         "product": "21",
-        "vector": "0.40.0",
+        "vector": "0.40.1",
     },
     {
         "product": "22",
-        "vector": "0.40.0",
+        "vector": "0.40.1",
     },
 ]

--- a/opa/versions.py
+++ b/opa/versions.py
@@ -1,13 +1,13 @@
 versions = [
     {
         "product": "0.66.0",
-        "vector": "0.40.0",
+        "vector": "0.40.1",
         "bundle_builder_version": "1.1.2",
         "stackable-base": "1.0.0",
     },
     {
         "product": "0.67.1",
-        "vector": "0.40.0",
+        "vector": "0.40.1",
         "bundle_builder_version": "1.1.2",
         "stackable-base": "1.0.0",
     },

--- a/spark-k8s/versions.py
+++ b/spark-k8s/versions.py
@@ -11,7 +11,7 @@ versions = [
         "jackson_dataformat_xml": "2.14.2",  # https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.13/3.4.2
         "stax2_api": "4.2.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.14.2
         "woodstox_core": "6.5.0",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.14.2
-        "vector": "0.40.0",
+        "vector": "0.40.1",
         "jmx_exporter": "1.0.1",
         "tini": "0.19.0",
     },
@@ -27,7 +27,7 @@ versions = [
         "jackson_dataformat_xml": "2.14.2",  # https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.13/3.4.3
         "stax2_api": "4.2.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.14.2
         "woodstox_core": "6.5.0",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.14.2
-        "vector": "0.40.0",
+        "vector": "0.40.1",
         "jmx_exporter": "1.0.1",
         "tini": "0.19.0",
     },
@@ -43,7 +43,7 @@ versions = [
         "jackson_dataformat_xml": "2.15.2",  # https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.13/3.5.1
         "stax2_api": "4.2.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.2
         "woodstox_core": "6.5.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.2
-        "vector": "0.40.0",
+        "vector": "0.40.1",
         "jmx_exporter": "1.0.1",
         "tini": "0.19.0",
     },

--- a/superset/versions.py
+++ b/superset/versions.py
@@ -2,28 +2,28 @@ versions = [
     {
         "product": "2.1.3",
         "python": "3.9",
-        "vector": "0.40.0",
+        "vector": "0.40.1",
         "statsd_exporter": "0.26.1",
         "authlib": "0.15.4",  # https://github.com/dpgaspar/Flask-AppBuilder/blob/v4.3.0/requirements-extra.txt#L10
     },
     {
         "product": "3.1.0",
         "python": "3.9",
-        "vector": "0.40.0",
+        "vector": "0.40.1",
         "statsd_exporter": "0.26.1",
         "authlib": "1.2.1",  # https://github.com/dpgaspar/Flask-AppBuilder/blob/v4.3.10/requirements-extra.txt#L7
     },
     {
         "product": "3.1.3",
         "python": "3.9",
-        "vector": "0.40.0",
+        "vector": "0.40.1",
         "statsd_exporter": "0.26.1",
         "authlib": "1.2.1",  # https://github.com/dpgaspar/Flask-AppBuilder/blob/release/4.4.1/requirements/extra.txt#L7
     },
     {
         "product": "4.0.2",
         "python": "3.9",
-        "vector": "0.40.0",
+        "vector": "0.40.1",
         "statsd_exporter": "0.26.1",
         "authlib": "1.2.1",  # https://github.com/dpgaspar/Flask-AppBuilder/blob/release/4.4.1/requirements/extra.txt#L7
     },

--- a/vector/versions.py
+++ b/vector/versions.py
@@ -1,6 +1,6 @@
 versions = [
     {
-        "product": "0.40.0",
+        "product": "0.40.1",
         "rpm_release": "1",
         "stackable-base": "1.0.0",
         "inotify_tools": "3.22.1.0-1.el9",


### PR DESCRIPTION
# Description

Replaces #802 and #803.

> _Fixes a Vector v0.40.0 regression where the reduce transform would not group top level objects correctly._

_container build works_