### PR TITLE
fix: Don't use release profile for phoenix build

### DIFF
--- a/hbase/Dockerfile
+++ b/hbase/Dockerfile
@@ -248,7 +248,6 @@ mvn \
   -Dhadoop.version=${HADOOP} \
   -DskipTests \
   -Dcheckstyle.skip=true \
-  -Prelease \
   -fphoenix-${PHOENIX}-src \
   clean \
   package

--- a/hbase/stackable/patches/phoenix/5.2.0/01-cyclonedx-plugin.patch
+++ b/hbase/stackable/patches/phoenix/5.2.0/01-cyclonedx-plugin.patch
@@ -1,28 +1,28 @@
 diff --git a/pom.xml b/pom.xml
-index bce2398..92d92f1 100644
+index bce2398..4abcb5a 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -1744,6 +1744,23 @@
-       <id>release</id>
-       <build>
-         <plugins>
-+          <plugin>
-+            <groupId>org.cyclonedx</groupId>
-+            <artifactId>cyclonedx-maven-plugin</artifactId>
-+            <version>2.8.0</version>
-+            <configuration>
-+              <projectType>application</projectType>
-+              <schemaVersion>1.5</schemaVersion>
-+            </configuration>
-+            <executions>
-+              <execution>
-+              <goals>
-+                <goal>makeBom</goal>
-+              </goals>
-+              <phase>package</phase>
-+              </execution>
-+            </executions>
-+          </plugin>
-           <plugin>
-             <groupId>org.apache.rat</groupId>
-             <artifactId>apache-rat-plugin</artifactId>
+@@ -680,6 +680,23 @@
+         <extensions>true</extensions>
+         <inherited>true</inherited>
+       </plugin>
++      <plugin>
++        <groupId>org.cyclonedx</groupId>
++        <artifactId>cyclonedx-maven-plugin</artifactId>
++        <version>2.8.0</version>
++        <configuration>
++          <projectType>application</projectType>
++          <schemaVersion>1.5</schemaVersion>
++        </configuration>
++        <executions>
++          <execution>
++          <goals>
++            <goal>makeBom</goal>
++          </goals>
++          <phase>package</phase>
++          </execution>
++        </executions>
++      </plugin>
+     </plugins>
+   </build>
+ 

--- a/hbase/stackable/patches/phoenix/5.3.0-4afe457/01-cyclonedx-plugin.patch
+++ b/hbase/stackable/patches/phoenix/5.3.0-4afe457/01-cyclonedx-plugin.patch
@@ -1,28 +1,28 @@
 diff --git a/pom.xml b/pom.xml
-index e3d5b9a..503a8b3 100644
+index e3d5b9a..8a5cfdc 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -1833,6 +1833,23 @@
-               </execution>
-             </executions>
-           </plugin>
-+          <plugin>
-+            <groupId>org.cyclonedx</groupId>
-+            <artifactId>cyclonedx-maven-plugin</artifactId>
-+            <version>2.8.0</version>
-+            <configuration>
-+              <projectType>application</projectType>
-+              <schemaVersion>1.5</schemaVersion>
-+            </configuration>
-+            <executions>
-+              <execution>
-+              <goals>
-+                <goal>makeBom</goal>
-+              </goals>
-+              <phase>package</phase>
-+              </execution>
-+            </executions>
-+          </plugin>
-         </plugins>
-       </build>
-     </profile>
+@@ -685,6 +685,23 @@
+         <extensions>true</extensions>
+         <inherited>true</inherited>
+       </plugin>
++      <plugin>
++        <groupId>org.cyclonedx</groupId>
++        <artifactId>cyclonedx-maven-plugin</artifactId>
++        <version>2.8.0</version>
++        <configuration>
++          <projectType>application</projectType>
++          <schemaVersion>1.5</schemaVersion>
++        </configuration>
++        <executions>
++          <execution>
++          <goals>
++            <goal>makeBom</goal>
++          </goals>
++          <phase>package</phase>
++          </execution>
++        </executions>
++      </plugin>
+     </plugins>
+   </build>
+ 


### PR DESCRIPTION
In [this PR](https://github.com/stackabletech/docker-images/pull/814) I enabled the CycloneDX plugin for the `release` profile of Phoenix and changed the Maven command to build Phoenix using that profile (because that's how HBase does it as well).

However, the Phoenix `release` profile also enables the [apache-rat-plugin](https://creadur.apache.org/rat/apache-rat-plugin/) which causes a minor problem with our current build of Phoenix 5.3.0.

Since using the release profile does not seem to have any further advantages I moved the CycloneDX plugin to the general plugin section in the pom.xml and do not activate the release profile anymore when building Phoenix.