### PR TITLE
chore: bump hbase version used by spark / fix failing hbase connector test

### DIFF
--- a/spark-k8s/Dockerfile
+++ b/spark-k8s/Dockerfile
@@ -149,10 +149,10 @@ ln -s /stackable/hbase-connectors/spark/hbase-spark/target/hbase-spark-${HBASE_C
 # Spark contains only log4j-slf4j2-impl-x.x.x.jar but not
 # log4j-slf4j-impl-x.x.x.jar. It is okay to have both JARs in the
 # classpath as long as they have the same version.
-mvn --quiet --non-recursive  --no-transfer-progress --batch-mode --file /stackable/spark/pom.xml \
+mvn --quiet --non-recursive --no-transfer-progress --batch-mode --file /stackable/spark/pom.xml \
     dependency:copy \
     -Dartifact=org.apache.logging.log4j:log4j-slf4j-impl:'${log4j.version}' \
-    -DoutputDirectory=.
+    -DoutputDirectory=./jars
 EOF
 
 

--- a/spark-k8s/versions.py
+++ b/spark-k8s/versions.py
@@ -5,7 +5,7 @@ versions = [
         "java-devel": "17",
         "python": "3.11",
         "hadoop": "3.3.6",  # Hadoop version defined in ../hbase/versions.py to reduce build time and disk requirements
-        "hbase": "2.4.18",  # current Stackable LTS version
+        "hbase": "2.6.1",  # current Stackable LTS version
         "aws_java_sdk_bundle": "1.12.367",  # https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-aws/3.3.6
         "azure_storage": "7.0.1",  # https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-azure/3.3.6
         "azure_keyvault_core": "1.0.0",  # https://mvnrepository.com/artifact/com.microsoft.azure/azure-storage/7.0.1
@@ -23,7 +23,7 @@ versions = [
         "java-devel": "17",
         "python": "3.11",
         "hadoop": "3.3.6",  # Hadoop version defined in ../hbase/versions.py to reduce build time and disk requirements
-        "hbase": "2.4.18",  # current Stackable LTS version
+        "hbase": "2.6.1",  # current Stackable LTS version
         "aws_java_sdk_bundle": "1.12.367",  # https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-aws/3.3.6
         "azure_storage": "7.0.1",  # https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-azure/3.3.6
         "azure_keyvault_core": "1.0.0",  # https://mvnrepository.com/artifact/com.microsoft.azure/azure-storage/7.0.1


### PR DESCRIPTION
# Description

Make Spark use our new LTS version of HBase.

Running the hbase-connector test failed for me, because the class `StaticLoggerBinder` could not be found. It seems like the Maven command in line 152 downloads the file to `/stackable/spark` instead of `/stackable/spark/jars`, even though it's running in that directory, but I guess Maven resolves "." to the directory that `pom.xml` is located in (which is `/stackable/spark`). That results in the `log4j-slf4j-impl` jar not being there at runtime. Once I fixed it, the test succeeded on my machine.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
- [x] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] All packages should have (if available) signatures/hashes verified
- [x] Add an entry to the CHANGELOG.md file
- [x] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
