### PR TITLE
Ignore Docker warning

### DIFF
--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.10.0@sha256:865e5dd094beca432e8c0a1d5e1c465db5f998dca4e439981029b3b81fb39ed5
-# check=error=true
+# check=error=true;skip=InvalidDefaultArgInFrom
 
 ARG GIT_SYNC
 


### PR DESCRIPTION
# Description

It'd warn about GIT_SYNC being possibly undefined. This is correct in theory, in practice however we always set it from the outside and defining it here could lead to version skew or another place to update versions.