### PR TITLE
Base aircompressor 0.27 patch diff on previous patches

### DIFF
--- a/hbase/stackable/patches/2.6.0/06-CVE-2024-36114-bump-aircompressor-0-27.patch
+++ b/hbase/stackable/patches/2.6.0/06-CVE-2024-36114-bump-aircompressor-0-27.patch
@@ -19,15 +19,15 @@ leak other sensitive information from the Java process. There are no
 known workarounds for this issue.
 
 diff --git a/pom.xml b/pom.xml
-index 918cdaa675..bc7ed28404 100644
+index 0bd6a69703..50948c2746 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -655,7 +655,7 @@
      <spotless.version>2.27.2</spotless.version>
-     <maven-site.version>3.12.0</maven-site.version>
+     <maven-site.version>3.12.1</maven-site.version>
      <!-- compression -->
 -    <aircompressor.version>0.24</aircompressor.version>
 +    <aircompressor.version>0.27</aircompressor.version>
      <brotli4j.version>1.11.0</brotli4j.version>
      <lz4.version>1.8.0</lz4.version>
-     <snappy.version>1.1.10.4</snappy.version>
+     <snappy.version>1.1.10.5</snappy.version>


### PR DESCRIPTION
# Description

This **should** fix the HBase 2.6.0 build errors.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
