### PR TITLE
chore(opa): Use 1.0.1 instead of 1.0.0

### DIFF
--- a/opa/versions.py
+++ b/opa/versions.py
@@ -1,6 +1,6 @@
 versions = [
     {
-        "product": "1.0.0",
+        "product": "1.0.1",
         "vector": "0.43.1",
         "bundle_builder_version": "1.1.2",
         "stackable-base": "1.0.0",


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/998
