### PR TITLE
Change default user id and gid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to this project will be documented in this file.
 - yq: Bump products to use `4.45.2` ([#1090]).
 - cyclonedx-bom: Bump airflow and superset to use `6.0.0` ([#1090]).
 - vector: Bump to `0.46.1` ([#1098]).
+- Changed default user & group IDs from 1000/1000 to 782252253/574654813 ([#916])
 
 ### Fixed
 
@@ -75,6 +76,7 @@ All notable changes to this project will be documented in this file.
 - opa: Remove `0.67.1` ([#1103]).
 - opa: Remove legacy bundle-builder from container build ([#1103]).
 
+[#916]: https://github.com/stackabletech/docker-images/pull/916
 [#1025]: https://github.com/stackabletech/docker-images/pull/1025
 [#1027]: https://github.com/stackabletech/docker-images/pull/1027
 [#1028]: https://github.com/stackabletech/docker-images/pull/1028

--- a/conf.py
+++ b/conf.py
@@ -98,7 +98,7 @@ cache = [
 
 args = {
     "STACKABLE_USER_NAME": "stackable",
-    "STACKABLE_USER_UID": "1000",
-    "STACKABLE_USER_GID": "1000",
+    "STACKABLE_USER_UID": "782252253",
+    "STACKABLE_USER_GID": "574654813",
     "DELETE_CACHES": "true",
 }

--- a/conf.py
+++ b/conf.py
@@ -98,7 +98,7 @@ cache = [
 
 args = {
     "STACKABLE_USER_NAME": "stackable",
-    "STACKABLE_USER_UID": "782252253",
-    "STACKABLE_USER_GID": "574654813",
+    "STACKABLE_USER_UID": "782252253", # This is a random high id to not conflict with any existing user
+    "STACKABLE_USER_GID": "574654813", # This is a random high id to not conflict with any existing group
     "DELETE_CACHES": "true",
 }

--- a/conf.py
+++ b/conf.py
@@ -98,7 +98,7 @@ cache = [
 
 args = {
     "STACKABLE_USER_NAME": "stackable",
-    "STACKABLE_USER_UID": "782252253", # This is a random high id to not conflict with any existing user
-    "STACKABLE_USER_GID": "574654813", # This is a random high id to not conflict with any existing group
+    "STACKABLE_USER_UID": "782252253",  # This is a random high id to not conflict with any existing user
+    "STACKABLE_USER_GID": "574654813",  # This is a random high id to not conflict with any existing group
     "DELETE_CACHES": "true",
 }


### PR DESCRIPTION
# Description
_Part of https://github.com/stackabletech/issues/issues/645_

Change default user id and gid to the same ones we use in the operators themselves.
These are only the defaults that are used when a Pod does not specify their own `securityContext.runAsUser` or `runAsGroup`.

As of now all our operators do set these (and `fsGroup`) to 1000 and 0 respectively.
As the next step we want to remove that hardcoding so the default would then fall back to what we specify here.

Therefore I do believe that this PR should be a simple change with no downstream consequences until the PRs from https://github.com/stackabletech/issues/issues/651 are merged.

## Definition of Done Checklist

- [x] Changes are OpenShift compatible
- [x] Add an entry to the CHANGELOG.md file
- [x] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
