### PR TITLE
chore(vector): Bump to 0.43.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - tools: Add the package util-linux-core ([#952]).
   util-linux-core contains a basic set of Linux utilities, including the
   command logger which allows to enter messages into the system log.
+- vector: Add version 0.43.1, remove version 0.41.1 [#980]
 
 ### Changed
 
@@ -37,7 +38,7 @@ All notable changes to this project will be documented in this file.
 [#958]: https://github.com/stackabletech/docker-images/pull/958
 [#959]: https://github.com/stackabletech/docker-images/pull/959
 [#962]: https://github.com/stackabletech/docker-images/pull/962
-
+[#980]: https://github.com/stackabletech/docker-images/pull/980
 ## [24.11.0] - 2024-11-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 [#959]: https://github.com/stackabletech/docker-images/pull/959
 [#962]: https://github.com/stackabletech/docker-images/pull/962
 [#980]: https://github.com/stackabletech/docker-images/pull/980
+
 ## [24.11.0] - 2024-11-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 
 - kafka: Remove `kubectl`, as we are now using listener-op ([#884]).
 - vector: remove version 0.41.1 [#980].
+
 ### Fixed
 
 - hadoop: Fix the JMX exporter configuration for metrics suffixed with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 - tools: Add the package util-linux-core ([#952]).
   util-linux-core contains a basic set of Linux utilities, including the
   command logger which allows to enter messages into the system log.
-- vector: Add version 0.43.1, remove version 0.41.1 [#980]
+- vector: Add version 0.43.1 [#980].
 
 ### Changed
 
@@ -23,7 +23,7 @@ All notable changes to this project will be documented in this file.
 ### Removed
 
 - kafka: Remove `kubectl`, as we are now using listener-op ([#884]).
-
+- vector: remove version 0.41.1 [#980].
 ### Fixed
 
 - hadoop: Fix the JMX exporter configuration for metrics suffixed with

--- a/airflow/versions.py
+++ b/airflow/versions.py
@@ -5,7 +5,7 @@ versions = [
         "git_sync": "v4.2.4",
         "statsd_exporter": "0.27.1",
         "tini": "0.19.0",
-        "vector": "0.41.1",
+        "vector": "0.43.1",
     },
     {
         "product": "2.9.3",
@@ -13,7 +13,7 @@ versions = [
         "git_sync": "v4.2.4",
         "statsd_exporter": "0.27.1",
         "tini": "0.19.0",
-        "vector": "0.41.1",
+        "vector": "0.43.1",
     },
     {
         "product": "2.10.2",
@@ -21,6 +21,6 @@ versions = [
         "git_sync": "v4.2.4",
         "statsd_exporter": "0.27.1",
         "tini": "0.19.0",
-        "vector": "0.41.1",
+        "vector": "0.43.1",
     },
 ]

--- a/java-base/versions.py
+++ b/java-base/versions.py
@@ -1,22 +1,22 @@
 versions = [
     {
         "product": "8",
-        "vector": "0.41.1",
+        "vector": "0.43.1",
     },
     {
         "product": "11",
-        "vector": "0.41.1",
+        "vector": "0.43.1",
     },
     {
         "product": "17",
-        "vector": "0.41.1",
+        "vector": "0.43.1",
     },
     {
         "product": "21",
-        "vector": "0.41.1",
+        "vector": "0.43.1",
     },
     {
         "product": "22",
-        "vector": "0.41.1",
+        "vector": "0.43.1",
     },
 ]

--- a/opa/versions.py
+++ b/opa/versions.py
@@ -1,13 +1,13 @@
 versions = [
     {
         "product": "0.66.0",
-        "vector": "0.41.1",
+        "vector": "0.43.1",
         "bundle_builder_version": "1.1.2",
         "stackable-base": "1.0.0",
     },
     {
         "product": "0.67.1",
-        "vector": "0.41.1",
+        "vector": "0.43.1",
         "bundle_builder_version": "1.1.2",
         "stackable-base": "1.0.0",
     },

--- a/spark-k8s/versions.py
+++ b/spark-k8s/versions.py
@@ -12,7 +12,7 @@ versions = [
         "jackson_dataformat_xml": "2.15.2",  # https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.13/3.5.1
         "stax2_api": "4.2.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.2
         "woodstox_core": "6.5.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.2
-        "vector": "0.41.1",
+        "vector": "0.43.1",
         "jmx_exporter": "1.0.1-stackable",
         "tini": "0.19.0",
         "hbase_connector": "1.0.1",
@@ -30,7 +30,7 @@ versions = [
         "jackson_dataformat_xml": "2.15.2",  # https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.13/3.5.2
         "stax2_api": "4.2.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.2
         "woodstox_core": "6.5.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.2
-        "vector": "0.41.1",
+        "vector": "0.43.1",
         "jmx_exporter": "1.0.1-stackable",
         "tini": "0.19.0",
         "hbase_connector": "1.0.1",

--- a/superset/versions.py
+++ b/superset/versions.py
@@ -2,7 +2,7 @@ versions = [
     {
         "product": "4.0.2",
         "python": "3.9",
-        "vector": "0.41.1",
+        "vector": "0.43.1",
         "statsd_exporter": "0.27.1",
         "authlib": "1.2.1",  # https://github.com/dpgaspar/Flask-AppBuilder/blob/release/4.4.1/requirements/extra.txt#L7
     },

--- a/vector/versions.py
+++ b/vector/versions.py
@@ -1,6 +1,6 @@
 versions = [
     {
-        "product": "0.41.1",
+        "product": "0.43.1",
         "rpm_release": "1",
         "stackable-base": "1.0.0",
         "inotify_tools": "3.22.1.0-1.el9",


### PR DESCRIPTION
# Description

Following  https://github.com/stackabletech/docker-images/issues/967

Updated Vector to `0.43.1` in

- /vector
- /airflow
- /superset
- /java-base
- /java-devel
- /opa
- /spark-k8s


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
