### PR TITLE
Spark now depends on HBase and should be rebuilt automatically as well

### DIFF
--- a/.github/workflows/build_spark-k8s.yaml
+++ b/.github/workflows/build_spark-k8s.yaml
@@ -15,6 +15,7 @@ on:
     paths:
       # To check dependencies, run this ( you will need to consider transitive dependencies)
       # bake --product PRODUCT -d | grep -v 'docker buildx bake' | jq '.target | keys[]'
+      - hbase/**
       - spark-k8s/**
       - vector/**
       - stackable-base/**


### PR DESCRIPTION
# Description

Spark now depends on HBase and should be rebuilt automatically as well.

