### PR TITLE
fix: patchable worktree initialization

### DIFF
--- a/patchable.nu
+++ b/patchable.nu
@@ -80,9 +80,9 @@ def "main checkout" [
     # $GIT_DIR must be the worktree's .git dir, even if that is just an alias for the backing repo, since each worktree maintains its own index
     $env.GIT_DIR = $"($worktree_path)/.git"
     $env.GIT_WORK_TREE = $worktree_path
-    let worktree_git_dir = git rev-parse --git-dir
-    let worktree_rebase_progress_dir = $"($worktree_git_dir)/rebase-apply"
     if ($worktree_path | path exists) {
+        let worktree_git_dir = git rev-parse --git-dir
+        let worktree_rebase_progress_dir = $"($worktree_git_dir)/rebase-apply"
         log info "Worktree root already exists, resetting"
         if ($worktree_rebase_progress_dir | path exists) {
             if $force {


### PR DESCRIPTION
# Description

Running patchable for the first time failed on my machine with the error:
```
fatal: not a git repository: '/home/voeti/stackable/docker-images/druid/patchable-work/worktree/26.0.0/.git'
```

It looks like `git rev-parse --git-dir` throws this error because the worktree directory is not present yet in my case.
