### PR TITLE
chore(kafka): Remove kubectl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project will be documented in this file.
 
 - nifi: Add NiFi hadoop Azure and GCP libraries ([#943]).
 
+### Removed
+
+- kafka: Remove `kubectl`, as we are now using listener-op ([#884]).
+
+[#884]: https://github.com/stackabletech/docker-images/pull/884
 [#943]: https://github.com/stackabletech/docker-images/pull/943
 
 ## [24.11.0] - 2024-11-18

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -68,8 +68,6 @@ LABEL name="Apache Kafka" \
       summary="The Stackable image for Apache Kafka." \
       description="This image is deployed by the Stackable Operator for Apache Kafka."
 
-# This is needed for kubectl
-COPY kafka/kubernetes.repo /etc/yum.repos.d/kubernetes.repo
 COPY --chown=${STACKABLE_USER_UID}:0 kafka/licenses /licenses
 COPY --chown=${STACKABLE_USER_UID}:0 --from=kafka-builder /stackable/kafka_${SCALA}-${PRODUCT} /stackable/kafka_${SCALA}-${PRODUCT}
 COPY --chown=${STACKABLE_USER_UID}:0 --from=kafka-builder /stackable/kafka_${SCALA}-${PRODUCT}.cdx.json /stackable/kafka_${SCALA}-${PRODUCT}/kafka_${SCALA}-${PRODUCT}.cdx.json
@@ -82,10 +80,8 @@ WORKDIR /stackable
 RUN <<EOF
 microdnf update
 # cyrus-sasl-gssapi: needed by kcat for kerberos
-# kubectl: Can be removed once listener-operator integration is used
 microdnf install \
-  cyrus-sasl-gssapi \
-  kubectl
+  cyrus-sasl-gssapi
 
 microdnf clean all
 rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}\n" | sort > /stackable/package_manifest.txt

--- a/kafka/kubernetes.repo
+++ b/kafka/kubernetes.repo
@@ -1,7 +1,0 @@
-# Copied from https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management
-[kubernetes]
-name=Kubernetes
-baseurl=https://pkgs.k8s.io/core:/stable:/v1.31/rpm/
-enabled=1
-gpgcheck=1
-gpgkey=https://pkgs.k8s.io/core:/stable:/v1.31/rpm/repodata/repomd.xml.key


### PR DESCRIPTION
# Description

Not needed anymore since https://github.com/stackabletech/kafka-operator/pull/443.
We could have removed back than already, but waited for 24.11 explicitly just to be sure.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
