### PR TITLE
chore: update to oci references

### DIFF
--- a/.github/ISSUE_TEMPLATE/update-base-java.md
+++ b/.github/ISSUE_TEMPLATE/update-base-java.md
@@ -69,7 +69,7 @@ pip install image-tools-stackabletech==0.0.13
 # Test a product image can build, eg: ZooKeeper
 bake --product zookeeper=x.y.z # where x.y.z is a valid product version using the newly added Java version
 
-kind load docker-image docker.stackable.tech/stackable/zookeeper:x.y.z-stackable0.0.0-dev
+kind load docker-image oci.stackable.tech/sdp/zookeeper:x.y.z-stackable0.0.0-dev
 
 # Change directory into one of the operator repositories (eg: zookeeper-operator) and update the
 # product version in tests/test-definition.yaml

--- a/.github/ISSUE_TEMPLATE/update-base-vector.md
+++ b/.github/ISSUE_TEMPLATE/update-base-vector.md
@@ -75,7 +75,7 @@ pip install image-tools-stackabletech==0.0.13
 
 bake --product vector=x.y.z # where x.y.z is the new version added in this PR
 
-kind load docker-image docker.stackable.tech/stackable/vector:x.y.z-stackable0.0.0-dev
+kind load docker-image oci.stackable.tech/sdp/vector:x.y.z-stackable0.0.0-dev
 
 # Change directory into one of the operator repositories and update the
 # product version in tests/test-definition.yaml

--- a/.github/ISSUE_TEMPLATE/update-product-airflow.md
+++ b/.github/ISSUE_TEMPLATE/update-product-airflow.md
@@ -67,7 +67,7 @@ pip install image-tools-stackabletech==0.0.13
 
 bake --product airflow=x.y.z # where x.y.z is the new version added in this PR
 
-kind load docker-image docker.stackable.tech/stackable/airflow:x.y.z-stackable0.0.0-dev
+kind load docker-image oci.stackable.tech/sdp/airflow:x.y.z-stackable0.0.0-dev
 
 # Change directory into the airflow-operator repository and update the
 # product version in tests/test-definition.yaml

--- a/.github/ISSUE_TEMPLATE/update-product-druid.md
+++ b/.github/ISSUE_TEMPLATE/update-product-druid.md
@@ -71,7 +71,7 @@ pip install image-tools-stackabletech==0.0.13
 
 bake --product druid=x.y.z # where x.y.z is the new version added in this PR
 
-kind load docker-image docker.stackable.tech/stackable/druid:x.y.z-stackable0.0.0-dev
+kind load docker-image oci.stackable.tech/sdp/druid:x.y.z-stackable0.0.0-dev
 
 # Change directory into the druid-operator repository and update the
 # product version in tests/test-definition.yaml

--- a/.github/ISSUE_TEMPLATE/update-product-hbase-phoenix-omid.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hbase-phoenix-omid.md
@@ -76,8 +76,8 @@ pip install image-tools-stackabletech==0.0.13
 bake --product hbase=x.y.z # where x.y.z is the new version added in this PR
 bake --product omid=x.y.z # where x.y.z is the new version added in this PR
 
-kind load docker-image docker.stackable.tech/stackable/hbase:x.y.z-stackable0.0.0-dev
-kind load docker-image docker.stackable.tech/stackable/omid:x.y.z-stackable0.0.0-dev
+kind load docker-image oci.stackable.tech/sdp/hbase:x.y.z-stackable0.0.0-dev
+kind load docker-image oci.stackable.tech/sdp/omid:x.y.z-stackable0.0.0-dev
 
 # Change directory into the hbase-operator repository and update the
 # product version in tests/test-definition.yaml

--- a/.github/ISSUE_TEMPLATE/update-product-hdfs.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hdfs.md
@@ -69,7 +69,7 @@ pip install image-tools-stackabletech==0.0.13
 
 bake --product hadoop=x.y.z # where x.y.z is the new version added in this PR
 
-kind load docker-image docker.stackable.tech/stackable/hadoop:x.y.z-stackable0.0.0-dev
+kind load docker-image oci.stackable.tech/sdp/hadoop:x.y.z-stackable0.0.0-dev
 
 # Change directory into the hdfs-operator repository and update the
 # product version in tests/test-definition.yaml

--- a/.github/ISSUE_TEMPLATE/update-product-hive.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hive.md
@@ -68,7 +68,7 @@ pip install image-tools-stackabletech==0.0.13
 
 bake --product hive=x.y.z # where x.y.z is the new version added in this PR
 
-kind load docker-image docker.stackable.tech/stackable/hive:x.y.z-stackable0.0.0-dev
+kind load docker-image oci.stackable.tech/sdp/hive:x.y.z-stackable0.0.0-dev
 
 # Change directory into the hive-operator repository and update the
 # product version in tests/test-definition.yaml

--- a/.github/ISSUE_TEMPLATE/update-product-kafka.md
+++ b/.github/ISSUE_TEMPLATE/update-product-kafka.md
@@ -80,8 +80,8 @@ pip install image-tools-stackabletech==0.0.13
 bake --product kafka=x.y.z # where x.y.z is the new version added in this PR
 bake --product kafka-testing-tools=1.0.0 # This version doesn't change
 
-kind load docker-image docker.stackable.tech/stackable/kafka:x.y.z-stackable0.0.0-dev
-kind load docker-image docker.stackable.tech/stackable/kafka-testing-tools:1.0.0-stackable0.0.0-dev
+kind load docker-image oci.stackable.tech/sdp/kafka:x.y.z-stackable0.0.0-dev
+kind load docker-image oci.stackable.tech/sdp/kafka-testing-tools:1.0.0-stackable0.0.0-dev
 
 # Change directory into the kafka-operator repository and update the
 # product version in tests/test-definition.yaml

--- a/.github/ISSUE_TEMPLATE/update-product-nifi.md
+++ b/.github/ISSUE_TEMPLATE/update-product-nifi.md
@@ -68,7 +68,7 @@ pip install image-tools-stackabletech==0.0.13
 
 bake --product nifi=x.y.z # where x.y.z is the new version added in this PR
 
-kind load docker-image docker.stackable.tech/stackable/nifi:x.y.z-stackable0.0.0-dev
+kind load docker-image oci.stackable.tech/sdp/nifi:x.y.z-stackable0.0.0-dev
 
 # Change directory into the nifi-operator repository and update the
 # product version in tests/test-definition.yaml

--- a/.github/ISSUE_TEMPLATE/update-product-opa.md
+++ b/.github/ISSUE_TEMPLATE/update-product-opa.md
@@ -67,7 +67,7 @@ pip install image-tools-stackabletech==0.0.13
 
 bake --product opa=x.y.z # where x.y.z is the new version added in this PR
 
-kind load docker-image docker.stackable.tech/stackable/opa:x.y.z-stackable0.0.0-dev
+kind load docker-image oci.stackable.tech/sdp/opa:x.y.z-stackable0.0.0-dev
 
 # Change directory into the opa-operator repository and update the
 # product version in tests/test-definition.yaml

--- a/.github/ISSUE_TEMPLATE/update-product-spark.md
+++ b/.github/ISSUE_TEMPLATE/update-product-spark.md
@@ -69,7 +69,7 @@ pip install image-tools-stackabletech==0.0.13
 
 bake --product spark-k8s=x.y.z # where x.y.z is the new version added in this PR
 
-kind load docker-image docker.stackable.tech/stackable/spark-k8s:x.y.z-stackable0.0.0-dev
+kind load docker-image oci.stackable.tech/sdp/spark-k8s:x.y.z-stackable0.0.0-dev
 
 # Change directory into the spark-k8s-operator repository and update the
 # product version in tests/test-definition.yaml

--- a/.github/ISSUE_TEMPLATE/update-product-superset.md
+++ b/.github/ISSUE_TEMPLATE/update-product-superset.md
@@ -69,7 +69,7 @@ pip install image-tools-stackabletech==0.0.13
 
 bake --product superset=x.y.z # where x.y.z is the new version added in this PR
 
-kind load docker-image docker.stackable.tech/stackable/superset:x.y.z-stackable0.0.0-dev
+kind load docker-image oci.stackable.tech/sdp/superset:x.y.z-stackable0.0.0-dev
 
 # Change directory into the superset-operator repository and update the
 # product version in tests/test-definition.yaml

--- a/.github/ISSUE_TEMPLATE/update-product-trino.md
+++ b/.github/ISSUE_TEMPLATE/update-product-trino.md
@@ -78,8 +78,8 @@ pip install image-tools-stackabletech==0.0.13
 bake --product trino=x.y.z # where x.y.z is the new version added in this PR
 bake --product trino-cli=x.y.z # where x.y.z is the new version added in this PR
 
-kind load docker-image docker.stackable.tech/stackable/trino:x.y.z-stackable0.0.0-dev
-kind load docker-image docker.stackable.tech/stackable/trino-cli:x.y.z-stackable0.0.0-dev
+kind load docker-image oci.stackable.tech/sdp/trino:x.y.z-stackable0.0.0-dev
+kind load docker-image oci.stackable.tech/sdp/trino-cli:x.y.z-stackable0.0.0-dev
 
 # Change directory into the trino-operator repository and update the
 # product version in tests/test-definition.yaml

--- a/.github/ISSUE_TEMPLATE/update-product-zookeeper.md
+++ b/.github/ISSUE_TEMPLATE/update-product-zookeeper.md
@@ -68,7 +68,7 @@ pip install image-tools-stackabletech==0.0.13
 
 bake --product zookeeper=x.y.z # where x.y.z is the new version added in this PR
 
-kind load docker-image docker.stackable.tech/stackable/zookeeper:x.y.z-stackable0.0.0-dev
+kind load docker-image oci.stackable.tech/sdp/zookeeper:x.y.z-stackable0.0.0-dev
 
 # Change directory into the zookeeper-operator repository and update the
 # product version in tests/test-definition.yaml

--- a/.github/workflows/preflight.yaml
+++ b/.github/workflows/preflight.yaml
@@ -34,7 +34,7 @@ on:
       registry:
         description: 'Image repository.'
         required: true
-        default: 'docker.stackable.tech'
+        default: 'oci.stackable.tech'
         type: string
 jobs:
   preflight:

--- a/.github/workflows/preflight.yaml
+++ b/.github/workflows/preflight.yaml
@@ -36,6 +36,11 @@ on:
         required: true
         default: 'oci.stackable.tech'
         type: string
+      organization:
+        description: 'Organization name within the given registry'
+        required: true
+        default: 'sdp'
+        type: string
 jobs:
   preflight:
     name: ${{ matrix.product }} preflight checks
@@ -84,12 +89,14 @@ jobs:
         if: ${{ inputs.submit == true }}
         env:
           REGISTRY: ${{ inputs.registry }}
-          IMAGE_VERSION: ${{inputs.tag }}
+          ORGANIZATION: ${{ inputs.organization }}
+          IMAGE_VERSION: ${{ inputs.tag }}
         run: |
           ARCH_FOR_PREFLIGHT="$(arch | sed -e 's#x86_64#amd64#' | sed -e 's#aarch64#arm64#')"
           check-container --product "${{ matrix.product }}" \
             --image-version "$IMAGE_VERSION" \
             --registry "$REGISTRY" \
+            --organization "$ORGANIZATION" \
             --architecture "linux/${ARCH_FOR_PREFLIGHT}" \
             --executable ./preflight-linux-amd64 \
             --token "${{ secrets.RH_PYXIS_API_TOKEN }}" \
@@ -98,12 +105,14 @@ jobs:
         if: ${{ inputs.submit == false }}
         env:
           REGISTRY: ${{ inputs.registry }}
-          IMAGE_VERSION: ${{inputs.tag }}
+          ORGANIZATION: ${{ inputs.organization }}
+          IMAGE_VERSION: ${{ inputs.tag }}
         run: |
           ARCH_FOR_PREFLIGHT="$(arch | sed -e 's#x86_64#amd64#' | sed -e 's#aarch64#arm64#')"
           check-container --product "${{ matrix.product }}" \
             --image-version "$IMAGE_VERSION" \
             --registry "$REGISTRY" \
+            --organization "$ORGANIZATION" \
             --architecture "linux/${ARCH_FOR_PREFLIGHT}" \
             --executable ./preflight-linux-amd64 \
             --token "${{ secrets.RH_PYXIS_API_TOKEN }}" \

--- a/.scripts/update_feature_tracker_db.sh
+++ b/.scripts/update_feature_tracker_db.sh
@@ -46,7 +46,7 @@ product_image_digest() {
   #
   # Params:
   #
-  # IMAGE_NAME - Example: docker.stackable.tech/stackable/zookeeper:3.8.3-stackable23.11.0
+  # IMAGE_NAME - Example: oci.stackable.tech/sdp/zookeeper:3.8.3-stackable23.11.0
   #
   IMAGE_NAME="$1"
 
@@ -123,7 +123,7 @@ update_release_components() {
   #
   # RELEASE_VERSION     - Example: 23.11.0
   # PRODUCT_VERSION_ID  - Example: 38. See ensure_product_version() above.
-  # REPOSITORY_NAME     - Example: docker.stackable.tech/stackable/zookeeper
+  # REPOSITORY_NAME     - Example: oci.stackable.tech/sdp/zookeeper
   # IMAGE_DIGEST        - Example: sha256:822d427031bf93055c51f4dc3bcaa468867ce83f59de6824af279df4cce2d066
 
   local RELEASE_VERSION="$1"
@@ -170,8 +170,8 @@ main() {
   local RELEASE_NAME="${1:-}"
   local RELEASE_VERSION="${2:-}"
 
-  local REGISTRY=docker.stackable.tech # REGISTRY=oci.stackable.tech
-  local REGISTRY_PATH=stackable        # REGISTRY_PATH=sdp
+  local REGISTRY=oci.stackable.tech
+  local REGISTRY_PATH=sdp
 
   if [ -z "$RELEASE_NAME" ]; then
     echo "Release name cannot be empty."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Update registry references to oci ([#989]).
+
 ### Added
 
 - nifi: Activate `include-hadoop` profile for NiFi version 2.* ([#958]).
@@ -38,6 +42,7 @@ All notable changes to this project will be documented in this file.
 [#980]: https://github.com/stackabletech/docker-images/pull/980
 [#981]: https://github.com/stackabletech/docker-images/pull/981
 [#982]: https://github.com/stackabletech/docker-images/pull/982
+[#989]: https://github.com/stackabletech/docker-images/pull/989
 
 ## [24.11.1] - 2025-01-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Changed
-
-- Update registry references to oci ([#989]).
-
 ### Added
 
 - nifi: Activate `include-hadoop` profile for NiFi version 2.* ([#958]).
@@ -25,6 +21,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - kafka: Bump 3.7.1 to 3.7.2 ([#968]).
+- Update registry references to oci ([#989]).
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This repository contains Dockerfiles and scripts to build base images for use wi
 
 ## Build Product Images
 
-Product images are published to the `docker.stackable.tech` registry under the `stackable` organization by default.
+Product images are published to the `oci.stackable.tech` registry under the `sdp` organization by default.
 
 ### Build single products locally
 
@@ -75,7 +75,7 @@ This will bake in the current stable Rust version at the time this image was bui
 ## Example usage
 
 ```dockerfile
-FROM docker.stackable.tech/ubi9-rust-builder AS builder
+FROM oci.stackable.tech/ubi9-rust-builder AS builder
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal AS operator
 LABEL maintainer="Stackable GmbH"


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/infrastructure/issues/142

Updates registry references to oci

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
- [x] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [x] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
