### PR TITLE
chore: Update gitsync to v4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - vector: Add version 0.43.1 ([#980]).
 - opa: Add version 1.0.0 ([#981]).
 - statsd-exporter: Bump version to 0.28.0 ([#982]).
+- git-sync: Bump version to 4.4.0 ([#990]).
 
 ### Removed
 
@@ -38,6 +39,7 @@ All notable changes to this project will be documented in this file.
 [#980]: https://github.com/stackabletech/docker-images/pull/980
 [#981]: https://github.com/stackabletech/docker-images/pull/981
 [#982]: https://github.com/stackabletech/docker-images/pull/982
+[#990]: https://github.com/stackabletech/docker-images/pull/990
 
 ## [24.11.1] - 2025-01-14
 

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -5,7 +5,7 @@ ARG GIT_SYNC
 
 # For updated versions check https://github.com/kubernetes/git-sync/releases
 # which should contain a image location (e.g. registry.k8s.io/git-sync/git-sync:v3.6.8)
-FROM oci.stackable.tech/sdp/git-sync:${GIT_SYNC} AS gitsync-image
+FROM oci.stackable.tech/sdp/git-sync/git-sync:${GIT_SYNC} AS gitsync-image
 
 FROM stackable/image/statsd_exporter AS statsd_exporter-builder
 

--- a/airflow/versions.py
+++ b/airflow/versions.py
@@ -2,7 +2,7 @@ versions = [
     {
         "product": "2.9.2",
         "python": "3.9",
-        "git_sync": "v4.2.4",
+        "git_sync": "v4.4.0",
         "statsd_exporter": "0.28.0",
         "tini": "0.19.0",
         "vector": "0.43.1",
@@ -10,7 +10,7 @@ versions = [
     {
         "product": "2.9.3",
         "python": "3.9",
-        "git_sync": "v4.2.4",
+        "git_sync": "v4.4.0",
         "statsd_exporter": "0.28.0",
         "tini": "0.19.0",
         "vector": "0.43.1",
@@ -18,7 +18,7 @@ versions = [
     {
         "product": "2.10.2",
         "python": "3.12",
-        "git_sync": "v4.2.4",
+        "git_sync": "v4.4.0",
         "statsd_exporter": "0.28.0",
         "tini": "0.19.0",
         "vector": "0.43.1",


### PR DESCRIPTION
# Description

Fixes https://github.com/stackabletech/docker-images/issues/987

:green_circle: Tested with the gitsync integration test:

```
--- PASS: kuttl (563.83s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/mount-dags-gitsync_airflow-latest-2.9.2_openshift-false_executor-kubernetes (148.17s)
        --- PASS: kuttl/harness/mount-dags-gitsync_airflow-latest-2.10.2_openshift-false_executor-celery (211.42s)
        --- PASS: kuttl/harness/mount-dags-gitsync_airflow-latest-2.9.3_openshift-false_executor-kubernetes (167.46s)
        --- PASS: kuttl/harness/mount-dags-gitsync_airflow-latest-2.9.2_openshift-false_executor-celery (206.06s)
        --- PASS: kuttl/harness/mount-dags-gitsync_airflow-latest-2.9.3_openshift-false_executor-celery (195.18s)
        --- PASS: kuttl/harness/mount-dags-gitsync_airflow-latest-2.10.2_openshift-false_executor-kubernetes (146.30s)
PASS
```

:green_circle: Openshift:

```
--- PASS: kuttl (468.64s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/mount-dags-gitsync_airflow-latest-2.10.2,docker.stackable.tech_sandbox_airflow_2.10.2-stackable0.0.0-dev_openshift-true_executor-kubernetes (455.61s)
PASS

```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
- [x] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] Add an entry to the CHANGELOG.md file
- [x] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
