### PR TITLE
ci: Bump stackabletech/actions to 0.0.6

### DIFF
--- a/.github/workflows/dev_airflow.yaml
+++ b/.github/workflows/dev_airflow.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -51,14 +51,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -68,7 +68,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -91,7 +91,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -100,7 +100,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_druid.yaml
+++ b/.github/workflows/dev_druid.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -53,14 +53,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -70,7 +70,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -102,7 +102,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_hadoop.yaml
+++ b/.github/workflows/dev_hadoop.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -53,14 +53,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -70,7 +70,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -102,7 +102,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_hbase.yaml
+++ b/.github/workflows/dev_hbase.yaml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -54,14 +54,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -71,7 +71,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -94,7 +94,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -103,7 +103,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_hello-world.yaml
+++ b/.github/workflows/dev_hello-world.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -49,14 +49,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -66,7 +66,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -89,7 +89,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -98,7 +98,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_hive.yaml
+++ b/.github/workflows/dev_hive.yaml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -54,14 +54,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -71,7 +71,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -94,7 +94,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -103,7 +103,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_java-base.yaml
+++ b/.github/workflows/dev_java-base.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -49,14 +49,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -66,7 +66,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -89,7 +89,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -98,7 +98,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_java-devel.yaml
+++ b/.github/workflows/dev_java-devel.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -49,14 +49,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -66,7 +66,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -89,7 +89,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -98,7 +98,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_kafka-testing-tools.yaml
+++ b/.github/workflows/dev_kafka-testing-tools.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -53,14 +53,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -70,7 +70,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -102,7 +102,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_kafka.yaml
+++ b/.github/workflows/dev_kafka.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -55,14 +55,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -72,7 +72,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -95,7 +95,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -104,7 +104,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_kcat.yaml
+++ b/.github/workflows/dev_kcat.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -53,14 +53,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -70,7 +70,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -102,7 +102,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_krb5.yaml
+++ b/.github/workflows/dev_krb5.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -49,14 +49,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -66,7 +66,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -89,7 +89,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -98,7 +98,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_nifi.yaml
+++ b/.github/workflows/dev_nifi.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -53,14 +53,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -70,7 +70,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -102,7 +102,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_omid.yaml
+++ b/.github/workflows/dev_omid.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -53,14 +53,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -70,7 +70,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -102,7 +102,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_opa.yaml
+++ b/.github/workflows/dev_opa.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -51,14 +51,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -68,7 +68,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -91,7 +91,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -100,7 +100,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_spark-k8s.yaml
+++ b/.github/workflows/dev_spark-k8s.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -53,14 +53,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -70,7 +70,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -102,7 +102,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_stackable-base.yaml
+++ b/.github/workflows/dev_stackable-base.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -50,14 +50,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -67,7 +67,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -90,7 +90,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -99,7 +99,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_superset.yaml
+++ b/.github/workflows/dev_superset.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -51,14 +51,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -68,7 +68,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -91,7 +91,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -100,7 +100,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_testing-tools.yaml
+++ b/.github/workflows/dev_testing-tools.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -49,14 +49,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -66,7 +66,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -89,7 +89,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -98,7 +98,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_tools.yaml
+++ b/.github/workflows/dev_tools.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -50,14 +50,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -67,7 +67,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -90,7 +90,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -99,7 +99,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_trino-cli.yaml
+++ b/.github/workflows/dev_trino-cli.yaml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -52,14 +52,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -69,7 +69,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -92,7 +92,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -101,7 +101,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_trino.yaml
+++ b/.github/workflows/dev_trino.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -53,14 +53,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -70,7 +70,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -102,7 +102,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_vector.yaml
+++ b/.github/workflows/dev_vector.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -49,14 +49,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -66,7 +66,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -89,7 +89,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -98,7 +98,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_zookeeper.yaml
+++ b/.github/workflows/dev_zookeeper.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/shard@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -53,14 +53,14 @@ jobs:
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/build-product-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -70,7 +70,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -102,7 +102,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -50,7 +50,7 @@ jobs:
           echo "IMAGE_REPOSITORY=$(.scripts/get_repo_name.sh)" | tee -a "$GITHUB_ENV"
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -60,7 +60,7 @@ jobs:
           source-image-uri: ${{ format('{0}:{1}', inputs.image-repository-uri, inputs.image-index-manifest-tag) }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-image@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -85,7 +85,7 @@ jobs:
           echo "IMAGE_REPOSITORY=$(.scripts/get_repo_name.sh)" | tee -a "$GITHUB_ENV"
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -94,7 +94,7 @@ jobs:
           image-index-manifest-tag: ${{ inputs.image-index-manifest-tag }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+        uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/pr_pre-commit.yaml
+++ b/.github/workflows/pr_pre-commit.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
-      - uses: stackabletech/actions/run-pre-commit@e8781161bc1eb037198098334cec6061fe24b6c3 # 0.0.2
+      - uses: stackabletech/actions/run-pre-commit@013e6482fbc0edf2d38cf9220fc931f6a81336fb # 0.0.6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           hadolint: ${{ env.HADOLINT_VERSION }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 - java: migrate to temurin jdk/jre ([#894]).
 - tools: bump kubectl to `1.31.1` and jq to `1.7.1` ([#896]).
 - Make username, user id, group id configurable, use numeric ids everywhere, change group of all files to 0 ([#849], [#890]).
+- ci: Bump `stackabletech/actions` to 0.0.6 ([#901]).
 
 ### Removed
 
@@ -85,6 +86,7 @@ All notable changes to this project will be documented in this file.
 [#890]: https://github.com/stackabletech/docker-images/pull/890
 [#894]: https://github.com/stackabletech/docker-images/pull/894
 [#896]: https://github.com/stackabletech/docker-images/pull/896
+[#901]: https://github.com/stackabletech/docker-images/pull/901
 
 ## [24.7.0] - 2024-07-24
 


### PR DESCRIPTION
This PR updates all `stackabletech` actions to 0.0.6.

This also fixes the issue encountered [here](https://github.com/stackabletech/docker-images/actions/runs/11443883437/job/31837551061#step:4:356).