### PR TITLE
feat: move patch apply logic to patchable

### DIFF
--- a/druid/Dockerfile
+++ b/druid/Dockerfile
@@ -23,10 +23,8 @@ microdnf update
 #   This requirement is documented in docs/development/build.md and version 5.1 or later is required.
 #   UBI 9 ships with 5.4.x so that should be fine
 #
-# patch: Required for the apply-patches.sh script
 microdnf install \
-python-pyyaml \
-patch
+python-pyyaml
 
 microdnf clean all
 rm -rf /var/cache/yum
@@ -35,8 +33,7 @@ EOF
 USER ${STACKABLE_USER_UID}
 WORKDIR /stackable
 
-COPY --chown=stackable:0 druid/stackable/patches/apply_patches.sh /stackable/apache-druid-${PRODUCT}-src/patches/apply_patches.sh
-COPY --chown=stackable:0 druid/stackable/patches/${PRODUCT} /stackable/apache-druid-${PRODUCT}-src/patches/${PRODUCT}
+COPY --chown=stackable:0 druid/stackable/patches/${PRODUCT} /stackable/apache-druid-${PRODUCT}-src/druid/stackable/patches/${PRODUCT}
 
 # Cache mounts are owned by root by default
 # We need to explicitly give the uid to use which is hardcoded to "1000" in stackable-base
@@ -50,10 +47,8 @@ RUN --mount=type=cache,id=maven-${PRODUCT},uid=${STACKABLE_USER_UID},target=/sta
     --mount=type=cache,id=npm-${PRODUCT},uid=${STACKABLE_USER_UID},target=/stackable/.npm \
     --mount=type=cache,id=cache-${PRODUCT},uid=${STACKABLE_USER_UID},target=/stackable/.cache \
     <<EOF
-curl "https://repo.stackable.tech/repository/packages/druid/apache-druid-${PRODUCT}-src.tar.gz" | tar -xzC .
 cd apache-druid-${PRODUCT}-src
-./patches/apply_patches.sh ${PRODUCT}
-
+cd "$(/stackable/patchable --images-repo-root=. checkout druid ${PRODUCT})" && \
 mvn --batch-mode --no-transfer-progress clean install -Pdist,stackable-bundle-contrib-exts -DskipTests -Dmaven.javadoc.skip=true
 mv distribution/target/apache-druid-${PRODUCT}-bin/apache-druid-${PRODUCT} /stackable/
 mv distribution/target/bom.json /stackable/apache-druid-${PRODUCT}/apache-druid-${PRODUCT}.cdx.json

--- a/stackable-base/Dockerfile
+++ b/stackable-base/Dockerfile
@@ -59,6 +59,23 @@ rustup toolchain install
 cargo auditable --quiet build --release && cargo cyclonedx --all --spec-version 1.5 --describe binaries
 EOF
 
+FROM product-utils-builder AS patchable
+
+# Copy source code of patchable
+COPY rust/patchable/ /patchable/rust/patchable
+# Copy workspace files
+COPY Cargo.* /patchable/
+
+RUN <<EOF
+microdnf update --assumeyes
+microdnf install --assumeyes openssl-devel pkg-config
+cd /patchable
+. "$HOME/.cargo/env"
+rustup toolchain install
+cargo auditable --quiet build --release && cargo cyclonedx --all --spec-version 1.5 --describe binaries
+microdnf clean all
+EOF
+
 # Find the latest version at https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5?container-tabs=gti
 # IMPORTANT: Make sure to use the "Manifest List Digest" that references the images for multiple architectures
 # rather than just the "Image Digest" that references the image for the selected architecture.
@@ -203,6 +220,10 @@ COPY --from=config-utils --chown=${STACKABLE_USER_UID}:0 /config-utils/config-ut
 # **containerdebug**
 # Debug tool that logs generic system information.
 COPY --from=containerdebug --chown=${STACKABLE_USER_UID}:0 /containerdebug/target/release/containerdebug /stackable/containerdebug
+
+# **patchable**
+# Tool for patch management
+COPY --from=patchable --chown=${STACKABLE_USER_UID}:0 /patchable/target/release/patchable /stackable/patchable
 
 ENV PATH="${PATH}:/stackable"
 

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -17,10 +17,9 @@ USER ${STACKABLE_USER_UID}
 WORKDIR /stackable
 
 # Download ZooKeeper sources from our own repo
-RUN curl "https://repo.stackable.tech/repository/packages/zookeeper/apache-zookeeper-${PRODUCT}.tar.gz" | tar -xzC . && \
-    # Apply any required patches
-    patches/apply_patches.sh ${PRODUCT} && \
-    cd /stackable/apache-zookeeper-${PRODUCT}/ && \
+RUN mkdir -p zookeeper/stackable && mv patches zookeeper/stackable/ && \
+    BUILD_SRC_DIR="$(/stackable/patchable --images-repo-root=. checkout zookeeper ${PRODUCT})" && \
+    cd "${BUILD_SRC_DIR}" && \
     # Exclude the `zookeeper-client` submodule, this is not needed and has c parts
     # that created all kinds of issues for the build container
     mvn --batch-mode --no-transfer-progress -pl "!zookeeper-client/zookeeper-client-c" clean install checkstyle:check spotbugs:check -DskipTests -Pfull-build && \
@@ -29,7 +28,7 @@ RUN curl "https://repo.stackable.tech/repository/packages/zookeeper/apache-zooke
     # Unpack the archive which contains the build artifacts from above. Remove some
     # unused files to shrink the final image size.
     tar xvzf /stackable/apache-zookeeper-${PRODUCT}-bin.tar.gz && \
-    mv /stackable/apache-zookeeper-${PRODUCT}/zookeeper-assembly/target/bom.json /stackable/apache-zookeeper-${PRODUCT}-bin/apache-zookeeper-${PRODUCT}.cdx.json && \
+    mv "${BUILD_SRC_DIR}/zookeeper-assembly/target/bom.json" /stackable/apache-zookeeper-${PRODUCT}-bin/apache-zookeeper-${PRODUCT}.cdx.json && \
     rm -rf /stackable/apache-zookeeper-${PRODUCT}-bin/docs && \
     rm /stackable/apache-zookeeper-${PRODUCT}-bin/README_packaging.md && \
     # Download the JMX exporter jar from our own repo


### PR DESCRIPTION
# Description

This is a draft PR to solve https://github.com/stackabletech/docker-images/issues/677. I replaced the `apply_patches.sh` script with Patchable for Zookeeper and Druid.

We decided in https://github.com/stackabletech/decisions/issues/44 that all sources should be mirrored on Github (to be implemented by https://github.com/stackabletech/docker-images/issues/1011). 

My idea was that we can just reuse the existing `checkout` logic, since it does exactly what we want: checkout a repo at a specific commit and apply a bunch of .patch files on top of it. In this PR, the original Apache repositories are used, those would need to be replaced by our mirror repos.

I added an optional flag `--images_repo_root` to manually specify a custom root for the `images` repo instead of relying on the auto-detection that Patchable currently does. We could also just use the auto-detection, but then we'd probably need to run `git init && touch .patchable` before running the `patchable checkout` command inside the container, which is a bit awkward. The extra flag isn't super pretty either though and I couldn't get around using `PathBuf` in the implementation, hence I made this a draft PR to serve as a PoC. This is just one way we could replace the patch scripts with Patchable. Maybe this can be solved in a more elegant way, I didn't find one yet though.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
