### PR TITLE
feat(kafka): Add 3.9.0, Bump 3.7.1 to 3.7.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+
+patchable-work/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to this project will be documented in this file.
 ### Removed
 
 - kafka: Remove `kubectl`, as we are now using listener-op ([#884]).
-- kafka: Remove 2.7.1 ([#968]).
+- kafka: Remove 3.7.1 ([#968]).
 - vector: remove version 0.41.1 ([#980]).
 - opa: remove version 0.66.0 ([#981])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,13 @@ All notable changes to this project will be documented in this file.
 - statsd-exporter: Bump version to 0.28.0 ([#982]).
 - kafka: Bump version to 3.9.0 ([#988]).
 
+### Changed
+
+- kafka: Bump 3.7.1 to 3.7.2 ([#968]).
+
 ### Removed
 
 - kafka: Remove `kubectl`, as we are now using listener-op ([#884]).
-- kafka: Remove 3.7.1 ([#988]).
 - vector: remove version 0.41.1 ([#980]).
 - opa: remove version 0.66.0 ([#981])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,12 @@ All notable changes to this project will be documented in this file.
 - vector: Add version 0.43.1 ([#980]).
 - opa: Add version 1.0.0 ([#981]).
 - statsd-exporter: Bump version to 0.28.0 ([#982]).
+- kafka: Bump version to 3.9.0 ([#968]).
 
 ### Removed
 
 - kafka: Remove `kubectl`, as we are now using listener-op ([#884]).
+- kafka: Remove 2.7.1 ([#968]).
 - vector: remove version 0.41.1 ([#980]).
 - opa: remove version 0.66.0 ([#981])
 
@@ -38,6 +40,7 @@ All notable changes to this project will be documented in this file.
 [#980]: https://github.com/stackabletech/docker-images/pull/980
 [#981]: https://github.com/stackabletech/docker-images/pull/981
 [#982]: https://github.com/stackabletech/docker-images/pull/982
+[#968]: https://github.com/stackabletech/docker-images/pull/968
 
 ## [24.11.1] - 2025-01-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,12 @@ All notable changes to this project will be documented in this file.
 - vector: Add version 0.43.1 ([#980]).
 - opa: Add version 1.0.0 ([#981]).
 - statsd-exporter: Bump version to 0.28.0 ([#982]).
-- kafka: Bump version to 3.9.0 ([#968]).
+- kafka: Bump version to 3.9.0 ([#988]).
 
 ### Removed
 
 - kafka: Remove `kubectl`, as we are now using listener-op ([#884]).
-- kafka: Remove 3.7.1 ([#968]).
+- kafka: Remove 3.7.1 ([#988]).
 - vector: remove version 0.41.1 ([#980]).
 - opa: remove version 0.66.0 ([#981])
 
@@ -40,7 +40,7 @@ All notable changes to this project will be documented in this file.
 [#980]: https://github.com/stackabletech/docker-images/pull/980
 [#981]: https://github.com/stackabletech/docker-images/pull/981
 [#982]: https://github.com/stackabletech/docker-images/pull/982
-[#968]: https://github.com/stackabletech/docker-images/pull/968
+[#988]: https://github.com/stackabletech/docker-images/pull/988
 
 ## [24.11.1] - 2025-01-14
 

--- a/kafka/stackable/patches/3.7.2/0001-Add-cyclonedx-plugin.patch
+++ b/kafka/stackable/patches/3.7.2/0001-Add-cyclonedx-plugin.patch
@@ -1,0 +1,76 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nick Larsen <nick.larsen@stackable.tech>
+Date: Mon, 3 Feb 2025 13:54:54 +0100
+Subject: Add cyclonedx-plugin
+
+---
+ build.gradle | 44 +++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 43 insertions(+), 1 deletion(-)
+
+diff --git a/build.gradle b/build.gradle
+index 3a9914a9cd..398a7c994e 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -48,6 +48,48 @@ plugins {
+   // artifacts - see https://github.com/johnrengelman/shadow/issues/901
+   id 'com.github.johnrengelman.shadow' version '8.1.0' apply false
+   id 'com.diffplug.spotless' version '6.14.0' apply false // 6.14.1 and newer require Java 11 at compile time, so we can't upgrade until AK 4.0
++  id 'org.cyclonedx.bom' version '1.10.0'
++}
++
++cyclonedxBom {
++    // Specified the type of project being built. Defaults to 'library'
++    projectType = "application"
++    // Specified the version of the CycloneDX specification to use. Defaults to '1.5'
++    schemaVersion = "1.5"
++    // Boms destination directory. Defaults to 'build/reports'
++    destination = file("build/reports")
++    // The file name for the generated BOMs (before the file format suffix). Defaults to 'bom'
++    outputName = "bom"
++    // The file format generated, can be xml, json or all for generating both. Defaults to 'all'
++    outputFormat = "json"
++    includeConfigs = ["runtimeClasspath"]
++    // Exclude test components. This list needs to be checked and, if it changed, updated for every new Kafka version.
++    // The list can be obtained by running `gradle projects | grep upgrade-system-tests`
++    skipProjects = [
++      'upgrade-system-tests-0100',
++      'upgrade-system-tests-0101',
++      'upgrade-system-tests-0102',
++      'upgrade-system-tests-0110',
++      'upgrade-system-tests-10',
++      'upgrade-system-tests-11',
++      'upgrade-system-tests-20',
++      'upgrade-system-tests-21',
++      'upgrade-system-tests-22',
++      'upgrade-system-tests-23',
++      'upgrade-system-tests-24',
++      'upgrade-system-tests-25',
++      'upgrade-system-tests-26',
++      'upgrade-system-tests-27',
++      'upgrade-system-tests-28',
++      'upgrade-system-tests-30',
++      'upgrade-system-tests-31',
++      'upgrade-system-tests-32',
++      'upgrade-system-tests-33',
++      'upgrade-system-tests-34',
++      'upgrade-system-tests-35',
++      'upgrade-system-tests-36',
++      'upgrade-system-tests-37'
++    ]
+ }
+ 
+ ext {
+@@ -1015,7 +1057,7 @@ project(':core') {
+     testImplementation libs.junitJupiter
+     testImplementation libs.slf4jlog4j
+     testImplementation libs.caffeine
+-    
++
+     generator project(':generator')
+   }
+ 
+
+base-commit: 79a8f2b5f44f9d5a6867190d1dfc463d08d60b82
+-- 
+2.40.1
+

--- a/kafka/stackable/patches/3.7.2/0002-Use-stackable-maven-mirror.patch
+++ b/kafka/stackable/patches/3.7.2/0002-Use-stackable-maven-mirror.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nick Larsen <nick.larsen@stackable.tech>
+Date: Mon, 3 Feb 2025 13:56:21 +0100
+Subject: Use stackable maven mirror
+
+---
+ build.gradle | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/build.gradle b/build.gradle
+index 398a7c994e..6fb5efe645 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -20,7 +20,9 @@ import java.nio.charset.StandardCharsets
+ 
+ buildscript {
+   repositories {
+-    mavenCentral()
++    maven {
++      url 'https://build-repo.stackable.tech/repository/maven-public/'
++    }
+   }
+   apply from: "$rootDir/gradle/dependencies.gradle"
+ 
+@@ -161,7 +163,9 @@ ext {
+ allprojects {
+ 
+   repositories {
+-    mavenCentral()
++    maven {
++      url 'https://build-repo.stackable.tech/repository/maven-public/'
++    }
+   }
+ 
+   dependencyUpdates {
+-- 
+2.40.1
+

--- a/kafka/stackable/patches/3.7.2/patchable.toml
+++ b/kafka/stackable/patches/3.7.2/patchable.toml
@@ -1,0 +1,2 @@
+upstream = "https://github.com/apache/kafka"
+base = "79a8f2b5f44f9d5a6867190d1dfc463d08d60b82"

--- a/kafka/stackable/patches/3.9.0/0001-Add-cyclonedx-plugin.patch
+++ b/kafka/stackable/patches/3.9.0/0001-Add-cyclonedx-plugin.patch
@@ -1,11 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nick Larsen <nick.larsen@stackable.tech>
+Date: Wed, 29 Jan 2025 16:50:30 +0100
+Subject: Add cyclonedx-plugin
+
+---
+ build.gradle | 42 ++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 42 insertions(+)
+
 diff --git a/build.gradle b/build.gradle
-index 32e6e8f..13a0def 100644
+index 5b064f4203..2d7b442e7b 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -48,6 +48,47 @@ plugins {
-   // artifacts - see https://github.com/johnrengelman/shadow/issues/901
-   id 'com.github.johnrengelman.shadow' version '8.1.0' apply false
-   id 'com.diffplug.spotless' version '6.14.0' apply false // 6.14.1 and newer require Java 11 at compile time, so we can't upgrade until AK 4.0
+@@ -51,6 +51,48 @@ plugins {
+   //  We are going to drop JDK8 support. Hence, the spotless is upgrade to newest version and be applied only if the build env is compatible with JDK 11.
+   //  spotless 6.15.0+ has issue in runtime with JDK8 even through we define it with `apply:false`. see https://github.com/diffplug/spotless/issues/2156 for more details
+   id 'com.diffplug.spotless' version "6.14.0" apply false
 +  id 'org.cyclonedx.bom' version '1.10.0'
 +}
 +
@@ -45,8 +54,14 @@ index 32e6e8f..13a0def 100644
 +      'upgrade-system-tests-33',
 +      'upgrade-system-tests-34',
 +      'upgrade-system-tests-35',
-+      'upgrade-system-tests-36'
++      'upgrade-system-tests-36',
++      'upgrade-system-tests-37'
 +    ]
  }
  
  ext {
+
+base-commit: 84caaa6e9da06435411510a81fa321d4f99c351f
+-- 
+2.40.1
+

--- a/kafka/stackable/patches/3.9.0/0002-Use-stackable-maven-mirror.patch
+++ b/kafka/stackable/patches/3.9.0/0002-Use-stackable-maven-mirror.patch
@@ -1,14 +1,14 @@
-From e5102449fe825cfbba20ce6ace1f51cd91550780 Mon Sep 17 00:00:00 2001
-From: Lars Francke <git@lars-francke.de>
-Date: Thu, 12 Dec 2024 10:09:47 +0100
-Subject: [PATCH] Change Gradle to use the Nexus Build Repo
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nick Larsen <nick.larsen@stackable.tech>
+Date: Wed, 29 Jan 2025 17:00:48 +0100
+Subject: Use stackable maven mirror
 
 ---
  build.gradle | 8 ++++++--
  1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/build.gradle b/build.gradle
-index 92082fe7cf..3b56a2ad98 100644
+index 2d7b442e7b..3e727be2f0 100644
 --- a/build.gradle
 +++ b/build.gradle
 @@ -20,7 +20,9 @@ import java.nio.charset.StandardCharsets
@@ -22,7 +22,7 @@ index 92082fe7cf..3b56a2ad98 100644
    }
    apply from: "$rootDir/gradle/dependencies.gradle"
  
-@@ -126,7 +128,9 @@ ext {
+@@ -171,7 +173,9 @@ ext {
  allprojects {
  
    repositories {
@@ -34,5 +34,5 @@ index 92082fe7cf..3b56a2ad98 100644
  
    dependencyUpdates {
 -- 
-2.47.1
+2.40.1
 

--- a/kafka/stackable/patches/3.9.0/patchable.toml
+++ b/kafka/stackable/patches/3.9.0/patchable.toml
@@ -1,0 +1,2 @@
+upstream = "https://github.com/apache/kafka"
+base = "84caaa6e9da06435411510a81fa321d4f99c351f"

--- a/kafka/versions.py
+++ b/kafka/versions.py
@@ -1,5 +1,14 @@
 versions = [
     {
+        "product": "3.7.2",
+        "java-base": "21",
+        "java-devel": "21",
+        "scala": "2.13",
+        "kcat": "1.7.0",
+        "opa_authorizer": "1.5.1",
+        "jmx_exporter": "1.1.0",
+    },
+    {
         "product": "3.8.0",
         "java-base": "21",
         "java-devel": "21",

--- a/kafka/versions.py
+++ b/kafka/versions.py
@@ -1,20 +1,20 @@
 versions = [
     {
-        "product": "3.7.1",
-        "java-base": "21",
-        "java-devel": "21",
-        "scala": "2.13",
-        "kcat": "1.7.0",
-        "opa_authorizer": "1.5.1",
-        "jmx_exporter": "1.0.1-stackable",
-    },
-    {
         "product": "3.8.0",
         "java-base": "21",
         "java-devel": "21",
         "scala": "2.13",
         "kcat": "1.7.0",
         "opa_authorizer": "1.5.1",
-        "jmx_exporter": "1.0.1-stackable",
+        "jmx_exporter": "1.1.0",
+    },
+    {
+        "product": "3.9.0",
+        "java-base": "21",
+        "java-devel": "21",
+        "scala": "2.13",
+        "kcat": "1.7.0",
+        "opa_authorizer": "1.5.1",
+        "jmx_exporter": "1.1.0",
     },
 ]


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/docker-images/issues/968.

- Add Kafka 3.9.0
- Bump Kafka 3.7.1 to 3.7.2

> [!NOTE]
> In both cases, patches were added via patchable.nu (experimental).

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
- [x] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] All packages should have (if available) signatures/hashes verified
- [x] Add an entry to the CHANGELOG.md file
- [x] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
