### PR TITLE
Fix: zookeeper reduce image size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,6 @@ All notable changes to this project will be documented in this file.
 - opa: reduce docker image size by removing the recursive chown/chmods in the final image ([#1038]).
 - spark-k8s: reduce docker image size by removing the recursive chown/chmods in the final image ([#1042]).
 - trino: reduce docker image size by removing the recursive chown/chmods in the final image ([#1025]).
-- Add `--locked` flag to `cargo install` commands for reproducible builds ([#1044]).
 - zookeeper: reduce docker image size by removing the recursive chown/chmods in the final image ([#1043]).
 
 [#1025]: https://github.com/stackabletech/docker-images/pull/1025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- zookeeper: reduce docker image size by removing the recursive chown/chmods in the final image ([#1043]).
+
+[#1043]: https://github.com/stackabletech/docker-images/pull/1043
+
 ## [25.3.0] - 2025-03-21
 
 ### Added

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -38,24 +38,6 @@ RUN curl "https://repo.stackable.tech/repository/packages/zookeeper/apache-zooke
     chmod +x "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar" && \
     ln -s "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar" /stackable/jmx/jmx_prometheus_javaagent.jar
 
-# ===
-# For earlier versions this script removes the .class file that contains the
-# vulnerable code.
-# TODO: This can be restricted to target only versions which do not honor the environment
-#   varible that has been set above but this has not currently been implemented
-COPY shared/log4shell.sh /bin
-RUN /bin/log4shell.sh /stackable/apache-zookeeper-${PRODUCT}-bin
-
-# Ensure no vulnerable files are left over
-# This will currently report vulnerable files being present, as it also alerts
-# on SocketNode.class, which we do not remove with our scripts. Further
-# investigation will be needed whether this should also be removed.
-COPY shared/log4shell_1.6.1-log4shell_Linux_x86_64 /bin/log4shell_scanner_x86_64
-COPY shared/log4shell_1.6.1-log4shell_Linux_aarch64 /bin/log4shell_scanner_aarch64
-COPY shared/log4shell_scanner /bin/log4shell_scanner
-RUN /bin/log4shell_scanner s /stackable/apache-zookeeper-${PRODUCT}-bin
-# ===
-
 # END ZOOKEEPER BUILDER
 # ==============================================================================
 
@@ -69,12 +51,12 @@ ARG RELEASE
 ARG STACKABLE_USER_UID
 
 LABEL name="Apache ZooKeeper" \
-      maintainer="info@stackable.tech" \
-      vendor="Stackable GmbH" \
-      version="${PRODUCT}" \
-      release="${RELEASE}" \
-      summary="The Stackable image for Apache ZooKeeper." \
-      description="This image is deployed by the Stackable Operator for Apache ZooKeeper."
+    maintainer="info@stackable.tech" \
+    vendor="Stackable GmbH" \
+    version="${PRODUCT}" \
+    release="${RELEASE}" \
+    summary="The Stackable image for Apache ZooKeeper." \
+    description="This image is deployed by the Stackable Operator for Apache ZooKeeper."
 
 RUN microdnf update && \
     microdnf clean all && \

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -60,39 +60,52 @@ ARG RELEASE
 ARG STACKABLE_USER_UID
 
 LABEL  \
-    name="Apache ZooKeeper" \
-    maintainer="info@stackable.tech" \
-    vendor="Stackable GmbH" \
-    version="${PRODUCT}" \
-    release="${RELEASE}" \
-    summary="The Stackable image for Apache ZooKeeper." \
-    description="This image is deployed by the Stackable Operator for Apache ZooKeeper."
-
-RUN <<EOF
-microdnf update
-microdnf clean all
-rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}\n" | sort > /stackable/package_manifest.txt
-chown ${STACKABLE_USER_UID}:0 /stackable/package_manifest.txt
-rm -rf /var/cache/yum
-EOF
+  name="Apache ZooKeeper" \
+  maintainer="info@stackable.tech" \
+  vendor="Stackable GmbH" \
+  version="${PRODUCT}" \
+  release="${RELEASE}" \
+  summary="The Stackable image for Apache ZooKeeper." \
+  description="This image is deployed by the Stackable Operator for Apache ZooKeeper."
 
 # Copy over the ZooKeeper binary folder
 COPY --chown=${STACKABLE_USER_UID}:0 --from=builder /stackable/apache-zookeeper-${PRODUCT}-bin /stackable/apache-zookeeper-${PRODUCT}-bin/
 COPY --chown=${STACKABLE_USER_UID}:0 --from=builder /stackable/jmx /stackable/jmx/
 COPY zookeeper/licenses /licenses
 
+RUN <<EOF
+microdnf update
+microdnf clean all
+rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}\n" | sort > /stackable/package_manifest.txt
+chown ${STACKABLE_USER_UID}:0 /stackable/package_manifest.txt
+chmod g=u /stackable/package_manifest.txt
+rm -rf /var/cache/yum
+
 # Add link pointing from /stackable/zookeeper to /stackable/apache-zookeeper-${PRODUCT}-bin/
 # to preserve the folder name with the version.
-RUN <<EOF
 ln -s /stackable/apache-zookeeper-${PRODUCT}-bin/ /stackable/zookeeper
 chown -h ${STACKABLE_USER_UID}:0 /stackable/zookeeper
+
+# fix missing permissions
+chmod g=u /stackable/jmx
+chmod g=u /stackable/apache-zookeeper-${PRODUCT}-bin/ 
 EOF
 
 # ----------------------------------------
-# Attention:
-# If you do any file based actions (copying / creating etc.) below this comment you
-# absolutely need to make sure that the correct permissions are applied!
-# chown ${STACKABLE_USER_UID}:0
+# Checks
+# This section is to run final checks to ensure the created final images
+# adhere to several minimal requirements like:
+# - check file permissions and ownerships
+# ----------------------------------------
+
+# Check that permissions and ownership in /stackable are set correctly
+# This will fail and stop the build if any mismatches are found.
+RUN <<EOF
+/bin/check-permissions-ownership.sh /stackable ${STACKABLE_USER_UID} 0
+EOF
+
+# ----------------------------------------
+# Attention: Do not perform any file based actions (copying/creating etc.) below this comment because the permissions would not be checked.
 # ----------------------------------------
 
 ENV ZOOKEEPER_HOME=/stackable/zookeeper

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -17,26 +17,35 @@ USER ${STACKABLE_USER_UID}
 WORKDIR /stackable
 
 # Download ZooKeeper sources from our own repo
-RUN curl "https://repo.stackable.tech/repository/packages/zookeeper/apache-zookeeper-${PRODUCT}.tar.gz" | tar -xzC . && \
-    # Apply any required patches
-    patches/apply_patches.sh ${PRODUCT} && \
-    cd /stackable/apache-zookeeper-${PRODUCT}/ && \
-    # Exclude the `zookeeper-client` submodule, this is not needed and has c parts
-    # that created all kinds of issues for the build container
-    mvn --batch-mode --no-transfer-progress -pl "!zookeeper-client/zookeeper-client-c" clean install checkstyle:check spotbugs:check -DskipTests -Pfull-build && \
-    mv zookeeper-assembly/target/apache-zookeeper-${PRODUCT}-bin.tar.gz /stackable && \
-    cd /stackable && \
-    # Unpack the archive which contains the build artifacts from above. Remove some
-    # unused files to shrink the final image size.
-    tar xvzf /stackable/apache-zookeeper-${PRODUCT}-bin.tar.gz && \
-    mv /stackable/apache-zookeeper-${PRODUCT}/zookeeper-assembly/target/bom.json /stackable/apache-zookeeper-${PRODUCT}-bin/apache-zookeeper-${PRODUCT}.cdx.json && \
-    rm -rf /stackable/apache-zookeeper-${PRODUCT}-bin/docs && \
-    rm /stackable/apache-zookeeper-${PRODUCT}-bin/README_packaging.md && \
-    # Download the JMX exporter jar from our own repo
-    curl "https://repo.stackable.tech/repository/packages/jmx-exporter/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar" \
-    -o "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar" && \
-    chmod +x "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar" && \
-    ln -s "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar" /stackable/jmx/jmx_prometheus_javaagent.jar
+RUN <<EOF
+curl --fail "https://repo.stackable.tech/repository/packages/zookeeper/apache-zookeeper-${PRODUCT}.tar.gz" | tar -xzC .
+
+# Apply any required patches
+patches/apply_patches.sh ${PRODUCT}
+cd /stackable/apache-zookeeper-${PRODUCT}/
+
+# Exclude the `zookeeper-client` submodule, this is not needed and has c parts
+# that created all kinds of issues for the build container
+mvn --batch-mode --no-transfer-progress -pl "!zookeeper-client/zookeeper-client-c" clean install checkstyle:check spotbugs:check -DskipTests -Pfull-build
+mv zookeeper-assembly/target/apache-zookeeper-${PRODUCT}-bin.tar.gz /stackable
+
+cd /stackable
+# Unpack the archive which contains the build artifacts from above. Remove some
+# unused files to shrink the final image size.
+tar xvzf /stackable/apache-zookeeper-${PRODUCT}-bin.tar.gz
+mv /stackable/apache-zookeeper-${PRODUCT}/zookeeper-assembly/target/bom.json /stackable/apache-zookeeper-${PRODUCT}-bin/apache-zookeeper-${PRODUCT}.cdx.json
+rm -rf /stackable/apache-zookeeper-${PRODUCT}-bin/docs
+rm /stackable/apache-zookeeper-${PRODUCT}-bin/README_packaging.md
+
+# Download the JMX exporter jar from our own repo
+curl "https://repo.stackable.tech/repository/packages/jmx-exporter/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar" \
+  -o "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar"
+chmod +x "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar"
+ln -s "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar" /stackable/jmx/jmx_prometheus_javaagent.jar
+
+# set correct groups
+chmod -R g=u /stackable
+EOF
 
 # END ZOOKEEPER BUILDER
 # ==============================================================================
@@ -50,7 +59,8 @@ ARG PRODUCT
 ARG RELEASE
 ARG STACKABLE_USER_UID
 
-LABEL name="Apache ZooKeeper" \
+LABEL  \
+    name="Apache ZooKeeper" \
     maintainer="info@stackable.tech" \
     vendor="Stackable GmbH" \
     version="${PRODUCT}" \
@@ -58,12 +68,13 @@ LABEL name="Apache ZooKeeper" \
     summary="The Stackable image for Apache ZooKeeper." \
     description="This image is deployed by the Stackable Operator for Apache ZooKeeper."
 
-RUN microdnf update && \
-    microdnf clean all && \
-    rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}\n" | sort > /stackable/package_manifest.txt && \
-    rm -rf /var/cache/yum
-
-WORKDIR /stackable
+RUN <<EOF
+microdnf update
+microdnf clean all
+rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}\n" | sort > /stackable/package_manifest.txt
+chown ${STACKABLE_USER_UID}:0 /stackable/package_manifest.txt
+rm -rf /var/cache/yum
+EOF
 
 # Copy over the ZooKeeper binary folder
 COPY --chown=${STACKABLE_USER_UID}:0 --from=builder /stackable/apache-zookeeper-${PRODUCT}-bin /stackable/apache-zookeeper-${PRODUCT}-bin/
@@ -74,15 +85,11 @@ COPY zookeeper/licenses /licenses
 # to preserve the folder name with the version.
 RUN <<EOF
 ln -s /stackable/apache-zookeeper-${PRODUCT}-bin/ /stackable/zookeeper
-
-# All files and folders owned by root group to support running as arbitrary users.
-# This is best practice as all container users will belong to the root group (0).
-chown -R ${STACKABLE_USER_UID}:0 /stackable
-chmod -R g=u /stackable
+chown -h ${STACKABLE_USER_UID}:0 /stackable/zookeeper
 EOF
 
 # ----------------------------------------
-# Attention: We are changing the group of all files in /stackable directly above
+# Attention:
 # If you do any file based actions (copying / creating etc.) below this comment you
 # absolutely need to make sure that the correct permissions are applied!
 # chown ${STACKABLE_USER_UID}:0

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -88,7 +88,7 @@ chown -h ${STACKABLE_USER_UID}:0 /stackable/zookeeper
 
 # fix missing permissions
 chmod g=u /stackable/jmx
-chmod g=u /stackable/apache-zookeeper-${PRODUCT}-bin/ 
+chmod g=u /stackable/apache-zookeeper-${PRODUCT}-bin/
 EOF
 
 # ----------------------------------------


### PR DESCRIPTION
# Description

part of https://github.com/stackabletech/docker-images/issues/961

```
REPOSITORY                               TAG                                   IMAGE ID       CREATED          SIZE
oci.stackable.tech/sdp/zookeeper         3.9.3-stackable25.3.0-reduced-size    0cdaed351a1c   5 minutes ago    553MB
oci.stackable.tech/sdp/zookeeper         3.9.3-stackable25.3.0                 c39102329a46   2 days ago       577MB
```

- Does remove the recursive chmod/chown in the final image and attempts non recursive chmod/chown or doing as much as possible in the builder step.
- removed log4shell check
- Uses check-permissions-ownership script to validate any wrong permissions / ownership in the /stackable folder (example for nifi)

```
 => [nifi-2_2_0 final  7/10] RUN <<EOF (microdnf update...)                                                                                                                                         8.2s
 => ERROR [nifi-2_2_0 final  8/10] RUN <<EOF (chmod +x /tmp/check-permissions-ownership...)                                                                                                         0.9s
------
 > [nifi-2_2_0 final  8/10] RUN <<EOF (chmod +x /tmp/check-permissions-ownership...):
0.601 Ownership mismatch:  /stackable/nifi (Expected: 1000:0, Found: 0:0)
0.622 Permission mismatch: /stackable/python (Owner: rwx, Group: r-x)
0.624 Permission mismatch: /stackable/bin (Owner: rwx, Group: r-x)
0.628 Permission mismatch: /stackable/nifi-2.2.0 (Owner: rwx, Group: r-x)
0.843 Permission and Ownership checks failed for /stackable!
```
