### PR TITLE
fix: remove unnecessary file from druid 31 patch

### DIFF
--- a/druid/stackable/patches/31.0.1/0009-Update-FMPP-version.patch
+++ b/druid/stackable/patches/31.0.1/0009-Update-FMPP-version.patch
@@ -8,14 +8,9 @@ which itself depends on a Freemarker version that has not been pinned.
 Instead it specifies a "range" which resolves to a SNAPSHOT version
 which we don't want.
 ---
- 10-update-fmpp.patch | 0
- sql/pom.xml          | 7 +++++++
- 2 files changed, 7 insertions(+)
- create mode 100644 10-update-fmpp.patch
+ sql/pom.xml | 7 +++++++
+ 1 file changed, 7 insertions(+)
 
-diff --git a/10-update-fmpp.patch b/10-update-fmpp.patch
-new file mode 100644
-index 0000000000..e69de29bb2
 diff --git a/sql/pom.xml b/sql/pom.xml
 index 56ed03f5c2..d0d19dd854 100644
 --- a/sql/pom.xml


### PR DESCRIPTION
# Description

The "Update FMPP" patch for Druid 31.0.1 creates an unnecessary `10-update-fmpp.patch` file (this was probably accidentally introduced when migrating the patches to the Patchable format). This currently causes Patchable to fail during checkout of Druid 31.0.1 (`Diff::from_buffer` is failing to parse the diff).

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
