### PR TITLE
fix(ci): Install hadolint in pre-commit workflow

### DIFF
--- a/.github/workflows/pr_pre-commit.yaml
+++ b/.github/workflows/pr_pre-commit.yaml
@@ -22,12 +22,17 @@ jobs:
         run: |
           set -xeuo pipefail
 
-          LOCATION="$HOME/hadolint"
+          LOCATION_DIR="$HOME/.local/bin"
+          LOCATION_BIN="$LOCATION_DIR/hadolint"
+
           SYSTEM=$(uname -s)
           ARCH=$(uname -m)
 
-          curl -sL -o "${LOCATION}" "https://github.com/hadolint/hadolint/releases/download/${{ env.HADOLINT_VERSION }}/hadolint-$SYSTEM-$ARCH"
-          chmod 700 "${LOCATION}"
+          mkdir -p "$LOCATION_DIR"
+          curl -sL -o "${LOCATION_BIN}" "https://github.com/hadolint/hadolint/releases/download/${{ env.HADOLINT_VERSION }}/hadolint-$SYSTEM-$ARCH"
+          chmod 700 "${LOCATION_BIN}"
+
+          echo "$LOCATION_DIR" >> $GITHUB_PATH
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: "--from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/pr_pre-commit.yaml
+++ b/.github/workflows/pr_pre-commit.yaml
@@ -4,6 +4,9 @@ name: pre-commit
 on:
   pull_request:
 
+env:
+  HADOLINT_VERSION: "v1.17.6"
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
@@ -14,6 +17,17 @@ jobs:
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: '3.12'
+      - name: Setup Hadolint
+        shell: bash
+        run: |
+          set -xeuo pipefail
+
+          LOCATION="$HOME/hadolint"
+          SYSTEM=$(uname -s)
+          ARCH=$(uname -m)
+
+          curl -sL -o "${LOCATION}" "https://github.com/hadolint/hadolint/releases/download/${{ env.HADOLINT_VERSION }}/hadolint-$SYSTEM-$ARCH"
+          chmod 700 "${LOCATION}"
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: "--from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/pr_pre-commit.yaml
+++ b/.github/workflows/pr_pre-commit.yaml
@@ -32,7 +32,7 @@ jobs:
           curl -sL -o "${LOCATION_BIN}" "https://github.com/hadolint/hadolint/releases/download/${{ env.HADOLINT_VERSION }}/hadolint-$SYSTEM-$ARCH"
           chmod 700 "${LOCATION_BIN}"
 
-          echo "$LOCATION_DIR" >> $GITHUB_PATH
+          echo "$LOCATION_DIR" >> "$GITHUB_PATH"
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: "--from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/pr_pre-commit.yaml
+++ b/.github/workflows/pr_pre-commit.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Hadolint
         shell: bash
         run: |
-          set -xeuo pipefail
+          set -euo pipefail
 
           LOCATION_DIR="$HOME/.local/bin"
           LOCATION_BIN="$LOCATION_DIR/hadolint"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,9 @@
 fail_fast: false
 exclude: \.patch$
 
+default_language_version:
+  node: system
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c # 4.6.0

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -1,4 +1,5 @@
 # syntax=docker/dockerfile:1.8.1@sha256:e87caa74dcb7d46cd820352bfea12591f3dba3ddc4285e19c7dcd13359f7cefd
+# REVERT ME!
 
 ARG GIT_SYNC
 

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -1,5 +1,4 @@
 # syntax=docker/dockerfile:1.8.1@sha256:e87caa74dcb7d46cd820352bfea12591f3dba3ddc4285e19c7dcd13359f7cefd
-# REVERT ME!
 
 ARG GIT_SYNC
 


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/637

This fixes two things:

- Install the hadolint binary to be able to run the pre-commit hook
- Set the default language version of `node` to `system`. This fixes issues on NixOS systems.