### PR TITLE
ci(build): stagger the scheduled builds to ease load on external systems

### DIFF
--- a/.github/workflows/build_airflow.yaml
+++ b/.github/workflows/build_airflow.yaml
@@ -10,7 +10,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 1/2 * *' # https://crontab.guru/#0_1_1/2_*_*
+    - cron: '0 0 1/2 * *' # https://crontab.guru/#0_0_1/2_*_*
   push:
     branches: [main]
     tags: ['*']

--- a/.github/workflows/build_hadoop.yaml
+++ b/.github/workflows/build_hadoop.yaml
@@ -10,7 +10,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 1/2 * *' # https://crontab.guru/#0_1_1/2_*_*
+    - cron: '0 2 1/2 * *' # https://crontab.guru/#0_2_1/2_*_*
   push:
     branches: [main]
     tags: ['*']

--- a/.github/workflows/build_hbase.yaml
+++ b/.github/workflows/build_hbase.yaml
@@ -10,7 +10,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 1/2 * *' # https://crontab.guru/#0_1_1/2_*_*
+    - cron: '0 0 2/2 * *' # https://crontab.guru/#0_0_2/2_*_*
   push:
     branches: [main]
     tags: ['*']

--- a/.github/workflows/build_hello-world.yaml
+++ b/.github/workflows/build_hello-world.yaml
@@ -10,7 +10,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 1/2 * *' # https://crontab.guru/#0_1_1/2_*_*
+    - cron: '0 1 2/2 * *' # https://crontab.guru/#0_1_2/2_*_*
   push:
     branches: [main]
     tags: ['*']

--- a/.github/workflows/build_hive.yaml
+++ b/.github/workflows/build_hive.yaml
@@ -10,7 +10,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 1/2 * *' # https://crontab.guru/#0_1_1/2_*_*
+    - cron: '0 2 2/2 * *' # https://crontab.guru/#0_2_2/2_*_*
   push:
     branches: [main]
     tags: ['*']

--- a/.github/workflows/build_java-base.yaml
+++ b/.github/workflows/build_java-base.yaml
@@ -10,7 +10,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 1/2 * *' # https://crontab.guru/#0_1_1/2_*_*
+    - cron: '0 0 1/2 * *' # https://crontab.guru/#0_0_1/2_*_*
   push:
     branches: [main]
     tags: ['*']

--- a/.github/workflows/build_kafka-testing-tools.yaml
+++ b/.github/workflows/build_kafka-testing-tools.yaml
@@ -10,7 +10,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 1/2 * *' # https://crontab.guru/#0_1_1/2_*_*
+    - cron: '0 2 1/2 * *' # https://crontab.guru/#0_2_1/2_*_*
   push:
     branches: [main]
     tags: ['*']

--- a/.github/workflows/build_kafka.yaml
+++ b/.github/workflows/build_kafka.yaml
@@ -10,7 +10,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 1/2 * *' # https://crontab.guru/#0_1_1/2_*_*
+    - cron: '0 0 2/2 * *' # https://crontab.guru/#0_0_2/2_*_*
   push:
     branches: [main]
     tags: ['*']

--- a/.github/workflows/build_kcat.yaml
+++ b/.github/workflows/build_kcat.yaml
@@ -10,7 +10,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 1/2 * *' # https://crontab.guru/#0_1_1/2_*_*
+    - cron: '0 1 2/2 * *' # https://crontab.guru/#0_1_2/2_*_*
   push:
     branches: [main]
     tags: ['*']

--- a/.github/workflows/build_krb5.yaml
+++ b/.github/workflows/build_krb5.yaml
@@ -10,7 +10,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 1/2 * *' # https://crontab.guru/#0_1_1/2_*_*
+    - cron: '0 2 2/2 * *' # https://crontab.guru/#0_2_2/2_*_*
   push:
     branches: [main]
     tags: ['*']

--- a/.github/workflows/build_nifi.yaml
+++ b/.github/workflows/build_nifi.yaml
@@ -10,7 +10,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 1/2 * *' # https://crontab.guru/#0_1_1/2_*_*
+    - cron: '0 0 1/2 * *' # https://crontab.guru/#0_0_1/2_*_*
   push:
     branches: [main]
     tags: ['*']

--- a/.github/workflows/build_opa.yaml
+++ b/.github/workflows/build_opa.yaml
@@ -10,7 +10,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 1/2 * *' # https://crontab.guru/#0_1_1/2_*_*
+    - cron: '0 2 1/2 * *' # https://crontab.guru/#0_2_1/2_*_*
   push:
     branches: [main]
     tags: ['*']

--- a/.github/workflows/build_spark-k8s.yaml
+++ b/.github/workflows/build_spark-k8s.yaml
@@ -10,7 +10,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 1/2 * *' # https://crontab.guru/#0_1_1/2_*_*
+    - cron: '0 0 2/2 * *' # https://crontab.guru/#0_0_2/2_*_*
   push:
     branches: [main]
     tags: ['*']

--- a/.github/workflows/build_stackable-base.yaml
+++ b/.github/workflows/build_stackable-base.yaml
@@ -10,7 +10,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 1/2 * *' # https://crontab.guru/#0_1_1/2_*_*
+    - cron: '0 1 2/2 * *' # https://crontab.guru/#0_1_2/2_*_*
   push:
     branches: [main]
     tags: ['*']

--- a/.github/workflows/build_superset.yaml
+++ b/.github/workflows/build_superset.yaml
@@ -10,7 +10,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 1/2 * *' # https://crontab.guru/#0_1_1/2_*_*
+    - cron: '0 2 2/2 * *' # https://crontab.guru/#0_2_2/2_*_*
   push:
     branches: [main]
     tags: ['*']

--- a/.github/workflows/build_testing-tools.yaml
+++ b/.github/workflows/build_testing-tools.yaml
@@ -10,7 +10,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 1/2 * *' # https://crontab.guru/#0_1_1/2_*_*
+    - cron: '0 0 1/2 * *' # https://crontab.guru/#0_0_1/2_*_*
   push:
     branches: [main]
     tags: ['*']

--- a/.github/workflows/build_trino-cli.yaml
+++ b/.github/workflows/build_trino-cli.yaml
@@ -10,7 +10,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 1/2 * *' # https://crontab.guru/#0_1_1/2_*_*
+    - cron: '0 2 1/2 * *' # https://crontab.guru/#0_2_1/2_*_*
   push:
     branches: [main]
     tags: ['*']

--- a/.github/workflows/build_trino.yaml
+++ b/.github/workflows/build_trino.yaml
@@ -10,7 +10,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 1/2 * *' # https://crontab.guru/#0_1_1/2_*_*
+    - cron: '0 0 2/2 * *' # https://crontab.guru/#0_0_2/2_*_*
   push:
     branches: [main]
     tags: ['*']

--- a/.github/workflows/build_vector.yaml
+++ b/.github/workflows/build_vector.yaml
@@ -10,7 +10,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 1/2 * *' # https://crontab.guru/#0_1_1/2_*_*
+    - cron: '0 1 2/2 * *' # https://crontab.guru/#0_1_2/2_*_*
   push:
     branches: [main]
     tags: ['*']

--- a/.github/workflows/build_zookeeper.yaml
+++ b/.github/workflows/build_zookeeper.yaml
@@ -10,7 +10,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 1/2 * *' # https://crontab.guru/#0_1_1/2_*_*
+    - cron: '0 2 2/2 * *' # https://crontab.guru/#0_2_2/2_*_*
   push:
     branches: [main]
     tags: ['*']


### PR DESCRIPTION
# Description

Stagger jobs between the following schedules (different hours every second day from the first or second of the month):
- `0 0 1/2 * *` <https://crontab.guru/#0_0_1/2_*_*>
- `0 1 1/2 * *` <https://crontab.guru/#0_1_1/2_*_*>
- `0 2 1/2 * *` <https://crontab.guru/#0_2_1/2_*_*>
- `0 0 2/2 * *` <https://crontab.guru/#0_0_2/2_*_*>
- `0 1 2/2 * *` <https://crontab.guru/#0_1_2/2_*_*>
- `0 2 2/2 * *` <https://crontab.guru/#0_2_2/2_*_*>

### Concurrent Groups

```
# The listings below are modified from the out of of:
# grep -r "cron: '0" | sort -k2

cron: '0 0 1/2 * *' # https://crontab.guru/#0_0_1/2_*_*
- build_airflow.yaml
- build_java-base.yaml
- build_nifi.yaml
- build_testing-tools.yaml

cron: '0 0 2/2 * *' # https://crontab.guru/#0_0_2/2_*_*
- build_hbase.yaml
- build_kafka.yaml
- build_spark-k8s.yaml
- build_trino.yaml

cron: '0 1 1/2 * *' # https://crontab.guru/#0_1_1/2_*_*
- build_druid.yaml
- build_java-devel.yaml
- build_omid.yaml
- build_tools.yaml

cron: '0 1 2/2 * *' # https://crontab.guru/#0_1_2/2_*_*
- build_hello-world.yaml
- build_kcat.yaml
- build_stackable-base.yaml
- build_vector.yaml

cron: '0 2 1/2 * *' # https://crontab.guru/#0_2_1/2_*_*
- build_hadoop.yaml
- build_kafka-testing-tools.yaml
- build_opa.yaml
- build_trino-cli.yaml

cron: '0 2 2/2 * *' # https://crontab.guru/#0_2_2/2_*_*
- build_hive.yaml
- build_krb5.yaml
- build_superset.yaml
- build_zookeeper.yaml
```
