### PR TITLE
Use our build-repo for Maven downloads & other updates

### DIFF
--- a/.github/workflows/build_airflow.yaml
+++ b/.github/workflows/build_airflow.yaml
@@ -43,6 +43,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -91,6 +92,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/build_druid.yaml
+++ b/.github/workflows/build_druid.yaml
@@ -45,6 +45,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -93,6 +94,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/build_hadoop.yaml
+++ b/.github/workflows/build_hadoop.yaml
@@ -45,6 +45,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -93,6 +94,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/build_hbase.yaml
+++ b/.github/workflows/build_hbase.yaml
@@ -46,6 +46,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -94,6 +95,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/build_hello-world.yaml
+++ b/.github/workflows/build_hello-world.yaml
@@ -41,6 +41,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -89,6 +90,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/build_hive.yaml
+++ b/.github/workflows/build_hive.yaml
@@ -46,6 +46,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -94,6 +95,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/build_java-base.yaml
+++ b/.github/workflows/build_java-base.yaml
@@ -41,6 +41,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -89,6 +90,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/build_java-devel.yaml
+++ b/.github/workflows/build_java-devel.yaml
@@ -41,6 +41,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -89,6 +90,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/build_kafka-testing-tools.yaml
+++ b/.github/workflows/build_kafka-testing-tools.yaml
@@ -45,6 +45,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -93,6 +94,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/build_kafka.yaml
+++ b/.github/workflows/build_kafka.yaml
@@ -47,6 +47,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -95,6 +96,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/build_kcat.yaml
+++ b/.github/workflows/build_kcat.yaml
@@ -45,6 +45,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -93,6 +94,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/build_krb5.yaml
+++ b/.github/workflows/build_krb5.yaml
@@ -41,6 +41,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -89,6 +90,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/build_nifi.yaml
+++ b/.github/workflows/build_nifi.yaml
@@ -45,6 +45,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -93,6 +94,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/build_omid.yaml
+++ b/.github/workflows/build_omid.yaml
@@ -45,6 +45,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -93,6 +94,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/build_opa.yaml
+++ b/.github/workflows/build_opa.yaml
@@ -43,6 +43,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -91,6 +92,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/build_spark-k8s.yaml
+++ b/.github/workflows/build_spark-k8s.yaml
@@ -46,6 +46,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -94,6 +95,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/build_stackable-base.yaml
+++ b/.github/workflows/build_stackable-base.yaml
@@ -42,6 +42,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -90,6 +91,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/build_superset.yaml
+++ b/.github/workflows/build_superset.yaml
@@ -43,6 +43,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -91,6 +92,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/build_testing-tools.yaml
+++ b/.github/workflows/build_testing-tools.yaml
@@ -41,6 +41,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -89,6 +90,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/build_tools.yaml
+++ b/.github/workflows/build_tools.yaml
@@ -42,6 +42,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -90,6 +91,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/build_trino-cli.yaml
+++ b/.github/workflows/build_trino-cli.yaml
@@ -44,6 +44,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -92,6 +93,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/build_trino.yaml
+++ b/.github/workflows/build_trino.yaml
@@ -45,6 +45,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -93,6 +94,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/build_vector.yaml
+++ b/.github/workflows/build_vector.yaml
@@ -41,6 +41,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -89,6 +90,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/build_zookeeper.yaml
+++ b/.github/workflows/build_zookeeper.yaml
@@ -45,6 +45,7 @@ jobs:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - {name: "ubuntu-latest", arch: "amd64"}
@@ -93,6 +94,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -29,6 +29,7 @@ jobs:
     permissions:
       id-token: write
     strategy:
+      fail-fast: false
       matrix:
         arch:
           - amd64

--- a/.github/workflows/ubi-rust-builder.yml
+++ b/.github/workflows/ubi-rust-builder.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       id-token: write
     strategy:
+      fail-fast: false
       matrix:
         runner: ["ubuntu-latest", "ubicloud-standard-8-arm"]
         ubi-version: ["ubi8", "ubi9"]
@@ -52,6 +53,7 @@ jobs:
     permissions:
       id-token: write
     strategy:
+      fail-fast: false
       matrix:
         ubi-version: ["ubi8", "ubi9"]
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- all java products: These now use the Stackable Nexus build-repo by default instead of pulling from Maven central ([#953])
+- all java products: These now use the Stackable Nexus build-repo by default instead of pulling from Maven central ([#953]).
+- all java products: Maven is now consistently run with `--batch-mode` and `--no-transfer-progress` to reduce noise ([#953]).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 - nifi: Add NiFi hadoop Azure and GCP libraries ([#943]).
 - base: Add containerdebug tool ([#928]).
 
+### Changed
+
+- all java products: These now use the Stackable Nexus build-repo by default instead of pulling from Maven central ([#953])
+
 ### Removed
 
 - kafka: Remove `kubectl`, as we are now using listener-op ([#884]).
@@ -16,6 +20,7 @@ All notable changes to this project will be documented in this file.
 [#884]: https://github.com/stackabletech/docker-images/pull/884
 [#928]: https://github.com/stackabletech/docker-images/pull/928
 [#943]: https://github.com/stackabletech/docker-images/pull/943
+[#953]: https://github.com/stackabletech/docker-images/pull/953
 
 ## [24.11.0] - 2024-11-18
 

--- a/druid/stackable/patches/26.0.0/09-update-fmpp.patch
+++ b/druid/stackable/patches/26.0.0/09-update-fmpp.patch
@@ -1,0 +1,21 @@
+diff --git a/10-update-fmpp.patch b/10-update-fmpp.patch
+new file mode 100644
+index 0000000000..e69de29bb2
+diff --git a/sql/pom.xml b/sql/pom.xml
+index bdd29f3f91..e5ba89f655 100644
+--- a/sql/pom.xml
++++ b/sql/pom.xml
+@@ -322,6 +322,13 @@
+       <plugin>
+         <groupId>com.googlecode.fmpp-maven-plugin</groupId>
+         <artifactId>fmpp-maven-plugin</artifactId>
++        <dependencies>
++          <dependency>
++            <groupId>net.sourceforge.fmpp</groupId>
++            <artifactId>fmpp</artifactId>
++            <version>0.9.16</version>
++          </dependency>
++        </dependencies>
+         <executions>
+           <execution>
+             <id>generate-fmpp-sources</id>

--- a/druid/stackable/patches/30.0.0/09-update-fmpp.patch
+++ b/druid/stackable/patches/30.0.0/09-update-fmpp.patch
@@ -1,0 +1,21 @@
+diff --git a/10-update-fmpp.patch b/10-update-fmpp.patch
+new file mode 100644
+index 0000000000..e69de29bb2
+diff --git a/sql/pom.xml b/sql/pom.xml
+index bdd29f3f91..e5ba89f655 100644
+--- a/sql/pom.xml
++++ b/sql/pom.xml
+@@ -322,6 +322,13 @@
+       <plugin>
+         <groupId>com.googlecode.fmpp-maven-plugin</groupId>
+         <artifactId>fmpp-maven-plugin</artifactId>
++        <dependencies>
++          <dependency>
++            <groupId>net.sourceforge.fmpp</groupId>
++            <artifactId>fmpp</artifactId>
++            <version>0.9.16</version>
++          </dependency>
++        </dependencies>
+         <executions>
+           <execution>
+             <id>generate-fmpp-sources</id>

--- a/hadoop/Dockerfile
+++ b/hadoop/Dockerfile
@@ -65,7 +65,7 @@ COPY --chown=${STACKABLE_USER_UID}:0 hadoop/stackable/patches /stackable/patches
 RUN curl "https://repo.stackable.tech/repository/packages/hadoop/hadoop-${PRODUCT}-src.tar.gz" | tar -xzC . && \
     patches/apply_patches.sh ${PRODUCT} && \
     cd hadoop-${PRODUCT}-src && \
-    mvn --no-transfer-progress clean package -Pdist,native -pl '!hadoop-tools/hadoop-pipes,!hadoop-yarn-project,!hadoop-mapreduce-project,!hadoop-minicluster' -Drequire.fuse=true -DskipTests -Dmaven.javadoc.skip=true && \
+    mvn --batch-mode --no-transfer-progress clean package -Pdist,native -pl '!hadoop-tools/hadoop-pipes,!hadoop-yarn-project,!hadoop-mapreduce-project,!hadoop-minicluster' -Drequire.fuse=true -DskipTests -Dmaven.javadoc.skip=true && \
     cp -r hadoop-dist/target/hadoop-${PRODUCT} /stackable/hadoop-${PRODUCT} && \
     mv hadoop-dist/target/bom.json /stackable/hadoop-${PRODUCT}/hadoop-${PRODUCT}.cdx.json && \
     # HDFS fuse-dfs is not part of the regular dist output, so we need to copy it in ourselves
@@ -116,7 +116,7 @@ WORKDIR /stackable
 
 RUN curl "https://github.com/stackabletech/hdfs-utils/archive/refs/tags/v${HDFS_UTILS}.tar.gz" | tar -xzC . && \
     cd hdfs-utils-${HDFS_UTILS} && \
-    mvn --no-transfer-progress clean package -P hadoop-${PRODUCT} -DskipTests -Dmaven.javadoc.skip=true && \
+    mvn --batch-mode --no-transfer-progress clean package -P hadoop-${PRODUCT} -DskipTests -Dmaven.javadoc.skip=true && \
     mkdir -p /stackable/hadoop-${PRODUCT}/share/hadoop/common/lib && \
     cp target/hdfs-utils-$HDFS_UTILS.jar /stackable/hadoop-${PRODUCT}/share/hadoop/common/lib/hdfs-utils-${HDFS_UTILS}.jar && \
     rm -rf /stackable/hdfs-utils-main

--- a/java-devel/stackable/settings.xml
+++ b/java-devel/stackable/settings.xml
@@ -1,7 +1,43 @@
 <settings>
+  <mirrors>
+    <mirror>
+      <id>nexus</id>
+      <mirrorOf>*</mirrorOf>
+      <url>https://build-repo.stackable.tech/repository/maven-public/</url>
+    </mirror>
+  </mirrors>
+
   <profiles>
     <profile>
       <id>stackable</id>
+
+      <!--Enable snapshots for the built-in central repo to direct -->
+      <!--all requests to nexus via the mirror -->
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>http://central</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>central</id>
+          <url>http://central</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+
       <properties>
         <!--
         This is to work around an issue where Maven builds in Github Actions would randomly fail.

--- a/kafka/stackable/patches/3.7.1/002-use-stackable-repo.patch
+++ b/kafka/stackable/patches/3.7.1/002-use-stackable-repo.patch
@@ -1,0 +1,38 @@
+From e5102449fe825cfbba20ce6ace1f51cd91550780 Mon Sep 17 00:00:00 2001
+From: Lars Francke <git@lars-francke.de>
+Date: Thu, 12 Dec 2024 10:09:47 +0100
+Subject: [PATCH] Change Gradle to use the Nexus Build Repo
+
+---
+ build.gradle | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/build.gradle b/build.gradle
+index 92082fe7cf..3b56a2ad98 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -20,7 +20,9 @@ import java.nio.charset.StandardCharsets
+ 
+ buildscript {
+   repositories {
+-    mavenCentral()
++    maven {
++      url 'https://build-repo.stackable.tech/repository/maven-public/'
++    }
+   }
+   apply from: "$rootDir/gradle/dependencies.gradle"
+ 
+@@ -126,7 +128,9 @@ ext {
+ allprojects {
+ 
+   repositories {
+-    mavenCentral()
++    maven {
++      url 'https://build-repo.stackable.tech/repository/maven-public/'
++    }
+   }
+ 
+   dependencyUpdates {
+-- 
+2.47.1
+

--- a/kafka/stackable/patches/3.8.0/002-use-stackable-repo.patch
+++ b/kafka/stackable/patches/3.8.0/002-use-stackable-repo.patch
@@ -1,0 +1,38 @@
+From e5102449fe825cfbba20ce6ace1f51cd91550780 Mon Sep 17 00:00:00 2001
+From: Lars Francke <git@lars-francke.de>
+Date: Thu, 12 Dec 2024 10:09:47 +0100
+Subject: [PATCH] Change Gradle to use the Nexus Build Repo
+
+---
+ build.gradle | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/build.gradle b/build.gradle
+index 92082fe7cf..3b56a2ad98 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -20,7 +20,9 @@ import java.nio.charset.StandardCharsets
+ 
+ buildscript {
+   repositories {
+-    mavenCentral()
++    maven {
++      url 'https://build-repo.stackable.tech/repository/maven-public/'
++    }
+   }
+   apply from: "$rootDir/gradle/dependencies.gradle"
+ 
+@@ -126,7 +128,9 @@ ext {
+ allprojects {
+ 
+   repositories {
+-    mavenCentral()
++    maven {
++      url 'https://build-repo.stackable.tech/repository/maven-public/'
++    }
+   }
+ 
+   dependencyUpdates {
+-- 
+2.47.1
+

--- a/nifi/Dockerfile
+++ b/nifi/Dockerfile
@@ -45,7 +45,7 @@ RUN curl 'https://repo.stackable.tech/repository/m2/tech/stackable/nifi/stackabl
     patches/apply_patches.sh ${PRODUCT} && \
     # Build NiFi
     cd /stackable/nifi-${PRODUCT}-src/ && \
-    mvn clean install -Dmaven.javadoc.skip=true -DskipTests --activate-profiles include-iceberg,include-hadoop-aws,include-hadoop-azure,include-hadoop-gcp && \
+    mvn --batch-mode --no-transfer-progress clean install -Dmaven.javadoc.skip=true -DskipTests --activate-profiles include-iceberg,include-hadoop-aws,include-hadoop-azure,include-hadoop-gcp && \
     # Copy the binaries to the /stackable folder
     mv /stackable/nifi-${PRODUCT}-src/nifi-assembly/target/nifi-${PRODUCT}-bin/nifi-${PRODUCT} /stackable/nifi-${PRODUCT} && \
     # Copy the SBOM as well

--- a/spark-k8s/Dockerfile
+++ b/spark-k8s/Dockerfile
@@ -107,14 +107,14 @@ export JDK_JAVA_OPTIONS="\
 
 # Get the Scala version used by Spark
 SCALA_VERSION=$( \
-    mvn --quiet --non-recursive --file /stackable/spark/pom.xml \
+    mvn --quiet --non-recursive --no-transfer-progress --batch-mode --file /stackable/spark/pom.xml \
     org.apache.maven.plugins:maven-help-plugin:3.5.0:evaluate \
     -DforceStdout \
     -Dexpression='project.properties(scala.version)')
 
 # Get the Scala binary version used by Spark
 SCALA_BINARY_VERSION=$( \
-    mvn --quiet --non-recursive --file /stackable/spark/pom.xml \
+    mvn --quiet --non-recursive  --no-transfer-progress --batch-mode --file /stackable/spark/pom.xml \
     org.apache.maven.plugins:maven-help-plugin:3.5.0:evaluate \
     -DforceStdout \
     -Dexpression='project.properties(scala.binary.version)')
@@ -149,7 +149,7 @@ ln -s /stackable/hbase-connectors/spark/hbase-spark/target/hbase-spark-${HBASE_C
 # Spark contains only log4j-slf4j2-impl-x.x.x.jar but not
 # log4j-slf4j-impl-x.x.x.jar. It is okay to have both JARs in the
 # classpath as long as they have the same version.
-mvn --quiet --non-recursive --file /stackable/spark/pom.xml \
+mvn --quiet --non-recursive  --no-transfer-progress --batch-mode --file /stackable/spark/pom.xml \
     dependency:copy \
     -Dartifact=org.apache.logging.log4j:log4j-slf4j-impl:'${log4j.version}' \
     -DoutputDirectory=.

--- a/spark-k8s/Dockerfile
+++ b/spark-k8s/Dockerfile
@@ -192,7 +192,10 @@ RUN export MAVEN_OPTS="-Xss64m -Xmx2g -XX:ReservedCodeCacheSize=1g" \
       -Dhadoop.version="$HADOOP" \
       -Dmaven.test.skip=true \
       -DskipTests \
-      -P'hadoop-3' -Pkubernetes -Phive -Phive-thriftserver
+      -P'hadoop-3' -Pkubernetes -Phive -Phive-thriftserver \
+      --no-transfer-progress \
+      --batch-mode
+
 # <<< Build spark
 
 # Get the correct `tini` binary for our architecture.

--- a/trino/Dockerfile
+++ b/trino/Dockerfile
@@ -33,7 +33,7 @@ cd trino-storage-${STORAGE_CONNECTOR}-src
 mvn versions:set -DnewVersion=${STORAGE_CONNECTOR}
 
 # We need to use ./mvnw instead of mvn to get a recent maven version (which is required to build Trino)
-./mvnw package -DskipTests -Dmaven.gitcommitid.skip=true
+./mvnw --batch-mode --no-transfer-progress package -DskipTests -Dmaven.gitcommitid.skip=true
 EOF
 
 FROM stackable/image/java-devel AS trino-builder
@@ -79,7 +79,7 @@ git commit --allow-empty --message "Fake commit, so that we can create a tag"
 git tag ${PRODUCT}
 
 # We need to use ./mvnw instead of mvn to get a recent maven version (which is required to build Trino)
-./mvnw package -DskipTests --projects="!docs,!core/trino-server-rpm"
+./mvnw --batch-mode --no-transfer-progress package -DskipTests --projects="!docs,!core/trino-server-rpm"
 
 # Delete the worst intermediate build products to free some space
 rm -r /stackable/trino-server-${PRODUCT}-src/plugin/*/target /stackable/trino-server-${PRODUCT}-src/core/trino-server/target/trino-server-${PRODUCT}

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -23,7 +23,7 @@ RUN curl "https://repo.stackable.tech/repository/packages/zookeeper/apache-zooke
     cd /stackable/apache-zookeeper-${PRODUCT}/ && \
     # Exclude the `zookeeper-client` submodule, this is not needed and has c parts
     # that created all kinds of issues for the build container
-    mvn -pl "!zookeeper-client/zookeeper-client-c" clean install checkstyle:check spotbugs:check -DskipTests -Pfull-build && \
+    mvn --batch-mode --no-transfer-progress -pl "!zookeeper-client/zookeeper-client-c" clean install checkstyle:check spotbugs:check -DskipTests -Pfull-build && \
     mv zookeeper-assembly/target/apache-zookeeper-${PRODUCT}-bin.tar.gz /stackable && \
     cd /stackable && \
     # Unpack the archive which contains the build artifacts from above. Remove some


### PR DESCRIPTION
# Description

This PR bundles a few (hopefully) minor changes to our workflows:

- This uses the Stackable build repo which mirrors maven central and a few other repositories needed by our products
	-  We are hoping this is more stable than upstream Maven central where we see frequent connection errors in our builds
- Adds aCI change to prevent matrix jobs from canceling when one job fails. This should mean there are less jobs to rerun on failure
- Adds a patch to Druid to not depend on fmpp 0.9.14 anymore which does depend on a version range for Freemarker which would resolve to a SNAPSHOT dependency
- Adds a patch to Kafka to update the repositories used by Gradle
- Hopefully consistently adds `--batch-mode` and `--no-transfer-progress` to _all_ Maven based builds

## Definition of Done Checklist

Make sure all these products build and use the Maven pull-through cache in Nexus:

```[tasklist]
### Products
- [x] Druid
- [x] HBase
- [x] Hadoop HDFS
- [x] Hive
- [x] Kafka
- [x] NiFi
- [x] Spark
- [x] Trino
- [x] ZooKeeper
```

```[tasklist]
- [x] Add an entry to the CHANGELOG.md file
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
