### PR TITLE
fix(hbase): CVE-34455

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ All notable changes to this project will be documented in this file.
 - nifi: Fix CVE-2024-36114 in NiFi `1.27.0` and `2.0.0` by upgrading a dependency. ([#924]).
 - hbase: Fix CVE-2024-36114 in HBase `2.6.0` by upgrading a dependency. ([#925]).
 - druid: Fix CVE-2024-36114 in Druid `26.0.0` and `30.0.0` by upgrading a dependency ([#926]).
+- hbase: Fix CVE-2023-34455 in HBase `2.4.18` by upgrading a dependency. ([#934]).
 
 [#783]: https://github.com/stackabletech/docker-images/pull/783
 [#797]: https://github.com/stackabletech/docker-images/pull/797
@@ -119,6 +120,7 @@ All notable changes to this project will be documented in this file.
 [#924]: https://github.com/stackabletech/docker-images/pull/924
 [#925]: https://github.com/stackabletech/docker-images/pull/925
 [#926]: https://github.com/stackabletech/docker-images/pull/926
+[#934]: https://github.com/stackabletech/docker-images/pull/934
 
 ## [24.7.0] - 2024-07-24
 

--- a/hbase/stackable/patches/phoenix/5.2.0/02-CVE-2023-34455-update-snappy-version.patch
+++ b/hbase/stackable/patches/phoenix/5.2.0/02-CVE-2023-34455-update-snappy-version.patch
@@ -1,0 +1,97 @@
+Fix CVE-2023-34455
+
+See https://github.com/stackabletech/vulnerabilities/issues/558
+
+diff --git a/phoenix-core-client/pom.xml b/phoenix-core-client/pom.xml
+index f711b0f6f..3cfbffef9 100644
+--- a/phoenix-core-client/pom.xml
++++ b/phoenix-core-client/pom.xml
+@@ -230,6 +230,12 @@
+       <groupId>org.apache.hadoop</groupId>
+       <artifactId>hadoop-auth</artifactId>
+     </dependency>
++    <!-- Fix CVE-2023-34455 -->
++    <dependency>
++      <groupId>org.xerial.snappy</groupId>
++      <artifactId>snappy-java</artifactId>
++      <version>1.1.10.4</version>
++    </dependency>
+ 
+     <!-- HBase dependencies -->
+     <dependency>
+diff --git a/phoenix-core-server/pom.xml b/phoenix-core-server/pom.xml
+index d5032ece2..e47fb0837 100644
+--- a/phoenix-core-server/pom.xml
++++ b/phoenix-core-server/pom.xml
+@@ -59,6 +59,12 @@
+             <groupId>org.apache.hadoop</groupId>
+             <artifactId>hadoop-mapreduce-client-core</artifactId>
+         </dependency>
++        <!-- Fix CVE-2023-34455 -->
++        <dependency>
++          <groupId>org.xerial.snappy</groupId>
++          <artifactId>snappy-java</artifactId>
++          <version>1.1.10.4</version>
++        </dependency>
+ 
+         <!-- HBase dependencies -->
+         <dependency>
+@@ -192,4 +198,4 @@
+             </plugin>
+         </plugins>
+     </build>
+-</project>
+\ No newline at end of file
++</project>
+diff --git a/phoenix-pherf/pom.xml b/phoenix-pherf/pom.xml
+index c03fff9a1..cdcce2f98 100644
+--- a/phoenix-pherf/pom.xml
++++ b/phoenix-pherf/pom.xml
+@@ -159,6 +159,12 @@
+       <groupId>org.apache.hbase</groupId>
+       <artifactId>hbase-server</artifactId>
+     </dependency>
++    <!-- Fix CVE-2023-34455 -->
++    <dependency>
++      <groupId>org.xerial.snappy</groupId>
++      <artifactId>snappy-java</artifactId>
++      <version>1.1.10.4</version>
++    </dependency>
+ 
+     <!-- Test Dependencies -->
+     <dependency>
+diff --git a/phoenix-tracing-webapp/pom.xml b/phoenix-tracing-webapp/pom.xml
+index d2d1549ef..c8054159e 100755
+--- a/phoenix-tracing-webapp/pom.xml
++++ b/phoenix-tracing-webapp/pom.xml
+@@ -89,6 +89,12 @@
+         <groupId>org.apache.hbase</groupId>
+         <artifactId>hbase-common</artifactId>
+       </dependency>
++      <!-- Fix CVE-2023-34455 -->
++      <dependency>
++        <groupId>org.xerial.snappy</groupId>
++        <artifactId>snappy-java</artifactId>
++        <version>1.1.10.4</version>
++      </dependency>
+     </dependencies>
+ 
+     <build>
+diff --git a/pom.xml b/pom.xml
+index 4abcb5a28..21dcf71ad 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -850,6 +850,13 @@
+           </exclusion>
+         </exclusions>
+       </dependency>
++      <!-- Fix CVE-2023-34455 -->
++      <dependency>
++        <groupId>org.xerial.snappy</groupId>
++        <artifactId>snappy-java</artifactId>
++        <version>1.1.10.4</version>
++      </dependency>
++
+       <dependency>
+         <groupId>org.apache.hadoop</groupId>
+         <artifactId>hadoop-common</artifactId>

--- a/hbase/stackable/patches/phoenix/5.2.0/series
+++ b/hbase/stackable/patches/phoenix/5.2.0/series
@@ -1,1 +1,2 @@
 01-cyclonedx-plugin.patch
+02-CVE-2023-34455-update-snappy-version.patch


### PR DESCRIPTION
# Description

Part of: https://github.com/stackabletech/vulnerabilities/issues/558

:green_circle: CI https://testing.stackable.tech/job/hbase-operator-it-custom/35/

Trivy scan shows the CVE is not present anymore.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
