### PR TITLE
fix(kafka): Restore version 3.7.1, bump 3.8.0 to 3.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,11 @@ All notable changes to this project will be documented in this file.
 - opa: Add version 1.0.0 ([#981]).
 - statsd-exporter: Bump version to 0.28.0 ([#982]).
 - git-sync: Bump version to 4.4.0 ([#990]).
-- kafka: Bump version to 3.9.0 ([#988]).
+- kafka: Add versions 3.7.2 and 3.9.0 ([#988]).
 
 ### Changed
 
-- kafka: Bump 3.7.1 to 3.7.2 ([#968]).
+- kafka: Bump 3.8.0 to 3.8.1 ([#995]).
 - Update registry references to oci ([#989]).
 
 ### Removed
@@ -48,6 +48,7 @@ All notable changes to this project will be documented in this file.
 [#989]: https://github.com/stackabletech/docker-images/pull/989
 [#990]: https://github.com/stackabletech/docker-images/pull/990
 [#988]: https://github.com/stackabletech/docker-images/pull/988
+[#995]: https://github.com/stackabletech/docker-images/pull/995
 
 ## [24.11.1] - 2025-01-14
 

--- a/kafka/stackable/patches/3.7.1/001-cyclonedx-plugin.patch
+++ b/kafka/stackable/patches/3.7.1/001-cyclonedx-plugin.patch
@@ -1,0 +1,52 @@
+diff --git a/build.gradle b/build.gradle
+index 32e6e8f..13a0def 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -48,6 +48,47 @@ plugins {
+   // artifacts - see https://github.com/johnrengelman/shadow/issues/901
+   id 'com.github.johnrengelman.shadow' version '8.1.0' apply false
+   id 'com.diffplug.spotless' version '6.14.0' apply false // 6.14.1 and newer require Java 11 at compile time, so we can't upgrade until AK 4.0
++  id 'org.cyclonedx.bom' version '1.10.0'
++}
++
++cyclonedxBom {
++    // Specified the type of project being built. Defaults to 'library'
++    projectType = "application"
++    // Specified the version of the CycloneDX specification to use. Defaults to '1.5'
++    schemaVersion = "1.5"
++    // Boms destination directory. Defaults to 'build/reports'
++    destination = file("build/reports")
++    // The file name for the generated BOMs (before the file format suffix). Defaults to 'bom'
++    outputName = "bom"
++    // The file format generated, can be xml, json or all for generating both. Defaults to 'all'
++    outputFormat = "json"
++    includeConfigs = ["runtimeClasspath"]
++    // Exclude test components. This list needs to be checked and, if it changed, updated for every new Kafka version.
++    // The list can be obtained by running `gradle projects | grep upgrade-system-tests`
++    skipProjects = [
++      'upgrade-system-tests-0100',
++      'upgrade-system-tests-0101',
++      'upgrade-system-tests-0102',
++      'upgrade-system-tests-0110',
++      'upgrade-system-tests-10',
++      'upgrade-system-tests-11',
++      'upgrade-system-tests-20',
++      'upgrade-system-tests-21',
++      'upgrade-system-tests-22',
++      'upgrade-system-tests-23',
++      'upgrade-system-tests-24',
++      'upgrade-system-tests-25',
++      'upgrade-system-tests-26',
++      'upgrade-system-tests-27',
++      'upgrade-system-tests-28',
++      'upgrade-system-tests-30',
++      'upgrade-system-tests-31',
++      'upgrade-system-tests-32',
++      'upgrade-system-tests-33',
++      'upgrade-system-tests-34',
++      'upgrade-system-tests-35',
++      'upgrade-system-tests-36'
++    ]
+ }
+ 
+ ext {

--- a/kafka/stackable/patches/3.7.1/002-use-stackable-repo.patch
+++ b/kafka/stackable/patches/3.7.1/002-use-stackable-repo.patch
@@ -1,0 +1,38 @@
+From e5102449fe825cfbba20ce6ace1f51cd91550780 Mon Sep 17 00:00:00 2001
+From: Lars Francke <git@lars-francke.de>
+Date: Thu, 12 Dec 2024 10:09:47 +0100
+Subject: [PATCH] Change Gradle to use the Nexus Build Repo
+
+---
+ build.gradle | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/build.gradle b/build.gradle
+index 92082fe7cf..3b56a2ad98 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -20,7 +20,9 @@ import java.nio.charset.StandardCharsets
+ 
+ buildscript {
+   repositories {
+-    mavenCentral()
++    maven {
++      url 'https://build-repo.stackable.tech/repository/maven-public/'
++    }
+   }
+   apply from: "$rootDir/gradle/dependencies.gradle"
+ 
+@@ -126,7 +128,9 @@ ext {
+ allprojects {
+ 
+   repositories {
+-    mavenCentral()
++    maven {
++      url 'https://build-repo.stackable.tech/repository/maven-public/'
++    }
+   }
+ 
+   dependencyUpdates {
+-- 
+2.47.1
+

--- a/kafka/stackable/patches/3.8.1/0001-Add-cyclonedx-plugin.patch
+++ b/kafka/stackable/patches/3.8.1/0001-Add-cyclonedx-plugin.patch
@@ -1,5 +1,14 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nick Larsen <nick.larsen@stackable.tech>
+Date: Thu, 6 Feb 2025 10:21:26 +0100
+Subject: Add cyclonedx plugin
+
+---
+ build.gradle | 44 +++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 43 insertions(+), 1 deletion(-)
+
 diff --git a/build.gradle b/build.gradle
-index 92082fe..e3d6c72 100644
+index 8b44b09087..fadb64fda5 100644
 --- a/build.gradle
 +++ b/build.gradle
 @@ -48,6 +48,48 @@ plugins {
@@ -51,3 +60,17 @@ index 92082fe..e3d6c72 100644
  }
  
  ext {
+@@ -1011,7 +1053,7 @@ project(':core') {
+     testImplementation libs.junitJupiter
+     testImplementation libs.slf4jlog4j
+     testImplementation libs.caffeine
+-    
++
+     generator project(':generator')
+   }
+ 
+
+base-commit: 70d6ff42debf7e17478beb899fb5756bfbdbfbb5
+-- 
+2.40.1
+

--- a/kafka/stackable/patches/3.8.1/0002-Use-stackable-maven-mirror.patch
+++ b/kafka/stackable/patches/3.8.1/0002-Use-stackable-maven-mirror.patch
@@ -1,14 +1,14 @@
-From e5102449fe825cfbba20ce6ace1f51cd91550780 Mon Sep 17 00:00:00 2001
-From: Lars Francke <git@lars-francke.de>
-Date: Thu, 12 Dec 2024 10:09:47 +0100
-Subject: [PATCH] Change Gradle to use the Nexus Build Repo
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nick Larsen <nick.larsen@stackable.tech>
+Date: Thu, 6 Feb 2025 10:25:36 +0100
+Subject: Use stackable maven mirror
 
 ---
  build.gradle | 8 ++++++--
  1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/build.gradle b/build.gradle
-index 92082fe7cf..3b56a2ad98 100644
+index fadb64fda5..34786c0673 100644
 --- a/build.gradle
 +++ b/build.gradle
 @@ -20,7 +20,9 @@ import java.nio.charset.StandardCharsets
@@ -22,7 +22,7 @@ index 92082fe7cf..3b56a2ad98 100644
    }
    apply from: "$rootDir/gradle/dependencies.gradle"
  
-@@ -126,7 +128,9 @@ ext {
+@@ -168,7 +170,9 @@ ext {
  allprojects {
  
    repositories {
@@ -34,5 +34,5 @@ index 92082fe7cf..3b56a2ad98 100644
  
    dependencyUpdates {
 -- 
-2.47.1
+2.40.1
 

--- a/kafka/stackable/patches/3.8.1/patchable.toml
+++ b/kafka/stackable/patches/3.8.1/patchable.toml
@@ -1,0 +1,2 @@
+upstream = "https://github.com/apache/kafka"
+base = "70d6ff42debf7e17478beb899fb5756bfbdbfbb5"

--- a/kafka/versions.py
+++ b/kafka/versions.py
@@ -18,7 +18,7 @@ versions = [
         "jmx_exporter": "1.1.0",
     },
     {
-        "product": "3.8.0",
+        "product": "3.8.1",
         "java-base": "21",
         "java-devel": "21",
         "scala": "2.13",

--- a/kafka/versions.py
+++ b/kafka/versions.py
@@ -1,5 +1,14 @@
 versions = [
     {
+        "product": "3.7.1",
+        "java-base": "21",
+        "java-devel": "21",
+        "scala": "2.13",
+        "kcat": "1.7.0",
+        "opa_authorizer": "1.5.1",
+        "jmx_exporter": "1.1.0",
+    },
+    {
         "product": "3.7.2",
         "java-base": "21",
         "java-devel": "21",


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/docker-images/issues/968.

This PR corrects work done in https://github.com/stackabletech/docker-images/pull/988.
- Restore 3.7.1
- Replace 3.8.0 with 3.8.1.
  - kafka 3.8.1 source uploaded to Nexus.
  - Patches applied via patchable.nu (experimental)

> [!NOTE]
> Container image build tested via `bake kafka=3.8.1`.