### PR TITLE
fix: mergebom cosign verification

### DIFF
--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -122,7 +122,7 @@ runs:
         curl --fail -L -o mergebom https://repo.stackable.tech/repository/packages/mergebom/stable-$(uname -m)
         curl --fail -L -o mergebom_signature.bundle https://repo.stackable.tech/repository/packages/mergebom/stable-$(arch)_signature.bundle
         # Verify signature
-        cosign verify-blob --certificate-identity 'https://github.com/stackabletech/mergebom/.github/workflows/build_container_image.yaml@refs/heads/main' --certificate-oidc-issuer https://token.actions.githubusercontent.com --bundle mergebom_signature.bundle mergebom
+        cosign verify-blob --certificate-identity 'https://github.com/stackabletech/mergebom/.github/workflows/build_binary.yaml@refs/heads/main' --certificate-oidc-issuer https://token.actions.githubusercontent.com --bundle mergebom_signature.bundle mergebom
         chmod +x ./mergebom
         ./mergebom sbom_raw.json sbom.json
 


### PR DESCRIPTION
Fix for https://github.com/stackabletech/docker-images/pull/827

Sorry, I hope this is the last fix: I built mergebom as a container image first but then switched to building a binary and forgot to adapt the signature check in the GitHub action, so that it matches the new workflow name.

Tested the change locally, works:
```
curl -L -o mergebom https://repo.stackable.tech/repository/packages/mergebom/stable-x86_64

curl -L -o mergebom.bundle https://repo.stackable.tech/repository/packages/mergebom/stable-x86_64_signature.bundle

cosign verify-blob --certificate-identity 'https://github.com/stackabletech/mergebom/.github/workflows/build_binary.yaml@refs/heads/main' --certificate-oidc-issuer https://token.actions.githubusercontent.com --bundle mergebom.bundle mergebom
Verified OK
```