### PR TITLE
ci: Bump stackabletech/actions to 0.1.0

### DIFF
--- a/.github/workflows/dev_airflow.yaml
+++ b/.github/workflows/dev_airflow.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -49,16 +49,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -68,7 +71,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -90,8 +93,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -100,7 +105,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_druid.yaml
+++ b/.github/workflows/dev_druid.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -51,16 +51,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -70,7 +73,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -92,8 +95,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -102,7 +107,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_hadoop.yaml
+++ b/.github/workflows/dev_hadoop.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -51,16 +51,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -70,7 +73,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -92,8 +95,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -102,7 +107,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_hbase.yaml
+++ b/.github/workflows/dev_hbase.yaml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -52,16 +52,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -71,7 +74,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -93,8 +96,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -103,7 +108,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_hello-world.yaml
+++ b/.github/workflows/dev_hello-world.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -47,16 +47,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -66,7 +69,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -88,8 +91,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -98,7 +103,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_hive.yaml
+++ b/.github/workflows/dev_hive.yaml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -52,16 +52,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -71,7 +74,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -93,8 +96,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -103,7 +108,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_java-base.yaml
+++ b/.github/workflows/dev_java-base.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -47,16 +47,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -66,7 +69,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -88,8 +91,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -98,7 +103,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_java-devel.yaml
+++ b/.github/workflows/dev_java-devel.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -47,16 +47,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -66,7 +69,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -88,8 +91,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -98,7 +103,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_kafka-testing-tools.yaml
+++ b/.github/workflows/dev_kafka-testing-tools.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -51,16 +51,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -70,7 +73,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -92,8 +95,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -102,7 +107,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_kafka.yaml
+++ b/.github/workflows/dev_kafka.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -53,16 +53,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -72,7 +75,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -94,8 +97,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -104,7 +109,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_kcat.yaml
+++ b/.github/workflows/dev_kcat.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -51,16 +51,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -70,7 +73,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -92,8 +95,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -102,7 +107,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_krb5.yaml
+++ b/.github/workflows/dev_krb5.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -47,16 +47,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -66,7 +69,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -88,8 +91,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -98,7 +103,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_nifi.yaml
+++ b/.github/workflows/dev_nifi.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -51,16 +51,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -70,7 +73,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -92,8 +95,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -102,7 +107,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_omid.yaml
+++ b/.github/workflows/dev_omid.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -51,16 +51,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -70,7 +73,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -92,8 +95,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -102,7 +107,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_opa.yaml
+++ b/.github/workflows/dev_opa.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -49,16 +49,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -68,7 +71,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -90,8 +93,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -100,7 +105,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_spark-k8s.yaml
+++ b/.github/workflows/dev_spark-k8s.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -51,16 +51,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -70,7 +73,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -92,8 +95,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -102,7 +107,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_stackable-base.yaml
+++ b/.github/workflows/dev_stackable-base.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -48,16 +48,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -67,7 +70,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -89,8 +92,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -99,7 +104,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_superset.yaml
+++ b/.github/workflows/dev_superset.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -49,16 +49,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -68,7 +71,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -90,8 +93,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -100,7 +105,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_testing-tools.yaml
+++ b/.github/workflows/dev_testing-tools.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -47,16 +47,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -66,7 +69,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -88,8 +91,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -98,7 +103,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_tools.yaml
+++ b/.github/workflows/dev_tools.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -48,16 +48,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -67,7 +70,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -89,8 +92,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -99,7 +104,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_trino-cli.yaml
+++ b/.github/workflows/dev_trino-cli.yaml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -50,16 +50,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -69,7 +72,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -91,8 +94,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -101,7 +106,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_trino.yaml
+++ b/.github/workflows/dev_trino.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -51,16 +51,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -70,7 +73,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -92,8 +95,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -102,7 +107,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_vector.yaml
+++ b/.github/workflows/dev_vector.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -47,16 +47,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -66,7 +69,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -88,8 +91,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -98,7 +103,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/dev_zookeeper.yaml
+++ b/.github/workflows/dev_zookeeper.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - id: shard
-        uses: stackabletech/actions/shard@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/shard@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
     outputs:
@@ -51,16 +51,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
+
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/build-product-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           product-name: ${{ env.PRODUCT_NAME }}
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -70,7 +73,7 @@ jobs:
           source-image-uri: localhost/${{ env.PRODUCT_NAME }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -92,8 +95,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Free Disk Space
+        uses: stackabletech/actions/free-disk-space@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -102,7 +107,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -50,7 +50,7 @@ jobs:
           echo "IMAGE_REPOSITORY=$(.scripts/get_repo_name.sh)" | tee -a "$GITHUB_ENV"
 
       - name: Publish Container Image on docker.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -60,7 +60,7 @@ jobs:
           source-image-uri: ${{ format('{0}:{1}', inputs.image-repository-uri, inputs.image-index-manifest-tag) }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-image@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -85,7 +85,7 @@ jobs:
           echo "IMAGE_REPOSITORY=$(.scripts/get_repo_name.sh)" | tee -a "$GITHUB_ENV"
 
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: docker.stackable.tech
           image-registry-username: github
@@ -94,7 +94,7 @@ jobs:
           image-index-manifest-tag: ${{ inputs.image-index-manifest-tag }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+        uses: stackabletech/actions/publish-index-manifest@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/pr_pre-commit.yaml
+++ b/.github/workflows/pr_pre-commit.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
-      - uses: stackabletech/actions/run-pre-commit@9a7313de6170edc00f5a497ef58dcbaeb46ee1d2 # 0.0.8
+      - uses: stackabletech/actions/run-pre-commit@fe921a914283975f3be1f5f47348467a94276d41 # 0.1.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           hadolint: ${{ env.HADOLINT_VERSION }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file.
 - java: migrate to temurin jdk/jre ([#894]).
 - tools: bump kubectl to `1.31.1` and jq to `1.7.1` ([#896]).
 - Make username, user id, group id configurable, use numeric ids everywhere, change group of all files to 0 ([#849], [#890], [#897]).
-- ci: Bump `stackabletech/actions` to 0.0.8 ([#901], [#903], [#907]).
+- ci: Bump `stackabletech/actions` to 0.1.0 ([#901], [#903], [#907], [#910]).
 - ubi-rust-builder: Bump Rust toolchain to 1.81.0 ([#902]).
 
 ### Removed
@@ -94,6 +94,7 @@ All notable changes to this project will be documented in this file.
 [#902]: https://github.com/stackabletech/docker-images/pull/902
 [#903]: https://github.com/stackabletech/docker-images/pull/903
 [#907]: https://github.com/stackabletech/docker-images/pull/907
+[#910]: https://github.com/stackabletech/docker-images/pull/910
 
 ## [24.7.0] - 2024-07-24
 


### PR DESCRIPTION
# Description

> [!IMPORTANT]
> This fixes the workflows which were broken in #907.

Bump stackabletech/actions to [0.1.0](https://github.com/stackabletech/actions/releases/tag/v0.1.0).

This requires the free-disk-space action to be run directly in the workflow instead of being part of the build actions. See https://github.com/stackabletech/actions/pull/14.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
- [x] Add an entry to the CHANGELOG.md file
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
