### PR TITLE
chore(issue-templates): Improve acceptance critera

### DIFF
--- a/.github/ISSUE_TEMPLATE/update-base-java.md
+++ b/.github/ISSUE_TEMPLATE/update-base-java.md
@@ -40,17 +40,11 @@ we should also make new versions of Java available for use.
 - [ ] _Link to the docker-images PR (product update)_
 ```
 
-<!--
-Make this a regular list so it isn't easily editable from the rendered
-description?
--->
 ```[tasklist]
 ### Acceptance
 - [ ] Can build a product image that uses the new version(s)
 - [ ] Both `java-base` and `java-devel` have the same Java versions in `versions.py`
 - [ ] Kuttl smoke test passes locally for a product using the new Java version
-- [ ] Release notes written in a comment below
-- [ ] Applicable `release-note` label added to this issue
 ```
 
 <details>

--- a/.github/ISSUE_TEMPLATE/update-base-java.md
+++ b/.github/ISSUE_TEMPLATE/update-base-java.md
@@ -40,6 +40,8 @@ we should also make new versions of Java available for use.
 - [ ] _Link to the docker-images PR (product update)_
 ```
 
+This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build a product image that uses the new version(s)

--- a/.github/ISSUE_TEMPLATE/update-base-stackable.md
+++ b/.github/ISSUE_TEMPLATE/update-base-stackable.md
@@ -30,6 +30,8 @@ Part of #xxx.
 - [ ] _Link to the docker-images PR (product update)_
 ```
 
+This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build the image locally

--- a/.github/ISSUE_TEMPLATE/update-base-ubi-rust-builders.md
+++ b/.github/ISSUE_TEMPLATE/update-base-ubi-rust-builders.md
@@ -37,6 +37,8 @@ Part of #xxx.
 - [ ] _Bump rust toolchain in operator-templating_
 ```
 
+This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+
 ```[tasklist]
 ### Acceptance
 - Done for [ubi8-rust-builder/Dockerfile](https://github.com/stackabletech/docker-images/blob/main/ubi8-rust-builder/Dockerfile)

--- a/.github/ISSUE_TEMPLATE/update-base-vector.md
+++ b/.github/ISSUE_TEMPLATE/update-base-vector.md
@@ -48,8 +48,8 @@ This list should be completed by the assignee(s), once respective PRs have been 
 
 ```[tasklist]
 ### Acceptance
-- [ ] Can build image locally
-- [ ] Kuttl smoke tests passes locally
+- [ ] Can build image (either locally, or in CI)
+- [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue

--- a/.github/ISSUE_TEMPLATE/update-base-vector.md
+++ b/.github/ISSUE_TEMPLATE/update-base-vector.md
@@ -44,6 +44,8 @@ Part of #xxx.
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
+This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally

--- a/.github/ISSUE_TEMPLATE/update-base-vector.md
+++ b/.github/ISSUE_TEMPLATE/update-base-vector.md
@@ -37,16 +37,18 @@ Part of #xxx.
 - [ ] _Link to the operator PR (getting_started / kuttl)_
 - [ ] _Link to any other operator PRs (getting_started / kuttl)_
 - [ ] _Link to demo PR (raise against the `next` branch)_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 ```
 
-<!--
-Make this a regular list so it isn't easily editable from the rendered
-description?
--->
+> [!TIP]
+> Delete any items that do not apply so that all applicable items can be checked.
+> For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally
 - [ ] Kuttl smoke tests passes locally
+- [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
 ```

--- a/.github/ISSUE_TEMPLATE/update-product-airflow.md
+++ b/.github/ISSUE_TEMPLATE/update-product-airflow.md
@@ -30,16 +30,18 @@ Part of #xxx.
 - [ ] _Link to operator PR (getting_started / kuttl)_
 - [ ] _Link to any other operator PRs (getting_started / kuttl)_
 - [ ] _Link to demo PR (raise against the `next` branch)_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 ```
 
-<!--
-Make this a regular list so it isn't easily editable from the rendered
-description?
--->
+> [!TIP]
+> Delete any items that do not apply so that all applicable items can be checked.
+> For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally
 - [ ] Kuttl smoke tests passes locally
+- [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
 ```

--- a/.github/ISSUE_TEMPLATE/update-product-airflow.md
+++ b/.github/ISSUE_TEMPLATE/update-product-airflow.md
@@ -37,6 +37,8 @@ Part of #xxx.
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
+This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally

--- a/.github/ISSUE_TEMPLATE/update-product-airflow.md
+++ b/.github/ISSUE_TEMPLATE/update-product-airflow.md
@@ -41,8 +41,8 @@ This list should be completed by the assignee(s), once respective PRs have been 
 
 ```[tasklist]
 ### Acceptance
-- [ ] Can build image locally
-- [ ] Kuttl smoke tests passes locally
+- [ ] Can build image (either locally, or in CI)
+- [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue

--- a/.github/ISSUE_TEMPLATE/update-product-druid.md
+++ b/.github/ISSUE_TEMPLATE/update-product-druid.md
@@ -32,16 +32,18 @@ Part of #xxx.
 - [ ] _Link to any other operator PRs (getting_started / kuttl)_
 - [ ] _Link to demo PR (raise against the `next` branch)_
 - [ ] _Link to [druid-opa-authorizer](https://github.com/stackabletech/druid-opa-authorizer/) PR_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 ```
 
-<!--
-Make this a regular list so it isn't easily editable from the rendered
-description?
--->
+> [!TIP]
+> Delete any items that do not apply so that all applicable items can be checked.
+> For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally
 - [ ] Kuttl smoke tests passes locally
+- [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
 ```

--- a/.github/ISSUE_TEMPLATE/update-product-druid.md
+++ b/.github/ISSUE_TEMPLATE/update-product-druid.md
@@ -39,6 +39,8 @@ Part of #xxx.
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
+This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally

--- a/.github/ISSUE_TEMPLATE/update-product-druid.md
+++ b/.github/ISSUE_TEMPLATE/update-product-druid.md
@@ -43,8 +43,8 @@ This list should be completed by the assignee(s), once respective PRs have been 
 
 ```[tasklist]
 ### Acceptance
-- [ ] Can build image locally
-- [ ] Kuttl smoke tests passes locally
+- [ ] Can build image (either locally, or in CI)
+- [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue

--- a/.github/ISSUE_TEMPLATE/update-product-hbase-phoenix-omid.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hbase-phoenix-omid.md
@@ -45,6 +45,8 @@ Part of #xxx.
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
+This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally

--- a/.github/ISSUE_TEMPLATE/update-product-hbase-phoenix-omid.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hbase-phoenix-omid.md
@@ -38,16 +38,18 @@ Part of #xxx.
 - [ ] _Link to operator PR (getting_started / kuttl)_
 - [ ] _Link to any other operator PRs (getting_started / kuttl)_
 - [ ] _Link to demo PR (raise against the `next` branch)_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 ```
 
-<!--
-Make this a regular list so it isn't easily editable from the rendered
-description?
--->
+> [!TIP]
+> Delete any items that do not apply so that all applicable items can be checked.
+> For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally
 - [ ] Kuttl smoke tests passes locally
+- [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
 ```

--- a/.github/ISSUE_TEMPLATE/update-product-hbase-phoenix-omid.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hbase-phoenix-omid.md
@@ -49,8 +49,8 @@ This list should be completed by the assignee(s), once respective PRs have been 
 
 ```[tasklist]
 ### Acceptance
-- [ ] Can build image locally
-- [ ] Kuttl smoke tests passes locally
+- [ ] Can build image (either locally, or in CI)
+- [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue

--- a/.github/ISSUE_TEMPLATE/update-product-hdfs.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hdfs.md
@@ -32,16 +32,18 @@ Part of #xxx.
 - [ ] _Link to the operator PR (getting_started / kuttl)_
 - [ ] _Link to any other operator PRs (getting_started / kuttl)_
 - [ ] _Link to demo PR (raise against the `next` branch)_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 ```
 
-<!--
-Make this a regular list so it isn't easily editable from the rendered
-description?
--->
+> [!TIP]
+> Delete any items that do not apply so that all applicable items can be checked.
+> For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally
 - [ ] Kuttl smoke tests passes locally
+- [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
 ```

--- a/.github/ISSUE_TEMPLATE/update-product-hdfs.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hdfs.md
@@ -39,6 +39,8 @@ Part of #xxx.
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
+This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally

--- a/.github/ISSUE_TEMPLATE/update-product-hdfs.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hdfs.md
@@ -43,8 +43,8 @@ This list should be completed by the assignee(s), once respective PRs have been 
 
 ```[tasklist]
 ### Acceptance
-- [ ] Can build image locally
-- [ ] Kuttl smoke tests passes locally
+- [ ] Can build image (either locally, or in CI)
+- [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue

--- a/.github/ISSUE_TEMPLATE/update-product-hive.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hive.md
@@ -38,6 +38,8 @@ Part of #xxx.
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
+This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally

--- a/.github/ISSUE_TEMPLATE/update-product-hive.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hive.md
@@ -42,8 +42,8 @@ This list should be completed by the assignee(s), once respective PRs have been 
 
 ```[tasklist]
 ### Acceptance
-- [ ] Can build image locally
-- [ ] Kuttl smoke tests passes locally
+- [ ] Can build image (either locally, or in CI)
+- [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue

--- a/.github/ISSUE_TEMPLATE/update-product-hive.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hive.md
@@ -31,16 +31,18 @@ Part of #xxx.
 - [ ] _Link to the operator PR (getting_started / kuttl)_
 - [ ] _Link to any other operator PRs (getting_started / kuttl)_
 - [ ] _Link to demo PR (raise against the `next` branch)_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 ```
 
-<!--
-Make this a regular list so it isn't easily editable from the rendered
-description?
--->
+> [!TIP]
+> Delete any items that do not apply so that all applicable items can be checked.
+> For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally
 - [ ] Kuttl smoke tests passes locally
+- [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
 ```

--- a/.github/ISSUE_TEMPLATE/update-product-kafka.md
+++ b/.github/ISSUE_TEMPLATE/update-product-kafka.md
@@ -49,6 +49,8 @@ Part of #xxx.
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
+This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally

--- a/.github/ISSUE_TEMPLATE/update-product-kafka.md
+++ b/.github/ISSUE_TEMPLATE/update-product-kafka.md
@@ -53,8 +53,8 @@ This list should be completed by the assignee(s), once respective PRs have been 
 
 ```[tasklist]
 ### Acceptance
-- [ ] Can build image locally
-- [ ] Kuttl smoke tests passes locally
+- [ ] Can build image (either locally, or in CI)
+- [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue

--- a/.github/ISSUE_TEMPLATE/update-product-kafka.md
+++ b/.github/ISSUE_TEMPLATE/update-product-kafka.md
@@ -42,16 +42,18 @@ Part of #xxx.
 - [ ] _Link to the operator PR (getting_started / kuttl)_
 - [ ] _Link to any other operator PRs (getting_started / kuttl)_
 - [ ] _Link to demo PR (raise against the `next` branch)_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 ```
 
-<!--
-Make this a regular list so it isn't easily editable from the rendered
-description?
--->
+> [!TIP]
+> Delete any items that do not apply so that all applicable items can be checked.
+> For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally
 - [ ] Kuttl smoke tests passes locally
+- [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
 ```

--- a/.github/ISSUE_TEMPLATE/update-product-nifi.md
+++ b/.github/ISSUE_TEMPLATE/update-product-nifi.md
@@ -38,6 +38,8 @@ Part of #xxx.
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
+This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally

--- a/.github/ISSUE_TEMPLATE/update-product-nifi.md
+++ b/.github/ISSUE_TEMPLATE/update-product-nifi.md
@@ -42,8 +42,8 @@ This list should be completed by the assignee(s), once respective PRs have been 
 
 ```[tasklist]
 ### Acceptance
-- [ ] Can build image locally
-- [ ] Kuttl smoke tests passes locally
+- [ ] Can build image (either locally, or in CI)
+- [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue

--- a/.github/ISSUE_TEMPLATE/update-product-nifi.md
+++ b/.github/ISSUE_TEMPLATE/update-product-nifi.md
@@ -31,16 +31,18 @@ Part of #xxx.
 - [ ] _Link to the operator PR (getting_started / kuttl)_
 - [ ] _Link to any other operator PRs (getting_started / kuttl)_
 - [ ] _Link to demo PR (raise against the `next` branch)_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 ```
 
-<!--
-Make this a regular list so it isn't easily editable from the rendered
-description?
--->
+> [!TIP]
+> Delete any items that do not apply so that all applicable items can be checked.
+> For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally
 - [ ] Kuttl smoke tests passes locally
+- [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
 ```

--- a/.github/ISSUE_TEMPLATE/update-product-opa.md
+++ b/.github/ISSUE_TEMPLATE/update-product-opa.md
@@ -30,16 +30,18 @@ Part of #xxx.
 - [ ] _Link to the operator PR (getting_started / kuttl)_
 - [ ] _Link to any other operator PRs (getting_started / kuttl)_
 - [ ] _Link to demo PR (raise against the `next` branch)_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 ```
 
-<!--
-Make this a regular list so it isn't easily editable from the rendered
-description?
--->
+> [!TIP]
+> Delete any items that do not apply so that all applicable items can be checked.
+> For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally
 - [ ] Kuttl smoke tests passes locally
+- [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
 ```

--- a/.github/ISSUE_TEMPLATE/update-product-opa.md
+++ b/.github/ISSUE_TEMPLATE/update-product-opa.md
@@ -37,6 +37,8 @@ Part of #xxx.
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
+This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally

--- a/.github/ISSUE_TEMPLATE/update-product-opa.md
+++ b/.github/ISSUE_TEMPLATE/update-product-opa.md
@@ -41,8 +41,8 @@ This list should be completed by the assignee(s), once respective PRs have been 
 
 ```[tasklist]
 ### Acceptance
-- [ ] Can build image locally
-- [ ] Kuttl smoke tests passes locally
+- [ ] Can build image (either locally, or in CI)
+- [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue

--- a/.github/ISSUE_TEMPLATE/update-product-spark.md
+++ b/.github/ISSUE_TEMPLATE/update-product-spark.md
@@ -38,6 +38,8 @@ Part of #xxx.
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
+This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally

--- a/.github/ISSUE_TEMPLATE/update-product-spark.md
+++ b/.github/ISSUE_TEMPLATE/update-product-spark.md
@@ -42,8 +42,8 @@ This list should be completed by the assignee(s), once respective PRs have been 
 
 ```[tasklist]
 ### Acceptance
-- [ ] Can build image locally
-- [ ] Kuttl smoke tests passes locally
+- [ ] Can build image (either locally, or in CI)
+- [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue

--- a/.github/ISSUE_TEMPLATE/update-product-spark.md
+++ b/.github/ISSUE_TEMPLATE/update-product-spark.md
@@ -31,16 +31,18 @@ Part of #xxx.
 - [ ] _Link to the operator PR (getting_started / kuttl)_
 - [ ] _Link to any other operator PRs (getting_started / kuttl)_
 - [ ] _Link to demo PR (raise against the `next` branch)_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 ```
 
-<!--
-Make this a regular list so it isn't easily editable from the rendered
-description?
--->
+> [!TIP]
+> Delete any items that do not apply so that all applicable items can be checked.
+> For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally
 - [ ] Kuttl smoke tests passes locally
+- [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
 ```

--- a/.github/ISSUE_TEMPLATE/update-product-superset.md
+++ b/.github/ISSUE_TEMPLATE/update-product-superset.md
@@ -38,6 +38,8 @@ Part of #xxx.
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
+This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally

--- a/.github/ISSUE_TEMPLATE/update-product-superset.md
+++ b/.github/ISSUE_TEMPLATE/update-product-superset.md
@@ -42,8 +42,8 @@ This list should be completed by the assignee(s), once respective PRs have been 
 
 ```[tasklist]
 ### Acceptance
-- [ ] Can build image locally
-- [ ] Kuttl smoke tests passes locally
+- [ ] Can build image (either locally, or in CI)
+- [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue

--- a/.github/ISSUE_TEMPLATE/update-product-superset.md
+++ b/.github/ISSUE_TEMPLATE/update-product-superset.md
@@ -31,16 +31,18 @@ Part of #xxx.
 - [ ] _Link to the operator PR (getting_started / kuttl)_
 - [ ] _Link to any other operator PRs (getting_started / kuttl)_
 - [ ] _Link to demo PR (raise against the `next` branch)_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 ```
 
-<!--
-Make this a regular list so it isn't easily editable from the rendered
-description?
--->
+> [!TIP]
+> Delete any items that do not apply so that all applicable items can be checked.
+> For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally
 - [ ] Kuttl smoke tests passes locally
+- [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
 ```

--- a/.github/ISSUE_TEMPLATE/update-product-trino.md
+++ b/.github/ISSUE_TEMPLATE/update-product-trino.md
@@ -47,6 +47,8 @@ Part of #xxx.
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
+This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally

--- a/.github/ISSUE_TEMPLATE/update-product-trino.md
+++ b/.github/ISSUE_TEMPLATE/update-product-trino.md
@@ -40,16 +40,18 @@ Part of #xxx.
 - [ ] _Link to the operator PR (getting_started / kuttl)_
 - [ ] _Link to any other operator PRs (getting_started / kuttl)_
 - [ ] _Link to demo PR (raise against the `next` branch)_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 ```
 
-<!--
-Make this a regular list so it isn't easily editable from the rendered
-description?
--->
+> [!TIP]
+> Delete any items that do not apply so that all applicable items can be checked.
+> For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally
 - [ ] Kuttl smoke tests passes locally
+- [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
 ```

--- a/.github/ISSUE_TEMPLATE/update-product-trino.md
+++ b/.github/ISSUE_TEMPLATE/update-product-trino.md
@@ -51,8 +51,8 @@ This list should be completed by the assignee(s), once respective PRs have been 
 
 ```[tasklist]
 ### Acceptance
-- [ ] Can build image locally
-- [ ] Kuttl smoke tests passes locally
+- [ ] Can build image (either locally, or in CI)
+- [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue

--- a/.github/ISSUE_TEMPLATE/update-product-zookeeper.md
+++ b/.github/ISSUE_TEMPLATE/update-product-zookeeper.md
@@ -38,6 +38,8 @@ Part of #xxx.
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
+This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally

--- a/.github/ISSUE_TEMPLATE/update-product-zookeeper.md
+++ b/.github/ISSUE_TEMPLATE/update-product-zookeeper.md
@@ -42,8 +42,8 @@ This list should be completed by the assignee(s), once respective PRs have been 
 
 ```[tasklist]
 ### Acceptance
-- [ ] Can build image locally
-- [ ] Kuttl smoke tests passes locally
+- [ ] Can build image (either locally, or in CI)
+- [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue

--- a/.github/ISSUE_TEMPLATE/update-product-zookeeper.md
+++ b/.github/ISSUE_TEMPLATE/update-product-zookeeper.md
@@ -31,16 +31,18 @@ Part of #xxx.
 - [ ] _Link to the operator PR (getting_started / kuttl)_
 - [ ] _Link to any other operator PRs (getting_started / kuttl)_
 - [ ] _Link to demo PR (raise against the `next` branch)_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 ```
 
-<!--
-Make this a regular list so it isn't easily editable from the rendered
-description?
--->
+> [!TIP]
+> Delete any items that do not apply so that all applicable items can be checked.
+> For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
+
 ```[tasklist]
 ### Acceptance
 - [ ] Can build image locally
 - [ ] Kuttl smoke tests passes locally
+- [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
 ```


### PR DESCRIPTION
# Description

- Allow the release notes to be updated at the same time (and linking the PR) instead of commenting and adding a label.
- Hint to delete acceptance criteria which do not apply (so all checkboxes can be ticked in the issue).
- Remove release note acceptance criteria from base images where they don't apply.
