### PR TITLE
Fix: spark-k8s reduce image size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- spark-k8s: reduce docker image size by removing the recursive chown/chmods in the final image ([#1042]).
+
+[#1042]: https://github.com/stackabletech/docker-images/pull/1042
+
 ## [25.3.0] - 2025-03-21
 
 ### Added

--- a/spark-k8s/Dockerfile
+++ b/spark-k8s/Dockerfile
@@ -255,6 +255,9 @@ curl --fail "https://repo.stackable.tech/repository/packages/jmx-exporter/jmx_pr
   -o "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar"
 ln -s "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar" /stackable/jmx/jmx_prometheus_javaagent.jar
 
+# Symlink example jar, so that we can easily use it in tests
+ln -s /stackable/spark-${PRODUCT}/dist/examples/jars/spark-examples_*.jar /stackable/spark-${PRODUCT}/dist/examples/jars/spark-examples.jar
+
 chmod -R g=u /stackable/spark-${PRODUCT}/dist
 chmod -R g=u /stackable/spark-${PRODUCT}/assembly/target/bom.json
 chmod -R g=u /stackable/jmx
@@ -309,15 +312,7 @@ microdnf clean all
 rm -rf /var/cache/yum
 
 ln -s /usr/bin/python${PYTHON} /usr/bin/python
-chown -h ${STACKABLE_USER_UID}:0 /usr/bin/python
 ln -s /usr/bin/pip-${PYTHON} /usr/bin/pip
-chown -h ${STACKABLE_USER_UID}:0 /usr/bin/pip
-
-# Symlink example jar, so that we can easily use it in tests
-ln -s /stackable/spark/examples/jars/spark-examples_*.jar /stackable/spark/examples/jars/spark-examples.jar
-chown -h ${STACKABLE_USER_UID}:0 /stackable/spark/examples/jars/spark-examples.jar
-
-chmod -R g=u /stackable/run-spark.sh
 EOF
 
 # ----------------------------------------

--- a/spark-k8s/Dockerfile
+++ b/spark-k8s/Dockerfile
@@ -157,7 +157,7 @@ EOF
 
 
 # spark-builder: Build Spark into /stackable/spark-${PRODUCT}/dist,
-# download additional JARs and perform checks, like log4shell check.
+# download additional JARs and perform checks
 FROM stackable/image/java-devel AS spark-builder
 
 ARG PRODUCT
@@ -202,7 +202,6 @@ RUN export MAVEN_OPTS="-Xss64m -Xmx2g -XX:ReservedCodeCacheSize=1g" \
 RUN curl -o /usr/bin/tini "https://repo.stackable.tech/repository/packages/tini/tini-${TINI}-${TARGETARCH}" \
     && chmod +x /usr/bin/tini
 
-# We download these under dist so that log4shell checks them
 WORKDIR /stackable/spark-${PRODUCT}/dist/jars
 
 # Copy modules required for s3a://

--- a/spark-k8s/Dockerfile
+++ b/spark-k8s/Dockerfile
@@ -198,13 +198,6 @@ RUN export MAVEN_OPTS="-Xss64m -Xmx2g -XX:ReservedCodeCacheSize=1g" \
 
 # <<< Build spark
 
-# Get the correct `tini` binary for our architecture.
-RUN <<EOF
-curl --fail "https://repo.stackable.tech/repository/packages/tini/tini-${TINI}-${TARGETARCH}" \
-  -o /usr/bin/tini
-chmod +x /usr/bin/tini
-EOF
-
 WORKDIR /stackable/spark-${PRODUCT}/dist/jars
 
 # Copy modules required for s3a://

--- a/spark-k8s/Dockerfile
+++ b/spark-k8s/Dockerfile
@@ -199,8 +199,11 @@ RUN export MAVEN_OPTS="-Xss64m -Xmx2g -XX:ReservedCodeCacheSize=1g" \
 # <<< Build spark
 
 # Get the correct `tini` binary for our architecture.
-RUN curl -o /usr/bin/tini "https://repo.stackable.tech/repository/packages/tini/tini-${TINI}-${TARGETARCH}" \
-    && chmod +x /usr/bin/tini
+RUN <<EOF
+curl --fail "https://repo.stackable.tech/repository/packages/tini/tini-${TINI}-${TARGETARCH}" \
+  -o /usr/bin/tini
+chmod +x /usr/bin/tini
+EOF
 
 WORKDIR /stackable/spark-${PRODUCT}/dist/jars
 
@@ -241,15 +244,28 @@ COPY --from=hbase-builder --chown=${STACKABLE_USER_UID}:0 \
 
 WORKDIR /stackable/spark-${PRODUCT}/dist/extra-jars
 
+COPY spark-k8s/stackable/jmx /stackable/jmx
+
+RUN <<EOF
 # Download jackson-dataformat-xml, stax2-api, and woodstox-core which are required for logging.
-RUN curl -O https://repo.stackable.tech/repository/packages/jackson-dataformat-xml/jackson-dataformat-xml-${JACKSON_DATAFORMAT_XML}.jar \
-    && curl -O https://repo.stackable.tech/repository/packages/stax2-api/stax2-api-${STAX2_API}.jar \
-    && curl -O https://repo.stackable.tech/repository/packages/woodstox-core/woodstox-core-${WOODSTOX_CORE}.jar
+curl --fail https://repo.stackable.tech/repository/packages/jackson-dataformat-xml/jackson-dataformat-xml-${JACKSON_DATAFORMAT_XML}.jar
+curl --fail https://repo.stackable.tech/repository/packages/stax2-api/stax2-api-${STAX2_API}.jar
+curl --fail https://repo.stackable.tech/repository/packages/woodstox-core/woodstox-core-${WOODSTOX_CORE}.jar
 
-WORKDIR /stackable/jmx
+# Get the correct `tini` binary for our architecture.
+curl --fail "https://repo.stackable.tech/repository/packages/tini/tini-${TINI}-${TARGETARCH}" \
+  -o /usr/bin/tini
+chmod +x /usr/bin/tini
 
-RUN curl -O "https://repo.stackable.tech/repository/packages/jmx-exporter/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar"
+# JMX Exporter
+curl --fail "https://repo.stackable.tech/repository/packages/jmx-exporter/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar" \
+  -o "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar"
+ln -s "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar" /stackable/jmx/jmx_prometheus_javaagent.jar
 
+chmod -R g=u /stackable/spark-${PRODUCT}/dist
+chmod -R g=u /stackable/spark-${PRODUCT}/assembly/target/bom.json
+chmod -R g=u /stackable/jmx
+EOF
 
 FROM stackable/image/java-base AS final
 
@@ -274,13 +290,14 @@ ENV PATH=$SPARK_HOME:$PATH:/bin:$JAVA_HOME/bin:$JAVA_HOME/jre/bin:$HOME/.local/b
 ENV PYSPARK_PYTHON=/usr/bin/python
 ENV PYTHONPATH=$SPARK_HOME/python
 
-COPY spark-k8s/stackable /stackable
-COPY spark-k8s/licenses /licenses
 
 COPY --chown=${STACKABLE_USER_UID}:0 --from=spark-builder /stackable/spark-${PRODUCT}/dist /stackable/spark
 COPY --chown=${STACKABLE_USER_UID}:0 --from=spark-builder /stackable/spark-${PRODUCT}/assembly/target/bom.json /stackable/spark/spark-${PRODUCT}.cdx.json
 COPY --chown=${STACKABLE_USER_UID}:0 --from=spark-builder /stackable/jmx /stackable/jmx
 COPY --from=spark-builder /usr/bin/tini /usr/bin/tini
+
+COPY --chown=${STACKABLE_USER_UID}:0 spark-k8s/stackable/run-spark.sh /stackable/run-spark.sh
+COPY --chown=${STACKABLE_USER_UID}:0 spark-k8s/licenses /licenses
 
 RUN <<EOF
 microdnf update
@@ -299,20 +316,19 @@ microdnf clean all
 rm -rf /var/cache/yum
 
 ln -s /usr/bin/python${PYTHON} /usr/bin/python
+chown -h ${STACKABLE_USER_UID}:0 /usr/bin/python
 ln -s /usr/bin/pip-${PYTHON} /usr/bin/pip
+chown -h ${STACKABLE_USER_UID}:0 /usr/bin/pip
 
-ln -s "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar" /stackable/jmx/jmx_prometheus_javaagent.jar
 # Symlink example jar, so that we can easily use it in tests
 ln -s /stackable/spark/examples/jars/spark-examples_*.jar /stackable/spark/examples/jars/spark-examples.jar
+chown -h ${STACKABLE_USER_UID}:0 /stackable/spark/examples/jars/spark-examples.jar
 
-# All files and folders owned by root group to support running as arbitrary users.
-# This is best practice as all container users will belong to the root group (0).
-chown -R ${STACKABLE_USER_UID}:0 /stackable
-chmod -R g=u /stackable
+chmod -R g=u /stackable/run-spark.sh
 EOF
 
 # ----------------------------------------
-# Attention: We are changing the group of all files in /stackable directly above
+# Attention:
 # If you do any file based actions (copying / creating etc.) below this comment you
 # absolutely need to make sure that the correct permissions are applied!
 # chown ${STACKABLE_USER_UID}:0

--- a/spark-k8s/Dockerfile
+++ b/spark-k8s/Dockerfile
@@ -189,12 +189,12 @@ COPY --chown=${STACKABLE_USER_UID}:0 --from=spark-source-builder \
 # 134.0 [ERROR] Detected Maven Version: 3.6.3 is not in the allowed range [3.8.8,)
 RUN export MAVEN_OPTS="-Xss64m -Xmx2g -XX:ReservedCodeCacheSize=1g" \
     && ./dev/make-distribution.sh \
-      -Dhadoop.version="$HADOOP" \
-      -Dmaven.test.skip=true \
-      -DskipTests \
-      -P'hadoop-3' -Pkubernetes -Phive -Phive-thriftserver \
-      --no-transfer-progress \
-      --batch-mode
+    -Dhadoop.version="$HADOOP" \
+    -Dmaven.test.skip=true \
+    -DskipTests \
+    -P'hadoop-3' -Pkubernetes -Phive -Phive-thriftserver \
+    --no-transfer-progress \
+    --batch-mode
 
 # <<< Build spark
 
@@ -251,25 +251,6 @@ WORKDIR /stackable/jmx
 
 RUN curl -O "https://repo.stackable.tech/repository/packages/jmx-exporter/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar"
 
-# ===
-# Mitigation for CVE-2021-44228 (Log4Shell)
-#
-# For earlier versions this script removes the .class file that contains the
-# vulnerable code.
-# TODO: This can be restricted to target only versions which do not honor the environment
-#   varible that has been set above but this has not currently been implemented
-COPY shared/log4shell.sh /bin
-RUN /bin/log4shell.sh /stackable/spark-${PRODUCT}/dist
-
-# Ensure no vulnerable files are left over
-# This will currently report vulnerable files being present, as it also alerts on
-# SocketNode.class, which we do not remove with our scripts.
-# Further investigation will be needed whether this should also be removed.
-COPY shared/log4shell_1.6.1-log4shell_Linux_x86_64 /bin/log4shell_scanner_x86_64
-COPY shared/log4shell_1.6.1-log4shell_Linux_aarch64 /bin/log4shell_scanner_aarch64
-COPY shared/log4shell_scanner /bin/log4shell_scanner
-RUN /bin/log4shell_scanner s /stackable/spark-${PRODUCT}/dist
-# ===
 
 FROM stackable/image/java-base AS final
 


### PR DESCRIPTION
# Description

part of https://github.com/stackabletech/docker-images/issues/961

- Does remove the recursive chmod/chown in the final image and attempts non recursive chmod/chown or doing as much as possible in the builder step.
- removed log4shell check
- removed patches from final image

```
REPOSITORY                              TAG                                   IMAGE ID       CREATED              SIZE
oci.stackable.tech/sdp/spark-k8s        3.5.5-stackable25.3.0-reduced-size    b7343e448bbc   About a minute ago   1.64GB
oci.stackable.tech/sdp/spark-k8s        3.5.5-stackable25.3.0                 c09da49b3bfb   2 days ago           2GB
```