### PR TITLE
fix: jq arg parsing

### DIFF
--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -129,19 +129,18 @@ runs:
         # TODO (@Techassi): Replace author with manufacturer, because it is
         # automated, see https://cyclonedx.org/docs/1.6/json/#metadata_component_manufacturer
         jq -s \
-          --arg description "$IMAGE_METADATA_DESCRIPTION" \
-          --arg name "$IMAGE_METADATA_NAME" \
+          --arg description "$IMAGE_METADATA_NAME. $IMAGE_METADATA_DESCRIPTION" \
           --arg purl "$PURL" \
           '{
               "metadata": {
                   "component": {
-                      "description": "$name. $description",
+                      "description": $description,
                       "supplier": {
                           "name": "Stackable GmbH",
                           "url": ["https://stackable.tech/"]
                       },
                       "author": "Stackable GmbH",
-                      "purl": "$purl",
+                      "purl": $purl,
                       "publisher": "Stackable GmbH"
                   }
               }


### PR DESCRIPTION
The args to `jq` were not parsed correctly, which resulted in e.g.
```
...
"purl": "$purl",
...
```
in the final JSON of the SBOM.

I could not figure out how to concatenate the two args with `jq` (`$name` and `$description`) so I concatenated both variables with Shellscript into one arg for `jq`.