### PR TITLE
fix(spark-k8s): Dockerfile lint error

### DIFF
--- a/spark-k8s/Dockerfile
+++ b/spark-k8s/Dockerfile
@@ -156,7 +156,7 @@ EOF
 
 # spark-builder: Build Spark into /stackable/spark-${PRODUCT}/dist,
 # download additional JARs and perform checks, like log4shell check.
-FROM stackable/image/java-devel as spark-builder
+FROM stackable/image/java-devel AS spark-builder
 
 ARG PRODUCT
 ARG HADOOP


### PR DESCRIPTION
# Description

Fix Dockerfile lint error

Fixed error:
> FromAsCasing: 'as' and 'FROM' keywords' casing do not match

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
