### PR TITLE
fix: readd Hive 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 - omid: Use jmx_export 1.1.0 ([#1021]).
 - spark: Add 3.5.5 ([#1022]).
 - trino: Add libstdc++ package, needed by snappy and duckdb ([#1015]).
+- hive: Revert the removal of 4.0.0 ([#1031]).
 
 ### Changed
 

--- a/hive/stackable/patches/4.0.0/0001-Include-Postgres-driver.patch
+++ b/hive/stackable/patches/4.0.0/0001-Include-Postgres-driver.patch
@@ -1,0 +1,34 @@
+From c5eb86648fe96b048723372024fa7278c9e108db Mon Sep 17 00:00:00 2001
+From: Sebastian Bernauer <sebastian.bernauer@stackable.de>
+Date: Tue, 3 Sep 2024 11:13:24 +0200
+Subject: Include Postgres driver
+
+---
+ standalone-metastore/metastore-server/pom.xml | 1 -
+ standalone-metastore/pom.xml                  | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/standalone-metastore/metastore-server/pom.xml b/standalone-metastore/metastore-server/pom.xml
+index a8f680928c..7102f1b5ca 100644
+--- a/standalone-metastore/metastore-server/pom.xml
++++ b/standalone-metastore/metastore-server/pom.xml
+@@ -334,7 +334,6 @@
+     <dependency>
+       <groupId>org.postgresql</groupId>
+       <artifactId>postgresql</artifactId>
+-      <optional>true</optional>
+     </dependency>
+     <dependency>
+       <groupId>org.eclipse.jetty</groupId>
+diff --git a/standalone-metastore/pom.xml b/standalone-metastore/pom.xml
+index 28ac5ceb65..e3cbd821bd 100644
+--- a/standalone-metastore/pom.xml
++++ b/standalone-metastore/pom.xml
+@@ -397,7 +397,6 @@
+         <groupId>org.postgresql</groupId>
+         <artifactId>postgresql</artifactId>
+         <version>${postgres.version}</version>
+-        <scope>runtime</scope>
+       </dependency>
+       <dependency>
+         <groupId>org.apache.httpcomponents</groupId>

--- a/hive/stackable/patches/4.0.0/0002-Include-logging-dependencies.patch
+++ b/hive/stackable/patches/4.0.0/0002-Include-logging-dependencies.patch
@@ -1,0 +1,26 @@
+From 69071d4d4525a8ceb27cbefa9a093d0678a1f3dd Mon Sep 17 00:00:00 2001
+From: Lars Francke <lars.francke@stackable.tech>
+Date: Tue, 13 Aug 2024 13:38:12 +0200
+Subject: Include logging dependencies
+
+This adds dependencies required for use of the XmlLayout for logging
+---
+ standalone-metastore/pom.xml | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/standalone-metastore/pom.xml b/standalone-metastore/pom.xml
+index e3cbd821bd..205fc31ec7 100644
+--- a/standalone-metastore/pom.xml
++++ b/standalone-metastore/pom.xml
+@@ -493,6 +493,11 @@
+       <groupId>com.fasterxml.jackson.core</groupId>
+       <artifactId>jackson-databind</artifactId>
+     </dependency>
++    <dependency>
++      <!-- Optional log4j dependency to be able to use the XmlLayout -->
++      <groupId>com.fasterxml.jackson.dataformat</groupId>
++      <artifactId>jackson-dataformat-xml</artifactId>
++    </dependency>
+   </dependencies>
+   <build>
+     <pluginManagement>

--- a/hive/stackable/patches/4.0.0/0003-Add-CycloneDX-plugin.patch
+++ b/hive/stackable/patches/4.0.0/0003-Add-CycloneDX-plugin.patch
@@ -1,0 +1,45 @@
+From 23995b6c1ef70e4e119ce0493e63ff3a75ea1378 Mon Sep 17 00:00:00 2001
+From: Lukas Voetmand <lukas.voetmand@stackable.tech>
+Date: Fri, 6 Sep 2024 17:53:52 +0200
+Subject: Add CycloneDX plugin
+
+---
+ standalone-metastore/pom.xml | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/standalone-metastore/pom.xml b/standalone-metastore/pom.xml
+index 205fc31ec7..2982a45ca0 100644
+--- a/standalone-metastore/pom.xml
++++ b/standalone-metastore/pom.xml
+@@ -41,6 +41,7 @@
+     <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
+     <maven.repo.local>${settings.localRepository}</maven.repo.local>
+     <maven.exec.plugin.version>3.1.0</maven.exec.plugin.version>
++    <maven.cyclonedx.plugin.version>2.8.0</maven.cyclonedx.plugin.version>
+     <checkstyle.conf.dir>${basedir}/${standalone.metastore.path.to.root}/checkstyle</checkstyle.conf.dir>
+     <!-- Test Properties -->
+     <log4j.conf.dir>${project.basedir}/src/test/resources</log4j.conf.dir>
+@@ -594,6 +595,23 @@
+           </excludes>
+         </configuration>
+       </plugin>
++      <plugin>
++        <groupId>org.cyclonedx</groupId>
++        <artifactId>cyclonedx-maven-plugin</artifactId>
++        <version>${maven.cyclonedx.plugin.version}</version>
++        <configuration>
++          <projectType>application</projectType>
++          <schemaVersion>1.5</schemaVersion>
++        </configuration>
++        <executions>
++          <execution>
++            <phase>package</phase>
++            <goals>
++              <goal>makeBom</goal>
++            </goals>
++          </execution>
++        </executions>
++      </plugin>
+     </plugins>
+   </build>
+   <profiles>

--- a/hive/stackable/patches/4.0.0/0004-Fix-CVE-2024-36114.patch
+++ b/hive/stackable/patches/4.0.0/0004-Fix-CVE-2024-36114.patch
@@ -1,0 +1,44 @@
+From 4a85ad5ec7b0dbfb9f2c4524531ae0198a352b3d Mon Sep 17 00:00:00 2001
+From: Malte Sander <malte.sander.it@gmail.com>
+Date: Tue, 12 Nov 2024 11:49:57 +0100
+Subject: Fix CVE-2024-36114
+
+see https://github.com/stackabletech/vulnerabilities/issues/834
+
+Aircompressor is a library with ports of the Snappy, LZO, LZ4, and
+Zstandard compression algorithms to Java. All decompressor
+implementations of Aircompressor (LZ4, LZO, Snappy, Zstandard) can crash
+the JVM for certain input, and in some cases also leak the content of
+other memory of the Java process (which could contain sensitive
+information). When decompressing certain data, the decompressors try to
+access memory outside the bounds of the given byte arrays or byte
+buffers. Because Aircompressor uses the JDK class sun.misc.Unsafe to
+speed up memory access, no additional bounds checks are performed and
+this has similar security consequences as out-of-bounds access in C or
+C++, namely it can lead to non-deterministic behavior or crash the JVM.
+Users should update to Aircompressor 0.27 or newer where these issues
+have been fixed. When decompressing data from untrusted users, this can
+be exploited for a denial-of-service attack by crashing the JVM, or to
+leak other sensitive information from the Java process. There are no
+known workarounds for this issue.
+---
+ standalone-metastore/pom.xml | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/standalone-metastore/pom.xml b/standalone-metastore/pom.xml
+index 2982a45ca0..cd34884e3b 100644
+--- a/standalone-metastore/pom.xml
++++ b/standalone-metastore/pom.xml
+@@ -121,6 +121,12 @@
+   </properties>
+   <dependencyManagement>
+     <dependencies>
++      <!-- Mitigate CVE-2024-36114: See https://github.com/stackabletech/vulnerabilities/issues/834 -->
++      <dependency>
++        <groupId>io.airlift</groupId>
++        <artifactId>aircompressor</artifactId>
++        <version>0.27</version>
++      </dependency>
+       <dependency>
+         <groupId>org.apache.orc</groupId>
+         <artifactId>orc-core</artifactId>

--- a/hive/stackable/patches/4.0.0/patchable.toml
+++ b/hive/stackable/patches/4.0.0/patchable.toml
@@ -1,0 +1,2 @@
+upstream = "https://github.com/apache/hive.git"
+base = "183f8cb41d3dbed961ffd27999876468ff06690c"

--- a/hive/versions.py
+++ b/hive/versions.py
@@ -12,6 +12,18 @@ versions = [
         "azure_keyvault_core": "1.0.0",
     },
     {
+        "product": "4.0.0",
+        "jmx_exporter": "1.1.0",
+        # Hive 4 must be built with Java 8 (according to GitHub README) but seems to run on Java 11
+        "java-base": "11",
+        "java-devel": "8",
+        "hadoop": "3.3.6",
+        # Keep consistent with the dependency from Hadoop: https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-aws/3.3.6
+        "aws_java_sdk_bundle": "1.12.367",
+        "azure_storage": "7.0.1",
+        "azure_keyvault_core": "1.0.0",
+    },
+    {
         "product": "4.0.1",
         "jmx_exporter": "1.1.0",
         # Hive 4 must be built with Java 8 (according to GitHub README) but seems to run on Java 11


### PR DESCRIPTION
# Description

As discussed [here](https://github.com/stackabletech/demos/pull/173), Hive 4.0.1 removes functions that break python-iceberg.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
