### PR TITLE
Fix: kafka reduce image size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- kafka: reduce docker image size by removing the recursive chown/chmods in the final image ([#1041]).
+
+[#1041]: https://github.com/stackabletech/docker-images/pull/1041
+
 ## [25.3.0] - 2025-03-21
 
 ### Added

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -27,30 +27,35 @@ WORKDIR /stackable
 
 COPY --chown=${STACKABLE_USER_UID}:0 kafka/stackable/patches/apply_patches.sh /stackable/kafka-${PRODUCT}-src/patches/apply_patches.sh
 COPY --chown=${STACKABLE_USER_UID}:0 kafka/stackable/patches/${PRODUCT} /stackable/kafka-${PRODUCT}-src/patches/${PRODUCT}
+COPY --chown=${STACKABLE_USER_UID}:0 kafka/stackable/jmx/ /stackable/jmx/
 
-RUN curl "https://repo.stackable.tech/repository/packages/kafka/kafka-${PRODUCT}-src.tgz" | tar -xzC . && \
-    cd kafka-${PRODUCT}-src && \
-    ./patches/apply_patches.sh ${PRODUCT} && \
-    # TODO: Try to install gradle via package manager (if possible) instead of fetching it from the internet
-    # We don't specify "-x test" to skip the tests, as we might bump some Kafka internal dependencies in the future and
-    # it's a good idea to run the tests in this case.
-    ./gradlew clean releaseTarGz && \
-    ./gradlew cyclonedxBom && \
-    tar -xf core/build/distributions/kafka_${SCALA}-${PRODUCT}.tgz -C /stackable && \
-    cp build/reports/bom.json /stackable/kafka_${SCALA}-${PRODUCT}.cdx.json && \
-    rm -rf /stackable/kafka_${SCALA}-${PRODUCT}/site-docs/ && \
-    rm -rf /stackable/kafka-${PRODUCT}-src
+RUN <<EOF
+curl "https://repo.stackable.tech/repository/packages/kafka/kafka-${PRODUCT}-src.tgz" | tar -xzC .
+cd kafka-${PRODUCT}-src
+./patches/apply_patches.sh ${PRODUCT}
+# TODO: Try to install gradle via package manager (if possible) instead of fetching it from the internet
+# We don't specify "-x test" to skip the tests, as we might bump some Kafka internal dependencies in the future and
+# it's a good idea to run the tests in this case.
+./gradlew clean releaseTarGz
+./gradlew cyclonedxBom
+tar -xf core/build/distributions/kafka_${SCALA}-${PRODUCT}.tgz -C /stackable
+cp build/reports/bom.json /stackable/kafka_${SCALA}-${PRODUCT}.cdx.json
+rm -rf /stackable/kafka_${SCALA}-${PRODUCT}/site-docs/
+rm -rf /stackable/kafka-${PRODUCT}-src
 
 # TODO (@NickLarsenNZ): Compile from source: https://github.com/StyraInc/opa-kafka-plugin
-RUN curl https://repo.stackable.tech/repository/packages/kafka-opa-authorizer/opa-authorizer-${OPA_AUTHORIZER}-all.jar \
-    -o /stackable/kafka_${SCALA}-${PRODUCT}/libs/opa-authorizer-${OPA_AUTHORIZER}-all.jar
+curl https://repo.stackable.tech/repository/packages/kafka-opa-authorizer/opa-authorizer-${OPA_AUTHORIZER}-all.jar \
+  -o /stackable/kafka_${SCALA}-${PRODUCT}/libs/opa-authorizer-${OPA_AUTHORIZER}-all.jar
 
-COPY --chown=${STACKABLE_USER_UID}:0 kafka/stackable/jmx/ /stackable/jmx/
-RUN curl https://repo.stackable.tech/repository/packages/jmx-exporter/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar \
-    -o /stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar && \
-    chmod +x /stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar && \
-    ln -s /stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar /stackable/jmx/jmx_prometheus_javaagent.jar
+# JMX exporter
+curl https://repo.stackable.tech/repository/packages/jmx-exporter/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar \
+  -o /stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar
+chmod +x /stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar
+ln -s /stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar /stackable/jmx/jmx_prometheus_javaagent.jar
 
+# change groups
+chmod -R g=u /stackable    
+EOF
 
 FROM stackable/image/java-base AS final
 
@@ -60,20 +65,22 @@ ARG SCALA
 ARG KCAT
 ARG STACKABLE_USER_UID
 
-LABEL name="Apache Kafka" \
-      maintainer="info@stackable.tech" \
-      vendor="Stackable GmbH" \
-      version="${PRODUCT}" \
-      release="${RELEASE}" \
-      summary="The Stackable image for Apache Kafka." \
-      description="This image is deployed by the Stackable Operator for Apache Kafka."
+LABEL \
+    name="Apache Kafka" \
+    maintainer="info@stackable.tech" \
+    vendor="Stackable GmbH" \
+    version="${PRODUCT}" \
+    release="${RELEASE}" \
+    summary="The Stackable image for Apache Kafka." \
+    description="This image is deployed by the Stackable Operator for Apache Kafka."
 
-COPY --chown=${STACKABLE_USER_UID}:0 kafka/licenses /licenses
 COPY --chown=${STACKABLE_USER_UID}:0 --from=kafka-builder /stackable/kafka_${SCALA}-${PRODUCT} /stackable/kafka_${SCALA}-${PRODUCT}
 COPY --chown=${STACKABLE_USER_UID}:0 --from=kafka-builder /stackable/kafka_${SCALA}-${PRODUCT}.cdx.json /stackable/kafka_${SCALA}-${PRODUCT}/kafka_${SCALA}-${PRODUCT}.cdx.json
 COPY --chown=${STACKABLE_USER_UID}:0 --from=kafka-builder /stackable/jmx/ /stackable/jmx/
 COPY --chown=${STACKABLE_USER_UID}:0 --from=kcat /stackable/kcat-${KCAT}/kcat /stackable/bin/kcat-${KCAT}
 COPY --chown=${STACKABLE_USER_UID}:0 --from=kcat /licenses /licenses
+
+COPY --chown=${STACKABLE_USER_UID}:0 kafka/licenses /licenses
 
 WORKDIR /stackable
 
@@ -85,21 +92,20 @@ microdnf install \
 
 microdnf clean all
 rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}\n" | sort > /stackable/package_manifest.txt
+chown ${STACKABLE_USER_UID}:0 /stackable/package_manifest.txt
 rm -rf /var/cache/yum
 
 ln -s /stackable/bin/kcat-${KCAT} /stackable/bin/kcat
+chown -h ${STACKABLE_USER_UID}:0 /stackable/bin/kcat
 # kcat was located in /stackable/kcat - legacy
 ln -s /stackable/bin/kcat /stackable/kcat
+chown -h ${STACKABLE_USER_UID}:0 /stackable/kcat
 ln -s /stackable/kafka_${SCALA}-${PRODUCT} /stackable/kafka
-
-# All files and folders owned by root group to support running as arbitrary users.
-# This is best practice as all container users will belong to the root group (0).
-chown -R ${STACKABLE_USER_UID}:0 /stackable
-chmod -R g=u /stackable
+chown -h ${STACKABLE_USER_UID}:0 /stackable/kafka
 EOF
 
 # ----------------------------------------
-# Attention: We are changing the group of all files in /stackable directly above
+# Attention:
 # If you do any file based actions (copying / creating etc.) below this comment you
 # absolutely need to make sure that the correct permissions are applied!
 # chown ${STACKABLE_USER_UID}:0

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -54,7 +54,7 @@ chmod +x /stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar
 ln -s /stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar /stackable/jmx/jmx_prometheus_javaagent.jar
 
 # change groups
-chmod -R g=u /stackable    
+chmod -R g=u /stackable
 EOF
 
 FROM stackable/image/java-base AS final

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -66,13 +66,13 @@ ARG KCAT
 ARG STACKABLE_USER_UID
 
 LABEL \
-    name="Apache Kafka" \
-    maintainer="info@stackable.tech" \
-    vendor="Stackable GmbH" \
-    version="${PRODUCT}" \
-    release="${RELEASE}" \
-    summary="The Stackable image for Apache Kafka." \
-    description="This image is deployed by the Stackable Operator for Apache Kafka."
+  name="Apache Kafka" \
+  maintainer="info@stackable.tech" \
+  vendor="Stackable GmbH" \
+  version="${PRODUCT}" \
+  release="${RELEASE}" \
+  summary="The Stackable image for Apache Kafka." \
+  description="This image is deployed by the Stackable Operator for Apache Kafka."
 
 COPY --chown=${STACKABLE_USER_UID}:0 --from=kafka-builder /stackable/kafka_${SCALA}-${PRODUCT} /stackable/kafka_${SCALA}-${PRODUCT}
 COPY --chown=${STACKABLE_USER_UID}:0 --from=kafka-builder /stackable/kafka_${SCALA}-${PRODUCT}.cdx.json /stackable/kafka_${SCALA}-${PRODUCT}/kafka_${SCALA}-${PRODUCT}.cdx.json
@@ -93,6 +93,7 @@ microdnf install \
 microdnf clean all
 rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}\n" | sort > /stackable/package_manifest.txt
 chown ${STACKABLE_USER_UID}:0 /stackable/package_manifest.txt
+chmod g=u /stackable/package_manifest.txt
 rm -rf /var/cache/yum
 
 ln -s /stackable/bin/kcat-${KCAT} /stackable/bin/kcat
@@ -102,13 +103,28 @@ ln -s /stackable/bin/kcat /stackable/kcat
 chown -h ${STACKABLE_USER_UID}:0 /stackable/kcat
 ln -s /stackable/kafka_${SCALA}-${PRODUCT} /stackable/kafka
 chown -h ${STACKABLE_USER_UID}:0 /stackable/kafka
+
+# fix missing permissions
+chmod g=u /stackable/bin
+chmod g=u /stackable/jmx
+chmod g=u /stackable/kafka_${SCALA}-${PRODUCT}
 EOF
 
 # ----------------------------------------
-# Attention:
-# If you do any file based actions (copying / creating etc.) below this comment you
-# absolutely need to make sure that the correct permissions are applied!
-# chown ${STACKABLE_USER_UID}:0
+# Checks
+# This section is to run final checks to ensure the created final images
+# adhere to several minimal requirements like:
+# - check file permissions and ownerships
+# ----------------------------------------
+
+# Check that permissions and ownership in /stackable are set correctly
+# This will fail and stop the build if any mismatches are found.
+RUN <<EOF
+/bin/check-permissions-ownership.sh /stackable ${STACKABLE_USER_UID} 0
+EOF
+
+# ----------------------------------------
+# Attention: Do not perform any file based actions (copying/creating etc.) below this comment because the permissions would not be checked.
 # ----------------------------------------
 
 USER ${STACKABLE_USER_UID}

--- a/kcat/Dockerfile
+++ b/kcat/Dockerfile
@@ -9,8 +9,9 @@ FROM stackable/image/java-base AS builder
 ARG PRODUCT
 ARG STACKABLE_USER_UID
 
-RUN microdnf update \
-    && microdnf install \
+RUN <<EOF
+microdnf update
+microdnf install \
     cmake \
     cyrus-sasl-devel \
     gcc-c++ \
@@ -22,16 +23,21 @@ RUN microdnf update \
     wget \
     which \
     zlib \
-    zlib-devel && \
-    microdnf clean all && \
-    rm -rf /var/cache/yum
+    zlib-devel
+microdnf clean all
+rm -rf /var/cache/yum
+EOF
 
 WORKDIR /stackable
 
-RUN curl -O https://repo.stackable.tech/repository/packages/kcat/kcat-${PRODUCT}.tar.gz \
-    && tar xvfz kcat-${PRODUCT}.tar.gz \
-    && cd kcat-${PRODUCT} \
-    && ./bootstrap.sh
+RUN <<EOF
+curl -O https://repo.stackable.tech/repository/packages/kcat/kcat-${PRODUCT}.tar.gz
+tar xvfz kcat-${PRODUCT}.tar.gz
+cd kcat-${PRODUCT}
+./bootstrap.sh
+# set correct permissions
+chmod --recursive g=u /stackable/kcat-${PRODUCT}
+EOF
 
 COPY --chown=${STACKABLE_USER_UID}:0 kcat/licenses /licenses
 


### PR DESCRIPTION
# Description

part of https://github.com/stackabletech/docker-images/issues/961

```
REPOSITORY                              TAG                                   IMAGE ID       CREATED          SIZE
oci.stackable.tech/sdp/kafka            3.9.0-stackable25.3.0-reduced-size    427af0502953   12 minutes ago   708MB
oci.stackable.tech/sdp/kafka            3.9.0-stackable25.3.0                 51df3236caa8   2 days ago       847MB

```

- Does remove the recursive chmod/chown in the final image and attempts non recursive chmod/chown or doing as much as possible in the builder step.
- Uses check-permissions-ownership script to validate any wrong permissions / ownership in the /stackable folder (example for nifi)

```
 => [nifi-2_2_0 final  7/10] RUN <<EOF (microdnf update...)                                                                                                                                         8.2s
 => ERROR [nifi-2_2_0 final  8/10] RUN <<EOF (chmod +x /tmp/check-permissions-ownership...)                                                                                                         0.9s
------
 > [nifi-2_2_0 final  8/10] RUN <<EOF (chmod +x /tmp/check-permissions-ownership...):
0.601 Ownership mismatch:  /stackable/nifi (Expected: 1000:0, Found: 0:0)
0.622 Permission mismatch: /stackable/python (Owner: rwx, Group: r-x)
0.624 Permission mismatch: /stackable/bin (Owner: rwx, Group: r-x)
0.628 Permission mismatch: /stackable/nifi-2.2.0 (Owner: rwx, Group: r-x)
0.843 Permission and Ownership checks failed for /stackable!
```
