### PR TITLE
chore: update setuptools

### DIFF
--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -45,7 +45,7 @@ RUN python3 -m venv /stackable/app \
     && pip install \
         --no-cache-dir \
         --upgrade \
-        setuptools==66.1.1 \
+        setuptools==75.2.0 \
         pip \
     && pip install \
         --no-cache-dir \


### PR DESCRIPTION
# Description

Setuptools was pinned to version 66.1.1 in https://github.com/stackabletech/docker-images/pull/307. That package contains a vulnerability (CVE-2024-6345). I bumped the dependency to the latest version, building and running Superset in my test cluster worked fine. I only tested with Superset 4.0.2, as that is currently the only version we plan to ship with SDP 24.11.