### PR TITLE
chore: Bump Rust toolchain to 1.84.1

### DIFF
--- a/stackable-base/Dockerfile
+++ b/stackable-base/Dockerfile
@@ -15,7 +15,7 @@ ENV CONTAINERDEBUG_VERSION=0.1.1
 # This SHOULD be kept in sync with operator-templating and other tools to reduce build times
 # Find the latest version here: https://doc.rust-lang.org/stable/releases.html
 # renovate: datasource=github-releases packageName=rust-lang/rust
-ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.82.0
+ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.84.1
 # Find the latest version here: https://crates.io/crates/cargo-cyclonedx
 # renovate: datasource=crate packageName=cargo-cyclonedx
 ENV CARGO_CYCLONEDX_CRATE_VERSION=0.5.5

--- a/ubi8-rust-builder/Dockerfile
+++ b/ubi8-rust-builder/Dockerfile
@@ -13,7 +13,7 @@ LABEL maintainer="Stackable GmbH"
 # This SHOULD be kept in sync with operator-templating and other tools to reduce build times
 # Find the latest version here: https://doc.rust-lang.org/stable/releases.html
 # renovate: datasource=github-releases packageName=rust-lang/rust
-ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.82.0
+ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.84.1
 # Find the latest version here: https://crates.io/crates/cargo-cyclonedx
 # renovate: datasource=crate packageName=cargo-cyclonedx
 ENV CARGO_CYCLONEDX_CRATE_VERSION=0.5.5

--- a/ubi9-rust-builder/Dockerfile
+++ b/ubi9-rust-builder/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="Stackable GmbH"
 # This SHOULD be kept in sync with operator-templating and other tools to reduce build times
 # Find the latest version here: https://doc.rust-lang.org/stable/releases.html
 # renovate: datasource=github-releases packageName=rust-lang/rust
-ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.82.0
+ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.84.1
 # Find the latest version here: https://crates.io/crates/cargo-cyclonedx
 # renovate: datasource=crate packageName=cargo-cyclonedx
 ENV CARGO_CYCLONEDX_CRATE_VERSION=0.5.5


### PR DESCRIPTION
Part of https://github.com/stackabletech/operator-templating/issues/484