### PR TITLE
ci: Add failure notifications to workflows

### DIFF
--- a/.github/workflows/build_airflow.yaml
+++ b/.github/workflows/build_airflow.yaml
@@ -114,3 +114,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/build_druid.yaml
+++ b/.github/workflows/build_druid.yaml
@@ -116,3 +116,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/build_hadoop.yaml
+++ b/.github/workflows/build_hadoop.yaml
@@ -116,3 +116,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/build_hbase.yaml
+++ b/.github/workflows/build_hbase.yaml
@@ -117,3 +117,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/build_hello-world.yaml
+++ b/.github/workflows/build_hello-world.yaml
@@ -112,3 +112,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/build_hive.yaml
+++ b/.github/workflows/build_hive.yaml
@@ -117,3 +117,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/build_java-base.yaml
+++ b/.github/workflows/build_java-base.yaml
@@ -112,3 +112,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/build_java-devel.yaml
+++ b/.github/workflows/build_java-devel.yaml
@@ -112,3 +112,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/build_kafka-testing-tools.yaml
+++ b/.github/workflows/build_kafka-testing-tools.yaml
@@ -116,3 +116,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/build_kafka.yaml
+++ b/.github/workflows/build_kafka.yaml
@@ -118,3 +118,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/build_kcat.yaml
+++ b/.github/workflows/build_kcat.yaml
@@ -116,3 +116,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/build_krb5.yaml
+++ b/.github/workflows/build_krb5.yaml
@@ -112,3 +112,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/build_nifi.yaml
+++ b/.github/workflows/build_nifi.yaml
@@ -116,3 +116,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/build_omid.yaml
+++ b/.github/workflows/build_omid.yaml
@@ -116,3 +116,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/build_opa.yaml
+++ b/.github/workflows/build_opa.yaml
@@ -114,3 +114,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/build_spark-k8s.yaml
+++ b/.github/workflows/build_spark-k8s.yaml
@@ -116,3 +116,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/build_stackable-base.yaml
+++ b/.github/workflows/build_stackable-base.yaml
@@ -113,3 +113,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/build_superset.yaml
+++ b/.github/workflows/build_superset.yaml
@@ -114,3 +114,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/build_testing-tools.yaml
+++ b/.github/workflows/build_testing-tools.yaml
@@ -112,3 +112,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/build_tools.yaml
+++ b/.github/workflows/build_tools.yaml
@@ -113,3 +113,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/build_trino-cli.yaml
+++ b/.github/workflows/build_trino-cli.yaml
@@ -115,3 +115,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/build_trino.yaml
+++ b/.github/workflows/build_trino.yaml
@@ -116,3 +116,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/build_vector.yaml
+++ b/.github/workflows/build_vector.yaml
@@ -112,3 +112,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/build_zookeeper.yaml
+++ b/.github/workflows/build_zookeeper.yaml
@@ -116,3 +116,49 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Generate Version List",
+                      "short": true,
+                      "value": "${{ needs.generate_matrix.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -101,3 +101,44 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: ${{ format('sdp/{0}', env.IMAGE_REPOSITORY) }}
           image-index-manifest-tag: ${{ inputs.image-index-manifest-tag }}
+
+  notify:
+    name: Failure Notification
+    needs: [mirror-image, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Mirror Image",
+                      "short": true,
+                      "value": "${{ needs.mirror-image.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/preflight.yaml
+++ b/.github/workflows/preflight.yaml
@@ -96,3 +96,39 @@ jobs:
             --architecture "linux/${ARCH_FOR_PREFLIGHT}" \
             --executable ./preflight-linux-amd64 \
             --token "${{ secrets.RH_PYXIS_API_TOKEN }}" \
+
+  notify:
+    name: Failure Notification
+    needs: [preflight]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Preflight",
+                      "short": true,
+                      "value": "${{ needs.preflight.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}

--- a/.github/workflows/ubi-rust-builder.yml
+++ b/.github/workflows/ubi-rust-builder.yml
@@ -1,5 +1,5 @@
 ---
-name: UBI Builder rebuild
+name: Build UBI Rust Builders
 
 on:
   push:
@@ -78,3 +78,44 @@ jobs:
           # This generates a signature and publishes it to the registry, next to the image
           # Uses the keyless signing flow with Github Actions as identity provider
           cosign sign -y "$MANIFEST_LIST_NAME@$DIGEST"
+
+  notify:
+    name: Failure Notification
+    needs: [build, create_manifest]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Build",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Create Manifest",
+                      "short": true,
+                      "value": "${{ needs.create_manifest.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}


### PR DESCRIPTION
# Description

Add a job at the end of each workflow which only runs on failure to send a slack notitification.

<details>
<summary>Considerations</summary>

We had the following four options to choose from:

1. Manually create threads per workflow, and hard code thread ids into each workflow.
    - Continuous log of build successes/failures along with relevant conversations.
    - Main thread stays clean.
2. _Be smat_ and get a thread-id from a cached artifact, and if it doesn't exist, create a new one.
    - Same as the first option, but without all the manual work. Good for adding new workflows.
3. Create a thread per workflow run (begin workflow, build, manifest, done)
4. Only message on failure (higher signal-to-noise, people might be happy to receive alerts for it since each would require action)

We opted for _Option 4_ to keep things simple and to increase signal-to-noise (alerts are actionable).

We have a further idea of having each [action](https://github.com/stackabletech/actions) write some high-level results to a file/output, and have a wrapping action that collates them all and builds the slack payload. This will be a little complicated with matrix jobs.

</details>
