### PR TITLE
Fix: hive reduce image size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- hive: reduce docker image size by removing the recursive chown/chmods in the final image ([#1040]).
+
+[#1040]: https://github.com/stackabletech/docker-images/pull/1040
+
 ## [25.3.0] - 2025-03-21
 
 ### Added

--- a/hive/Dockerfile
+++ b/hive/Dockerfile
@@ -13,11 +13,19 @@ FROM stackable/image/java-devel AS hive-builder
 ARG PRODUCT
 ARG HADOOP
 ARG JMX_EXPORTER
+ARG AWS_JAVA_SDK_BUNDLE
+ARG AZURE_STORAGE
+ARG AZURE_KEYVAULT_CORE
 ARG STACKABLE_USER_UID
 
 # Setting this to anything other than "true" will keep the cache folders around (e.g. for Maven, NPM etc.)
 # This can be used to speed up builds when disk space is of no concern.
 ARG DELETE_CACHES="true"
+
+# It is useful to see which version of Hadoop is used at a glance
+# Therefore the use of the full name here
+# TODO: Do we really need all of Hadoop in here?
+COPY --chown=${STACKABLE_USER_UID}:0 --from=hadoop-builder /stackable/hadoop /stackable/hadoop-${HADOOP}
 
 COPY --chown=${STACKABLE_USER_UID}:0 hive/stackable /stackable
 
@@ -58,6 +66,18 @@ rm -rf /stackable/apache-hive-${PRODUCT}-src
 curl "https://repo.stackable.tech/repository/packages/jmx-exporter/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar" -o "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar"
 ln -s "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar" /stackable/jmx/jmx_prometheus_javaagent.jar
 
+# The next two sections for S3 and Azure use hardcoded version numbers on purpose instead of wildcards
+# This way the build will fail should one of the files not be available anymore in a later Hadoop version!
+
+# Add S3 Support for Hive (support for s3a://)
+cp /stackable/hadoop-${HADOOP}/share/hadoop/tools/lib/hadoop-aws-${HADOOP}.jar /stackable/apache-hive-metastore-${PRODUCT}-bin/lib/
+cp /stackable/hadoop-${HADOOP}/share/hadoop/tools/lib/aws-java-sdk-bundle-${AWS_JAVA_SDK_BUNDLE}.jar /stackable/apache-hive-metastore-${PRODUCT}-bin/lib/
+
+# Add Azure ABFS support (support for abfs://)
+cp /stackable/hadoop-${HADOOP}/share/hadoop/tools/lib/hadoop-azure-${HADOOP}.jar /stackable/apache-hive-metastore-${PRODUCT}-bin/lib/
+cp /stackable/hadoop-${HADOOP}/share/hadoop/tools/lib/azure-storage-${AZURE_STORAGE}.jar /stackable/apache-hive-metastore-${PRODUCT}-bin/lib/
+cp /stackable/hadoop-${HADOOP}/share/hadoop/tools/lib/azure-keyvault-core-${AZURE_KEYVAULT_CORE}.jar /stackable/apache-hive-metastore-${PRODUCT}-bin/lib/
+
 # We're removing these to make the intermediate layer smaller
 # This can be necessary even though it's only a builder image because the GitHub Action Runners only have very limited space available
 # and we are sometimes running into errors because we're out of space.
@@ -67,6 +87,9 @@ if [ "${DELETE_CACHES}" = "true" ] ; then
   rm -rf /stackable/.npm/*
   rm -rf /stackable/.cache/*
 fi
+
+# change groups
+chmod -R g=u /stackable
 EOF
 
 
@@ -75,9 +98,6 @@ FROM stackable/image/java-base AS final
 ARG PRODUCT
 ARG HADOOP
 ARG RELEASE
-ARG AWS_JAVA_SDK_BUNDLE
-ARG AZURE_STORAGE
-ARG AZURE_KEYVAULT_CORE
 ARG STACKABLE_USER_UID
 
 
@@ -106,44 +126,26 @@ LABEL io.k8s.display-name="${NAME}"
 WORKDIR /stackable
 
 COPY --chown=${STACKABLE_USER_UID}:0 --from=hive-builder /stackable/apache-hive-metastore-${PRODUCT}-bin /stackable/apache-hive-metastore-${PRODUCT}-bin
+COPY --chown=${STACKABLE_USER_UID}:0 --from=hive-builder /stackable/hadoop-${HADOOP} /stackable/hadoop-${HADOOP}
+COPY --chown=${STACKABLE_USER_UID}:0 --from=hive-builder /stackable/jmx /stackable/jmx
 
-# It is useful to see which version of Hadoop is used at a glance
-# Therefore the use of the full name here
-# TODO: Do we really need all of Hadoop in here?
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hadoop-builder /stackable/hadoop /stackable/hadoop-${HADOOP}
+COPY hive/licenses /licenses
 
 RUN <<EOF
 microdnf update
 microdnf clean all
 rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}\n" | sort > /stackable/package_manifest.txt
+chown ${STACKABLE_USER_UID}:0 /stackable/package_manifest.txt
 rm -rf /var/cache/yum
 
 ln -s /stackable/apache-hive-metastore-${PRODUCT}-bin /stackable/hive-metastore
+chown -h ${STACKABLE_USER_UID}:0 /stackable/hive-metastore
 ln -s /stackable/hadoop-${HADOOP} /stackable/hadoop
-
-# The next two sections for S3 and Azure use hardcoded version numbers on purpose instead of wildcards
-# This way the build will fail should one of the files not be available anymore in a later Hadoop version!
-
-# Add S3 Support for Hive (support for s3a://)
-cp /stackable/hadoop/share/hadoop/tools/lib/hadoop-aws-${HADOOP}.jar /stackable/hive-metastore/lib/
-cp /stackable/hadoop/share/hadoop/tools/lib/aws-java-sdk-bundle-${AWS_JAVA_SDK_BUNDLE}.jar /stackable/hive-metastore/lib/
-
-# Add Azure ABFS support (support for abfs://)
-cp /stackable/hadoop/share/hadoop/tools/lib/hadoop-azure-${HADOOP}.jar /stackable/hive-metastore/lib/
-cp /stackable/hadoop/share/hadoop/tools/lib/azure-storage-${AZURE_STORAGE}.jar /stackable/hive-metastore/lib/
-cp /stackable/hadoop/share/hadoop/tools/lib/azure-keyvault-core-${AZURE_KEYVAULT_CORE}.jar /stackable/hive-metastore/lib/
-
-# All files and folders owned by root group to support running as arbitrary users.
-# This is best practice as all container users will belong to the root group (0).
-chown -R ${STACKABLE_USER_UID}:0 /stackable
-chmod -R g=u /stackable
+chown -h ${STACKABLE_USER_UID}:0 /stackable/hadoop
 EOF
 
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hive-builder /stackable/jmx /stackable/jmx
-COPY hive/licenses /licenses
-
 # ----------------------------------------
-# Attention: We are changing the group of all files in /stackable directly above
+# Attention:
 # If you do any file based actions (copying / creating etc.) below this comment you
 # absolutely need to make sure that the correct permissions are applied!
 # chown ${STACKABLE_USER_UID}:0

--- a/hive/Dockerfile
+++ b/hive/Dockerfile
@@ -136,12 +136,18 @@ microdnf update
 microdnf clean all
 rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}\n" | sort > /stackable/package_manifest.txt
 chown ${STACKABLE_USER_UID}:0 /stackable/package_manifest.txt
+chmod g=u /stackable/package_manifest.txt
 rm -rf /var/cache/yum
 
 ln -s /stackable/apache-hive-metastore-${PRODUCT}-bin /stackable/hive-metastore
 chown -h ${STACKABLE_USER_UID}:0 /stackable/hive-metastore
+chmod g=u /stackable/hive-metastore
 ln -s /stackable/hadoop-${HADOOP} /stackable/hadoop
 chown -h ${STACKABLE_USER_UID}:0 /stackable/hadoop
+chmod g=u /stackable/hadoop
+
+# fix missing permissions
+chmod --recursive g=u /stackable/jmx
 EOF
 
 # ----------------------------------------
@@ -159,6 +165,7 @@ EOF
 
 # ----------------------------------------
 # Attention: Do not perform any file based actions (copying/creating etc.) below this comment because the permissions would not be checked.
+# ----------------------------------------
 
 USER ${STACKABLE_USER_UID}
 

--- a/hive/Dockerfile
+++ b/hive/Dockerfile
@@ -89,7 +89,7 @@ if [ "${DELETE_CACHES}" = "true" ] ; then
 fi
 
 # change groups
-chmod -R g=u /stackable
+chmod --recursive g=u /stackable
 EOF
 
 
@@ -145,11 +145,20 @@ chown -h ${STACKABLE_USER_UID}:0 /stackable/hadoop
 EOF
 
 # ----------------------------------------
-# Attention:
-# If you do any file based actions (copying / creating etc.) below this comment you
-# absolutely need to make sure that the correct permissions are applied!
-# chown ${STACKABLE_USER_UID}:0
+# Checks
+# This section is to run final checks to ensure the created final images
+# adhere to several minimal requirements like:
+# - check file permissions and ownerships
 # ----------------------------------------
+
+# Check that permissions and ownership in /stackable are set correctly
+# This will fail and stop the build if any mismatches are found.
+RUN <<EOF
+/bin/check-permissions-ownership.sh /stackable ${STACKABLE_USER_UID} 0
+EOF
+
+# ----------------------------------------
+# Attention: Do not perform any file based actions (copying/creating etc.) below this comment because the permissions would not be checked.
 
 USER ${STACKABLE_USER_UID}
 


### PR DESCRIPTION
# Description

part of https://github.com/stackabletech/docker-images/issues/961

```
REPOSITORY                              TAG                                   IMAGE ID       CREATED         SIZE
oci.stackable.tech/sdp/hive             4.0.0-stackable25.3.0-reduced-size    1b28b0333195   4 minutes ago   1.67GB
oci.stackable.tech/sdp/hive             4.0.0-stackable25.3.0                 06c646169cff   2 days ago      1.75GB
```

- Does remove the recursive chmod/chown in the final image and attempts non recursive chmod/chown or doing as much as possible in the builder step.
- Uses check-permissions-ownership script to validate any wrong permissions / ownership in the /stackable folder (example for nifi)

```
 => [nifi-2_2_0 final  7/10] RUN <<EOF (microdnf update...)                                                                                                                                         8.2s
 => ERROR [nifi-2_2_0 final  8/10] RUN <<EOF (chmod +x /tmp/check-permissions-ownership...)                                                                                                         0.9s
------
 > [nifi-2_2_0 final  8/10] RUN <<EOF (chmod +x /tmp/check-permissions-ownership...):
0.601 Ownership mismatch:  /stackable/nifi (Expected: 1000:0, Found: 0:0)
0.622 Permission mismatch: /stackable/python (Owner: rwx, Group: r-x)
0.624 Permission mismatch: /stackable/bin (Owner: rwx, Group: r-x)
0.628 Permission mismatch: /stackable/nifi-2.2.0 (Owner: rwx, Group: r-x)
0.843 Permission and Ownership checks failed for /stackable!
```
