### PR TITLE
chore(java-bases): Use a pull-through cache to reduce build failures

### DIFF
--- a/java-base/Dockerfile
+++ b/java-base/Dockerfile
@@ -21,7 +21,9 @@ LABEL name="Stackable image for OpenJDK" \
 RUN cat <<EOF > /etc/yum.repos.d/adoptium.repo
 [Adoptium]
 name=Adoptium
-baseurl=https://packages.adoptium.net/artifactory/rpm/rhel/\$releasever/\$basearch
+# The adoptium mirror times-out often, so we have created a pull-through cache
+# baseurl=https://packages.adoptium.net/artifactory/rpm/rhel/\$releasever/\$basearch
+baseurl=https://build-repo.stackable.tech/repository/Adoptium/\$releasever/\$basearch
 enabled=1
 gpgcheck=1
 gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public

--- a/java-devel/Dockerfile
+++ b/java-devel/Dockerfile
@@ -12,8 +12,11 @@ ARG PRODUCT
 # See: https://adoptium.net/en-gb/installation/linux/#_centosrhelfedora_instructions
 RUN cat <<EOF > /etc/yum.repos.d/adoptium.repo
 [Adoptium]
+[Adoptium]
 name=Adoptium
-baseurl=https://packages.adoptium.net/artifactory/rpm/rhel/\$releasever/\$basearch
+# The adoptium mirror times-out often, so we have created a pull-through cache
+# baseurl=https://packages.adoptium.net/artifactory/rpm/rhel/\$releasever/\$basearch
+baseurl=https://build-repo.stackable.tech/repository/Adoptium/\$releasever/\$basearch
 enabled=1
 gpgcheck=1
 gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public


### PR DESCRIPTION
# Description

*Please add a description here.*

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] All packages should have (if available) signatures/hashes verified
- [x] Add an entry to the CHANGELOG.md file
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
