### PR TITLE
feat: install yq in tools image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - kafka: Add cyrus-sasl-gssapi package for kerberos ([#874]).
 - spark: Add HBase connector ([#878], [#882]).
 - hbase: hbase-entrypoint.sh script to start and gracefully stop services ([#898]).
+- tools: install yq command line tool for YAML manipulation ([#912]).
 
 ### Changed
 
@@ -95,6 +96,7 @@ All notable changes to this project will be documented in this file.
 [#903]: https://github.com/stackabletech/docker-images/pull/903
 [#907]: https://github.com/stackabletech/docker-images/pull/907
 [#910]: https://github.com/stackabletech/docker-images/pull/910
+[#912]: https://github.com/stackabletech/docker-images/pull/912
 
 ## [24.7.0] - 2024-07-24
 

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -7,6 +7,7 @@ ARG PRODUCT
 ARG KUBECTL_VERSION
 ARG RELEASE
 ARG JQ_VERSION
+ARG YQ_VERSION
 ARG TARGETARCH
 ARG STACKABLE_USER_UID
 
@@ -36,13 +37,17 @@ ENV PATH=/stackable/bin:$PATH
 
 # Get latest stable version from curl -L -s https://dl.k8s.io/release/stable.txt
 RUN <<EOF
-curl "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
+curl --fail -L "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
     -o /stackable/bin/kubectl
 chmod +x /stackable/bin/kubectl
 
-curl "https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64" \
+curl --fail -L "https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64" \
     -o /stackable/bin/jq
 chmod +x /stackable/bin/jq
+
+curl --fail -L "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${TARGETARCH}" \
+    -o /stackable/bin/yq
+chmod +x /stackable/bin/yq
 
 # All files and folders owned by root group to support running as arbitrary users.
 # This is best practice as all container users will belong to the root group (0).

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -45,6 +45,8 @@ curl "https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux
     -o /stackable/bin/jq
 chmod +x /stackable/bin/jq
 
+# Needed to to patch manifests in OLM environments with tolerations
+# and environment variables.
 curl "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${TARGETARCH}" \
     -o /stackable/bin/yq
 chmod +x /stackable/bin/yq

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -37,15 +37,15 @@ ENV PATH=/stackable/bin:$PATH
 
 # Get latest stable version from curl -L -s https://dl.k8s.io/release/stable.txt
 RUN <<EOF
-curl --fail -L "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
+curl "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
     -o /stackable/bin/kubectl
 chmod +x /stackable/bin/kubectl
 
-curl --fail -L "https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64" \
+curl "https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64" \
     -o /stackable/bin/jq
 chmod +x /stackable/bin/jq
 
-curl --fail -L "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${TARGETARCH}" \
+curl "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${TARGETARCH}" \
     -o /stackable/bin/yq
 chmod +x /stackable/bin/yq
 

--- a/tools/versions.py
+++ b/tools/versions.py
@@ -4,5 +4,6 @@ versions = [
         "kubectl_version": "1.31.1",
         "jq_version": "1.7.1",
         "stackable-base": "1.0.0",
+        "yq_version": "4.44.3",
     },
 ]


### PR DESCRIPTION
# Description

Part of: <https://github.com/stackabletech/issues/issues/644>

This image is used to deploy the secret and listener ops in OLM environments.

`yq` is needed to manipulate the OLM manifests in order to append user defined tolerations and environment variables.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
