### PR TITLE
fix(hbase): remove dependency on jackson-databind 2.4.0

### DIFF
--- a/hbase/README.md
+++ b/hbase/README.md
@@ -4,7 +4,7 @@ As of SDP 24.7 we do include HBase 2.6 support in an experimental state.
 
 ## Phoenix
 
-At the time of this writing (July 12, 2024) there is no Phoenix release that supports HBase 2.6 so the script `upload_new_phoenix_version.sh` will not work.
+At the time of this writing (August 29, 2024) there is no Phoenix release that supports HBase 2.6 so the script `upload_new_phoenix_version.sh` will not work.
 
 HBase 2.6 support [was added](https://github.com/apache/phoenix/pull/1793) with [PHOENIX-7172](https://issues.apache.org/jira/browse/PHOENIX-7172).
 SDP 24.7 includes Phoenix built from the master branch from commit [4afe457](https://github.com/apache/phoenix/tree/4afe4579bb3ab01725e4939746d0b7b807b438ac).
@@ -13,17 +13,22 @@ SDP 24.7 includes Phoenix built from the master branch from commit [4afe457](htt
 # clone the Phoenix repo
 git clone git@github.com:apache/phoenix.git
 cd phoenix
-git checkout 4afe457
+git checkout 81d6cb2203
+git apply ~/repo/stackable/docker-images/hbase/stackable/patches/phoenix/01-exclude-old-jackson-databind.patch
+git commit -a -m "Exclude old jackson-databind"
+
+# Save the commit ID of the patched Phoenix version for later
+COMMIT_ID=$(git rev-parse --short HEAD)
 
 # create a tarball
-mkdir ../phoenix-5.3.0-4afe457
-git archive --format=tar --output ../phoenix-5.3.0-4afe457/phoenix.tar 4afe457
-cd ../phoenix-5.3.0-4afe457
+mkdir "../phoenix-5.3.0-$COMMIT_ID"
+git archive --format=tar --output "../phoenix-5.3.0-$COMMIT_ID/phoenix.tar" "$COMMIT_ID"
+cd "../phoenix-5.3.0-$COMMIT_ID"
 tar xf phoenix.tar
 rm phoenix.tar
-echo 4afe457 > git-commit
+echo "$COMMIT_ID" > git-commit
 cd ..
-tar -c phoenix-5.3.0-4afe457 | gzip > phoenix-5.3.0-4afe457-src.tar.gz
+tar -c "phoenix-5.3.0-$COMMIT_ID" | gzip > "phoenix-5.3.0-$COMMIT_ID-src.tar.gz"
 ```
 
 ## HBase operator tools

--- a/hbase/stackable/patches/phoenix/01-exclude-old-jackson-databind.patch
+++ b/hbase/stackable/patches/phoenix/01-exclude-old-jackson-databind.patch
@@ -1,0 +1,51 @@
+diff --git a/phoenix-core-client/pom.xml b/phoenix-core-client/pom.xml
+index ad65b74f39..90632e2c10 100644
+--- a/phoenix-core-client/pom.xml
++++ b/phoenix-core-client/pom.xml
+@@ -381,6 +381,12 @@
+     <dependency>
+       <groupId>org.apache.htrace</groupId>
+       <artifactId>htrace-core</artifactId>
++      <exclusions>
++        <exclusion>
++          <groupId>com.fasterxml.jackson.core</groupId>
++          <artifactId>jackson-databind</artifactId>
++        </exclusion>
++      </exclusions>
+     </dependency>
+     <dependency>
+       <groupId>org.slf4j</groupId>
+diff --git a/phoenix-core-server/pom.xml b/phoenix-core-server/pom.xml
+index bb55875b46..2551227a1d 100644
+--- a/phoenix-core-server/pom.xml
++++ b/phoenix-core-server/pom.xml
+@@ -131,6 +131,12 @@
+         <dependency>
+             <groupId>org.apache.htrace</groupId>
+             <artifactId>htrace-core</artifactId>
++            <exclusions>
++                <exclusion>
++                    <groupId>com.fasterxml.jackson.core</groupId>
++                    <artifactId>jackson-databind</artifactId>
++                </exclusion>
++            </exclusions>
+         </dependency>
+         <dependency>
+             <groupId>com.google.protobuf</groupId>
+diff --git a/pom.xml b/pom.xml
+index c3b72ad4e1..623c825fe1 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -1671,6 +1671,12 @@
+         <groupId>org.apache.htrace</groupId>
+         <artifactId>htrace-core</artifactId>
+         <version>${htrace.version}</version>
++        <exclusions>
++          <exclusion>
++            <groupId>com.fasterxml.jackson.core</groupId>
++            <artifactId>jackson-databind</artifactId>
++          </exclusion>
++        </exclusions>
+       </dependency>
+       <dependency>
+         <groupId>commons-codec</groupId>

--- a/hbase/versions.py
+++ b/hbase/versions.py
@@ -36,7 +36,7 @@ versions = [
         "java-base": "11",
         "java-devel": "11",
         "async_profiler": "2.9",
-        "phoenix": "5.3.0-4afe457",
+        "phoenix": "5.3.0-35213b043f",
         "hbase_profile": "2.6",
         "hadoop": "3.3.6",
         "jmx_exporter": "",  # 2.6 exports jmx and prometheus metrics by default


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/docker-images/issues/816

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
