### PR TITLE
Fix: druid reduce image size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- druid: reduce docker image size by removing the recursive chown/chmods in the final image ([#1039]).
+
+[#1039]: https://github.com/stackabletech/docker-images/pull/1039
+
 ## [25.3.0] - 2025-03-21
 
 ### Added

--- a/druid/Dockerfile
+++ b/druid/Dockerfile
@@ -117,7 +117,7 @@ RUN <<EOF
 microdnf update
 microdnf clean all
 rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}\n" | sort > /stackable/package_manifest.txt
-chown -h ${STACKABLE_USER_UID}:0 /stackable/package_manifest.txt
+chown ${STACKABLE_USER_UID}:0 /stackable/package_manifest.txt
 rm -rf /var/cache/yum
 
 chmod -R g=u /stackable/bin

--- a/druid/Dockerfile
+++ b/druid/Dockerfile
@@ -146,6 +146,9 @@ RUN <<EOF
 /bin/check-permissions-ownership.sh /stackable ${STACKABLE_USER_UID} 0
 EOF
 
+# ----------------------------------------
+# Attention: Do not perform any file based actions (copying/creating etc.) below this comment because the permissions would not be checked.
+
 USER ${STACKABLE_USER_UID}
 ENV PATH="${PATH}":/stackable/druid/bin
 

--- a/druid/Dockerfile
+++ b/druid/Dockerfile
@@ -58,9 +58,6 @@ mvn --batch-mode --no-transfer-progress clean install -Pdist,stackable-bundle-co
 mv distribution/target/apache-druid-${PRODUCT}-bin/apache-druid-${PRODUCT} /stackable/
 mv distribution/target/bom.json /stackable/apache-druid-${PRODUCT}/apache-druid-${PRODUCT}.cdx.json
 rm -rf /stackable/apache-druid-${PRODUCT}-src
-rm -rf /stackable/.m2
-
-ln -s /stackable/apache-druid-${PRODUCT} /stackable/druid
 
 # We're removing these to make the intermediate layer smaller
 # This can be necessary even though it's only a builder image because the GitHub Action Runners only have very limited space available
@@ -111,7 +108,7 @@ LABEL io.k8s.description="${DESCRIPTION}"
 LABEL io.k8s.display-name="${NAME}"
 
 
-COPY --chown=${STACKABLE_USER_UID}:0 --from=druid-builder /stackable /stackable
+COPY --chown=${STACKABLE_USER_UID}:0 --from=druid-builder /stackable/apache-druid-${PRODUCT} /stackable/apache-druid-${PRODUCT}
 
 COPY --chown=${STACKABLE_USER_UID}:0 druid/stackable/bin /stackable/bin
 COPY --chown=${STACKABLE_USER_UID}:0 druid/licenses /licenses
@@ -120,11 +117,15 @@ RUN <<EOF
 microdnf update
 microdnf clean all
 rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}\n" | sort > /stackable/package_manifest.txt
+chown -h ${STACKABLE_USER_UID}:0 /stackable/package_manifest.txt
 rm -rf /var/cache/yum
 
-chmod g=u /stackable/bin/run-druid 
+chmod -R g=u /stackable/bin
+ln -sf /stackable/apache-druid-${PRODUCT} /stackable/druid
+chown -h ${STACKABLE_USER_UID}:0 stackable/druid
 # Force to overwrite the existing 'run-druid'
 ln -sf /stackable/bin/run-druid /stackable/druid/bin/run-druid
+chown -h ${STACKABLE_USER_UID}:0 /stackable/druid/bin/run-druid
 EOF
 
 # ----------------------------------------

--- a/druid/Dockerfile
+++ b/druid/Dockerfile
@@ -25,8 +25,8 @@ microdnf update
 #
 # patch: Required for the apply-patches.sh script
 microdnf install \
-python-pyyaml \
-patch
+  python-pyyaml \
+  patch
 
 microdnf clean all
 rm -rf /var/cache/yum
@@ -118,22 +118,33 @@ microdnf update
 microdnf clean all
 rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}\n" | sort > /stackable/package_manifest.txt
 chown ${STACKABLE_USER_UID}:0 /stackable/package_manifest.txt
+chmod g=u /stackable/package_manifest.txt
 rm -rf /var/cache/yum
 
-chmod -R g=u /stackable/bin
 ln -sf /stackable/apache-druid-${PRODUCT} /stackable/druid
 chown -h ${STACKABLE_USER_UID}:0 stackable/druid
+
 # Force to overwrite the existing 'run-druid'
 ln -sf /stackable/bin/run-druid /stackable/druid/bin/run-druid
 chown -h ${STACKABLE_USER_UID}:0 /stackable/druid/bin/run-druid
+
+# fix missing permissions
+chmod -R g=u /stackable/bin
+chmod g=u /stackable/apache-druid-${PRODUCT}
 EOF
 
 # ----------------------------------------
-# Attention:
-# If you do any file based actions (copying / creating etc.) below this comment you
-# absolutely need to make sure that the correct permissions are applied!
-# chown ${STACKABLE_USER_UID}:0
+# Checks
+# This section is to run final checks to ensure the created final images
+# adhere to several minimal requirements like:
+# - check file permissions and ownerships
 # ----------------------------------------
+
+# Check that permissions and ownership in /stackable are set correctly
+# This will fail and stop the build if any mismatches are found.
+RUN <<EOF
+/bin/check-permissions-ownership.sh /stackable ${STACKABLE_USER_UID} 0
+EOF
 
 USER ${STACKABLE_USER_UID}
 ENV PATH="${PATH}":/stackable/druid/bin

--- a/druid/Dockerfile
+++ b/druid/Dockerfile
@@ -47,9 +47,9 @@ COPY --chown=stackable:0 druid/stackable/patches/${PRODUCT} /stackable/apache-dr
 # are still working in the cache directory.
 
 RUN --mount=type=cache,id=maven-${PRODUCT},uid=${STACKABLE_USER_UID},target=/stackable/.m2/repository \
-    --mount=type=cache,id=npm-${PRODUCT},uid=${STACKABLE_USER_UID},target=/stackable/.npm \
-    --mount=type=cache,id=cache-${PRODUCT},uid=${STACKABLE_USER_UID},target=/stackable/.cache \
-    <<EOF
+  --mount=type=cache,id=npm-${PRODUCT},uid=${STACKABLE_USER_UID},target=/stackable/.npm \
+  --mount=type=cache,id=cache-${PRODUCT},uid=${STACKABLE_USER_UID},target=/stackable/.cache \
+  <<EOF
 curl "https://repo.stackable.tech/repository/packages/druid/apache-druid-${PRODUCT}-src.tar.gz" | tar -xzC .
 cd apache-druid-${PRODUCT}-src
 ./patches/apply_patches.sh ${PRODUCT}
@@ -58,6 +58,9 @@ mvn --batch-mode --no-transfer-progress clean install -Pdist,stackable-bundle-co
 mv distribution/target/apache-druid-${PRODUCT}-bin/apache-druid-${PRODUCT} /stackable/
 mv distribution/target/bom.json /stackable/apache-druid-${PRODUCT}/apache-druid-${PRODUCT}.cdx.json
 rm -rf /stackable/apache-druid-${PRODUCT}-src
+rm -rf /stackable/.m2
+
+ln -s /stackable/apache-druid-${PRODUCT} /stackable/druid
 
 # We're removing these to make the intermediate layer smaller
 # This can be necessary even though it's only a builder image because the GitHub Action Runners only have very limited space available
@@ -74,6 +77,9 @@ fi
 
 # Install OPA authorizer extension.
 curl "https://repo.stackable.tech/repository/packages/druid/druid-opa-authorizer-${AUTHORIZER}.tar.gz" | tar -xzC /stackable/apache-druid-${PRODUCT}/extensions
+
+# change groups
+chmod -R g=u /stackable
 EOF
 
 FROM stackable/image/java-base AS final
@@ -105,7 +111,8 @@ LABEL io.k8s.description="${DESCRIPTION}"
 LABEL io.k8s.display-name="${NAME}"
 
 
-COPY --chown=${STACKABLE_USER_UID}:0 --from=druid-builder /stackable/apache-druid-${PRODUCT} /stackable/apache-druid-${PRODUCT}
+COPY --chown=${STACKABLE_USER_UID}:0 --from=druid-builder /stackable /stackable
+
 COPY --chown=${STACKABLE_USER_UID}:0 druid/stackable/bin /stackable/bin
 COPY --chown=${STACKABLE_USER_UID}:0 druid/licenses /licenses
 
@@ -115,19 +122,13 @@ microdnf clean all
 rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}\n" | sort > /stackable/package_manifest.txt
 rm -rf /var/cache/yum
 
-ln -s /stackable/apache-druid-${PRODUCT} /stackable/druid
-
+chmod g=u /stackable/bin/run-druid 
 # Force to overwrite the existing 'run-druid'
 ln -sf /stackable/bin/run-druid /stackable/druid/bin/run-druid
-
-# All files and folders owned by root group to support running as arbitrary users.
-# This is best practice as all container users will belong to the root group (0).
-chown -R ${STACKABLE_USER_UID}:0 /stackable
-chmod -R g=u /stackable
 EOF
 
 # ----------------------------------------
-# Attention: We are changing the group of all files in /stackable directly above
+# Attention:
 # If you do any file based actions (copying / creating etc.) below this comment you
 # absolutely need to make sure that the correct permissions are applied!
 # chown ${STACKABLE_USER_UID}:0


### PR DESCRIPTION
# Description

part of https://github.com/stackabletech/docker-images/issues/961

```
REPOSITORY                              TAG                                   IMAGE ID       CREATED          SIZE
oci.stackable.tech/sdp/druid            31.0.1-stackable25.3.0-reduced-size   f17d5ed72c07   58 seconds ago   1.19GB
oci.stackable.tech/sdp/druid            31.0.1-stackable25.3.0                818953ae9180   31 hours ago     1.85GB
```

- Does remove the recursive chmod/chown in the final image and attempts non recursive chmod/chown or doing as much as possible in the builder step.
- Uses check-permissions-ownership script to validate any wrong permissions / ownership in the /stackable folder (example for nifi)

```
 => [nifi-2_2_0 final  7/10] RUN <<EOF (microdnf update...)                                                                                                                                         8.2s
 => ERROR [nifi-2_2_0 final  8/10] RUN <<EOF (chmod +x /tmp/check-permissions-ownership...)                                                                                                         0.9s
------
 > [nifi-2_2_0 final  8/10] RUN <<EOF (chmod +x /tmp/check-permissions-ownership...):
0.601 Ownership mismatch:  /stackable/nifi (Expected: 1000:0, Found: 0:0)
0.622 Permission mismatch: /stackable/python (Owner: rwx, Group: r-x)
0.624 Permission mismatch: /stackable/bin (Owner: rwx, Group: r-x)
0.628 Permission mismatch: /stackable/nifi-2.2.0 (Owner: rwx, Group: r-x)
0.843 Permission and Ownership checks failed for /stackable!
```
