### PR TITLE
fix: Omid Dockerfile typo

### DIFF
--- a/omid/Dockerfile
+++ b/omid/Dockerfile
@@ -29,9 +29,9 @@ RUN --mount=type=cache,id=maven-omid-${PRODUCT},uid=1000,target=/stackable/.m2/r
   ./patches/apply_patches.sh ${PRODUCT}
   mvn --batch-mode --no-transfer-progress package -Phbase-2 -DskipTests
   tar -xf tso-server/target/omid-tso-server-${PRODUCT}-bin.tar.gz -C /stackable
-  mv tso-server/target/bom.json -C /stackable/omid-tso-server-${PRODUCT}/omid-tso-server-${PRODUCT}.cdx.json
+  mv tso-server/target/bom.json /stackable/omid-tso-server-${PRODUCT}/omid-tso-server-${PRODUCT}.cdx.json
   tar -xf examples/target/omid-examples-${PRODUCT}-bin.tar.gz -C /stackable
-  mv examples/target/bom.json -C /stackable/omid-examples-${PRODUCT}/omid-examples-${PRODUCT}.cdx.json
+  mv examples/target/bom.json /stackable/omid-examples-${PRODUCT}/omid-examples-${PRODUCT}.cdx.json
 
 if [ "${DELETE_CACHES}" = "true" ] ; then
   rm -rf /stackable/.m2/repository/*


### PR DESCRIPTION
I was checking the failing builds, all errors seem to be caused by flakiness in external sources, except this error in the Omid Dockerfile which snuck in with the SBOM generation PR. Must have been a copy/paste error after I first tested the Omid build locally. I fixed it and retested the Omid build for 1.1.0 and 1.1.2 locally, both worked fine and the SBOMs are present.