### PR TITLE
ci: Use correct version image index manifest tag

### DIFF
--- a/.github/workflows/build_airflow.yaml
+++ b/.github/workflows/build_airflow.yaml
@@ -102,7 +102,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -111,7 +111,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/build_druid.yaml
+++ b/.github/workflows/build_druid.yaml
@@ -104,7 +104,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -113,7 +113,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/build_hadoop.yaml
+++ b/.github/workflows/build_hadoop.yaml
@@ -104,7 +104,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -113,7 +113,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/build_hbase.yaml
+++ b/.github/workflows/build_hbase.yaml
@@ -105,7 +105,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -114,7 +114,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/build_hello-world.yaml
+++ b/.github/workflows/build_hello-world.yaml
@@ -100,7 +100,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -109,7 +109,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/build_hive.yaml
+++ b/.github/workflows/build_hive.yaml
@@ -105,7 +105,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -114,7 +114,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/build_java-base.yaml
+++ b/.github/workflows/build_java-base.yaml
@@ -100,7 +100,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -109,7 +109,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/build_java-devel.yaml
+++ b/.github/workflows/build_java-devel.yaml
@@ -100,7 +100,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -109,7 +109,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/build_kafka-testing-tools.yaml
+++ b/.github/workflows/build_kafka-testing-tools.yaml
@@ -104,7 +104,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -113,7 +113,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/build_kafka.yaml
+++ b/.github/workflows/build_kafka.yaml
@@ -106,7 +106,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -115,7 +115,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/build_kcat.yaml
+++ b/.github/workflows/build_kcat.yaml
@@ -104,7 +104,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -113,7 +113,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/build_krb5.yaml
+++ b/.github/workflows/build_krb5.yaml
@@ -100,7 +100,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -109,7 +109,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/build_nifi.yaml
+++ b/.github/workflows/build_nifi.yaml
@@ -104,7 +104,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -113,7 +113,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/build_omid.yaml
+++ b/.github/workflows/build_omid.yaml
@@ -104,7 +104,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -113,7 +113,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/build_opa.yaml
+++ b/.github/workflows/build_opa.yaml
@@ -102,7 +102,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -111,7 +111,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/build_spark-k8s.yaml
+++ b/.github/workflows/build_spark-k8s.yaml
@@ -105,7 +105,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -114,7 +114,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/build_stackable-base.yaml
+++ b/.github/workflows/build_stackable-base.yaml
@@ -101,7 +101,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -110,7 +110,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/build_superset.yaml
+++ b/.github/workflows/build_superset.yaml
@@ -102,7 +102,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -111,7 +111,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/build_testing-tools.yaml
+++ b/.github/workflows/build_testing-tools.yaml
@@ -100,7 +100,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -109,7 +109,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/build_tools.yaml
+++ b/.github/workflows/build_tools.yaml
@@ -101,7 +101,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -110,7 +110,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/build_trino-cli.yaml
+++ b/.github/workflows/build_trino-cli.yaml
@@ -103,7 +103,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -112,7 +112,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/build_trino.yaml
+++ b/.github/workflows/build_trino.yaml
@@ -104,7 +104,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -113,7 +113,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/build_vector.yaml
+++ b/.github/workflows/build_vector.yaml
@@ -100,7 +100,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -109,7 +109,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/build_zookeeper.yaml
+++ b/.github/workflows/build_zookeeper.yaml
@@ -104,7 +104,7 @@ jobs:
           image-registry-username: github
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: stackable/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@a3f7587879e9f12e04a29fd26435949aaa4fd59c # 0.2.0
@@ -113,7 +113,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: sdp/${{ env.PRODUCT_NAME }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ env.SDP_VERSION }}
 
   notify:
     name: Failure Notification

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,5 +58,5 @@ repos:
         name: update-readme-badges
         language: system
         entry: .scripts/update_readme_badges.sh
-        stages: [commit, merge-commit, manual]
+        stages: [pre-commit, pre-merge-commit, manual]
         pass_filenames: false


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/647

Fixes the invalid version in the image index manifest tag.