### PR TITLE
Fix: OPA reduce image size 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - nifi: check for correct permissions and ownerships in /stackable folder via
   `check-permissions-ownership.sh` provided in stackable-base image ([#1027]).
 - opa: check for correct permissions and ownerships in /stackable folder via
-`check-permissions-ownership.sh` provided in stackable-base image ([#1038]).
+  `check-permissions-ownership.sh` provided in stackable-base image ([#1038]).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- opa: reduce docker image size by removing the recursive chown/chmods in the final image ([#1038]).
+
+[#1038]: https://github.com/stackabletech/docker-images/pull/1038
+
 ## [25.3.0] - 2025-03-21
 
 ### Added

--- a/opa/Dockerfile
+++ b/opa/Dockerfile
@@ -147,6 +147,9 @@ microdnf install \
   jq
 microdnf clean all
 rm -rf /var/cache/yum
+
+# fix missing permissions
+chmod g=u /stackable/opa
 EOF
 
 # ----------------------------------------

--- a/opa/Dockerfile
+++ b/opa/Dockerfile
@@ -29,6 +29,8 @@ cd ./opa-bundle-builder
 . "$HOME/.cargo/env"
 rustup toolchain install
 cargo --quiet build --release
+# set correct groups
+chmod -R g=u /opa-bundle-builder/target/release/
 EOF
 
 FROM stackable/image/stackable-base AS multilog-builder
@@ -58,12 +60,15 @@ RUN patch < /daemontools/conf-cc.patch && \
 
 WORKDIR /daemontools/admin/daemontools-${DAEMONTOOLS_VERSION}
 
-RUN package/install
+RUN package/install && \
+    # set correct groups
+    chmod g=u /daemontools/admin/daemontools/command/multilog
 
 FROM stackable/image/stackable-base AS opa-builder
 
 ARG PRODUCT
 ARG RELEASE
+ARG STACKABLE_USER_UID
 ARG TARGETARCH
 ARG TARGETOS
 
@@ -81,11 +86,15 @@ RUN microdnf update && \
     tar && \
     microdnf clean all
 
+COPY --chown=${STACKABLE_USER_UID}:0 opa/stackable/bin /stackable/opa/bin
+
+RUN <<EOF
 # We use version 1.7.0, since a newer version of cyclonedx-gomod is not compatible with the version of Golang (>= 1.23.1)
-RUN go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.7.0
-RUN curl "https://repo.stackable.tech/repository/packages/opa/opa_${PRODUCT}.tar.gz" -o opa.tar.gz && \
-    tar -zxvf opa.tar.gz && \
-    mv "opa-${PRODUCT}" opa
+go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.7.0
+curl "https://repo.stackable.tech/repository/packages/opa/opa_${PRODUCT}.tar.gz" -o opa.tar.gz
+tar -zxvf opa.tar.gz
+mv "opa-${PRODUCT}" opa
+EOF
 
 WORKDIR /opa
 
@@ -97,7 +106,12 @@ git config user.name "Fake commiter"
 git commit --allow-empty --message "Fake commit, so that we can create a tag"
 git tag "v${PRODUCT}"
 go build -o opa -buildmode=exe
-~/go/bin/cyclonedx-gomod app -json -output-version 1.5 -output "opa_${PRODUCT}.cdx.json" -packages -files
+# move artifact to /stackable/*/ to copy in final image
+~/go/bin/cyclonedx-gomod app -json -output-version 1.5 -output /stackable/opa/"opa_${PRODUCT}.cdx.json" -packages -files
+# move artifact to /stackable/* to copy in final image
+mv /opa/opa /stackable/opa/
+# set correct groups
+chmod -R g=u /stackable/opa
 EOF
 
 FROM stackable/image/vector
@@ -114,32 +128,23 @@ LABEL name="Open Policy Agent" \
       summary="The Stackable image for Open Policy Agent (OPA)." \
       description="This image is deployed by the Stackable Operator for OPA."
 
-COPY opa/licenses /licenses
+COPY --chown=${STACKABLE_USER_UID}:0 opa/licenses /licenses
 
-COPY --from=opa-builder --chown=${STACKABLE_USER_UID}:0 /opa/opa /stackable/opa/opa
-COPY --from=opa-builder --chown=${STACKABLE_USER_UID}:0 /opa/opa_${PRODUCT}.cdx.json /stackable/opa/
+COPY --from=opa-builder --chown=${STACKABLE_USER_UID}:0 /stackable/opa /stackable/opa
 COPY --from=opa-bundle-builder --chown=${STACKABLE_USER_UID}:0 /opa-bundle-builder/target/release/stackable-opa-bundle-builder /stackable/opa-bundle-builder
 COPY --from=multilog-builder --chown=${STACKABLE_USER_UID}:0 /daemontools/admin/daemontools/command/multilog /stackable/multilog
 
-COPY --chown=${STACKABLE_USER_UID}:0 opa/stackable/bin /stackable/opa/bin
-
 RUN <<EOF
 microdnf update
-
 # jq: Required for filtering logs
 microdnf install \
   jq
 microdnf clean all
 rm -rf /var/cache/yum
-
-# All files and folders owned by root group to support running as arbitrary users.
-# This is best practice as all container users will belong to the root group (0).
-chown -R ${STACKABLE_USER_UID}:0 /stackable
-chmod -R g=u /stackable
 EOF
 
 # ----------------------------------------
-# Attention: We are changing the group of all files in /stackable directly above
+# Attention:
 # If you do any file based actions (copying / creating etc.) below this comment you
 # absolutely need to make sure that the correct permissions are applied!
 # chown ${STACKABLE_USER_UID}:0

--- a/opa/Dockerfile
+++ b/opa/Dockerfile
@@ -6,18 +6,20 @@ FROM stackable/image/stackable-base AS opa-bundle-builder
 ARG BUNDLE_BUILDER_VERSION
 
 # Update image and install everything needed for Rustup & Rust
-RUN microdnf update \
-  && microdnf install \
-    cmake \
-    gcc \
-    gcc-c++ \
-    git \
-    make \
-    openssl-devel \
-    pkg-config \
-    systemd-devel \
-    unzip \
-  && rm -rf /var/cache/yum
+RUN <<EOF
+microdnf update
+microdnf install \
+  cmake \
+  gcc \
+  gcc-c++ \
+  git \
+  make \
+  openssl-devel \
+  pkg-config \
+  systemd-devel \
+  unzip
+rm -rf /var/cache/yum
+EOF
 
 WORKDIR /
 
@@ -39,30 +41,32 @@ ARG DAEMONTOOLS_VERSION=0.76
 
 COPY opa/daemontools /daemontools
 
-RUN microdnf update && \
-    microdnf install \
-    gcc \
-    gzip \
-    make \
-    patch \
-    tar && \
-    microdnf clean all \
-    && rm -rf /var/cache/yum
+RUN <<EOF
+microdnf update
+microdnf install \
+  gcc \
+  gzip \
+  make \
+  patch \
+  tar
+microdnf clean all
+rm -rf /var/cache/yum
+EOF
 
-WORKDIR /daemontools
+RUN <<EOF
+cd /daemontools
+tar xzf daemontools-${DAEMONTOOLS_VERSION}.tar.gz
 
-RUN tar xzf daemontools-${DAEMONTOOLS_VERSION}.tar.gz
+cd /daemontools/admin/daemontools-${DAEMONTOOLS_VERSION}/src
+patch < /daemontools/conf-cc.patch
+patch multilog.c < /daemontools/multilog_max_file_size.patch
 
-WORKDIR /daemontools/admin/daemontools-${DAEMONTOOLS_VERSION}/src
+cd /daemontools/admin/daemontools-${DAEMONTOOLS_VERSION}
+package/install
 
-RUN patch < /daemontools/conf-cc.patch && \
-    patch multilog.c < /daemontools/multilog_max_file_size.patch
-
-WORKDIR /daemontools/admin/daemontools-${DAEMONTOOLS_VERSION}
-
-RUN package/install && \
-    # set correct groups
-    chmod g=u /daemontools/admin/daemontools/command/multilog
+# set correct groups
+chmod g=u /daemontools/admin/daemontools/command/multilog
+EOF
 
 FROM stackable/image/stackable-base AS opa-builder
 
@@ -78,13 +82,15 @@ ENV GOOS=$TARGETOS
 # gzip, tar - used to unpack the OPA source
 # git - needed by the cyclonedx-gomod tool to determine the version of OPA
 # golang - used to build OPA
-RUN microdnf update && \
-    microdnf install \
-    git \
-    golang \
-    gzip \
-    tar && \
-    microdnf clean all
+RUN <<EOF
+microdnf update
+microdnf install \
+  git \
+  golang \
+  gzip \
+  tar
+microdnf clean all
+EOF
 
 COPY --chown=${STACKABLE_USER_UID}:0 opa/stackable/bin /stackable/opa/bin
 
@@ -121,12 +127,12 @@ ARG RELEASE
 ARG STACKABLE_USER_UID
 
 LABEL name="Open Policy Agent" \
-      maintainer="info@stackable.tech" \
-      vendor="Stackable GmbH" \
-      version="${PRODUCT}" \
-      release="${RELEASE}" \
-      summary="The Stackable image for Open Policy Agent (OPA)." \
-      description="This image is deployed by the Stackable Operator for OPA."
+  maintainer="info@stackable.tech" \
+  vendor="Stackable GmbH" \
+  version="${PRODUCT}" \
+  release="${RELEASE}" \
+  summary="The Stackable image for Open Policy Agent (OPA)." \
+  description="This image is deployed by the Stackable Operator for OPA."
 
 COPY --chown=${STACKABLE_USER_UID}:0 opa/licenses /licenses
 
@@ -144,11 +150,20 @@ rm -rf /var/cache/yum
 EOF
 
 # ----------------------------------------
-# Attention:
-# If you do any file based actions (copying / creating etc.) below this comment you
-# absolutely need to make sure that the correct permissions are applied!
-# chown ${STACKABLE_USER_UID}:0
+# Checks
+# This section is to run final checks to ensure the created final images
+# adhere to several minimal requirements like:
+# - check file permissions and ownerships
 # ----------------------------------------
+
+# Check that permissions and ownership in /stackable are set correctly
+# This will fail and stop the build if any mismatches are found.
+RUN <<EOF
+/bin/check-permissions-ownership.sh /stackable ${STACKABLE_USER_UID} 0
+EOF
+
+# ----------------------------------------
+# Attention: Do not perform any file based actions (copying/creating etc.) below this comment because the permissions would not be checked.
 
 USER ${STACKABLE_USER_UID}
 WORKDIR /stackable/opa


### PR DESCRIPTION
# Description

part of https://github.com/stackabletech/docker-images/issues/961

```
REPOSITORY                                       TAG                                   IMAGE ID       CREATED             SIZE
oci.stackable.tech/sdp/opa                       1.0.1-stackable25.3.0-reduced-size    fe3a6374d0c6   2 minutes ago       417MB
oci.stackable.tech/sdp/opa                       1.0.1-stackable25.3.0                 9cf54f0be3b9   27 hours ago        477MB
```

- Does remove the recursive chmod/chown in the final image and attempts non recursive chmod/chown or doing as much as possible in the builder step.
- bundles artifacts in opa builder into /stackable/* to just copy the whole folder in the final image 
- Uses check-permissions-ownership script to validate any wrong permissions / ownership in the /stackable folder (example for nifi)

```
 => [nifi-2_2_0 final  7/10] RUN <<EOF (microdnf update...)                                                                                                                                         8.2s
 => ERROR [nifi-2_2_0 final  8/10] RUN <<EOF (chmod +x /tmp/check-permissions-ownership...)                                                                                                         0.9s
------
 > [nifi-2_2_0 final  8/10] RUN <<EOF (chmod +x /tmp/check-permissions-ownership...):
0.601 Ownership mismatch:  /stackable/nifi (Expected: 1000:0, Found: 0:0)
0.622 Permission mismatch: /stackable/python (Owner: rwx, Group: r-x)
0.624 Permission mismatch: /stackable/bin (Owner: rwx, Group: r-x)
0.628 Permission mismatch: /stackable/nifi-2.2.0 (Owner: rwx, Group: r-x)
0.843 Permission and Ownership checks failed for /stackable!
```
