### PR TITLE
fix: Install correct Rust toolchains for sub projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- stackable-base: Bump cargo-cyclonedx to 0.5.7 ([#1013]).
 - kafka: Bump 3.8.0 to 3.8.1 ([#995]).
 - Update registry references to oci ([#989]).
 - trino-storage-connector: Move the build out of trino/ for easier patching ([#996]).
@@ -52,6 +53,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- stackable-base: Install missing rust toolchains ([#1013]).
+- opa: Install missing rust toolchains ([#1013]).
 - druid: Fix CVE-2023-34455 in Druid `30.0.0` by deleting a dependency ([#935]).
 - hadoop: Fix the JMX exporter configuration for metrics suffixed with
   `_total`, `_info` and `_created` ([#962]).
@@ -84,6 +87,7 @@ All notable changes to this project will be documented in this file.
 [#1005]: https://github.com/stackabletech/docker-images/pull/1005
 [#1006]: https://github.com/stackabletech/docker-images/pull/1006
 [#1007]: https://github.com/stackabletech/docker-images/pull/1007
+[#1013]: https://github.com/stackabletech/docker-images/pull/1013
 
 ## [24.11.1] - 2025-01-14
 

--- a/opa/Dockerfile
+++ b/opa/Dockerfile
@@ -21,9 +21,15 @@ RUN microdnf update \
 
 WORKDIR /
 
+# WARNING (@NickLarsenNZ): We should pin the rustup version
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN git clone --depth 1 --branch ${BUNDLE_BUILDER_VERSION} https://github.com/stackabletech/opa-bundle-builder
-RUN cd ./opa-bundle-builder && . "$HOME/.cargo/env" && cargo --quiet build --release
+RUN <<EOF
+cd ./opa-bundle-builder
+. "$HOME/.cargo/env"
+rustup toolchain install
+cargo --quiet build --release
+EOF
 
 FROM stackable/image/stackable-base AS multilog-builder
 

--- a/stackable-base/Dockerfile
+++ b/stackable-base/Dockerfile
@@ -18,10 +18,10 @@ ENV CONTAINERDEBUG_VERSION=0.1.1
 ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.84.1
 # Find the latest version here: https://crates.io/crates/cargo-cyclonedx
 # renovate: datasource=crate packageName=cargo-cyclonedx
-ENV CARGO_CYCLONEDX_CRATE_VERSION=0.5.5
+ENV CARGO_CYCLONEDX_CRATE_VERSION=0.5.7
 # Find the latest version here: https://crates.io/crates/cargo-auditable
 # renovate: datasource=crate packageName=cargo-auditable
-ENV CARGO_AUDITABLE_CRATE_VERSION=0.6.4
+ENV CARGO_AUDITABLE_CRATE_VERSION=0.6.6
 
 RUN <<EOF
 microdnf update --assumeyes

--- a/stackable-base/Dockerfile
+++ b/stackable-base/Dockerfile
@@ -34,6 +34,7 @@ microdnf --assumeyes install \
 microdnf clean all
 rm -rf /var/cache/yum
 
+# WARNING (@NickLarsenNZ): We should pin the rustup version
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain "$RUST_DEFAULT_TOOLCHAIN_VERSION"
 . "$HOME/.cargo/env" && cargo --quiet install cargo-cyclonedx@"$CARGO_CYCLONEDX_CRATE_VERSION" cargo-auditable@"$CARGO_AUDITABLE_CRATE_VERSION"
 EOF
@@ -44,6 +45,7 @@ RUN <<EOF
 git clone --depth 1 --branch "${CONFIG_UTILS_VERSION}" https://github.com/stackabletech/config-utils
 cd ./config-utils
 . "$HOME/.cargo/env"
+rustup toolchain install
 cargo auditable --quiet build --release && cargo cyclonedx --all --spec-version 1.5 --describe binaries
 EOF
 
@@ -53,6 +55,7 @@ RUN <<EOF
 git clone --depth 1 --branch "${CONTAINERDEBUG_VERSION}" https://github.com/stackabletech/containerdebug
 cd ./containerdebug
 . "$HOME/.cargo/env"
+rustup toolchain install
 cargo auditable --quiet build --release && cargo cyclonedx --all --spec-version 1.5 --describe binaries
 EOF
 


### PR DESCRIPTION
Part of <https://github.com/stackabletech/operator-templating/issues/484>

The stackable-base image pulls in a bunch of Rust based projects (config-utils, containerdebug, opa-bundle-builder). Each of those projects (might) use a different toolchain from what we set as the default toolchain (1.84.1 as of #1012).

Since 1.28.0 (released on 2025-03-02), `rustup` will no longer automatically install the toolchain specified in `rust-toolchain.toml`. Instead, we manually need to run `rustup toolchain install` to install it before building.