### PR TITLE
Use check permissions script and consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 - spark-connect-client: A new image for Spark connect tests and demos ([#1034])
 - nifi: check for correct permissions and ownerships in /stackable folder via
   `check-permissions-ownership.sh` provided in stackable-base image ([#1027]).
+- superset: check for correct permissions and ownerships in /stackable folder via
+  `check-permissions-ownership.sh` provided in stackable-base image ([#1053]).
 
 ### Changed
 
@@ -26,6 +28,7 @@ All notable changes to this project will be documented in this file.
 [#1042]: https://github.com/stackabletech/docker-images/pull/1042
 [#1044]: https://github.com/stackabletech/docker-images/pull/1044
 [#1050]: https://github.com/stackabletech/docker-images/pull/1050
+[#1053]: https://github.com/stackabletech/docker-images/pull/1053
 
 ## [25.3.0] - 2025-03-21
 

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -103,14 +103,14 @@ RUN python3 -m venv /stackable/app \
     # Superset 4.1.0 will contain at least 22.0.0, the bump was done in https://github.com/apache/superset/commit/4f693c6db0dc5c7286a36b8d23e90541943ff13f
     # We only want to bump this for the 4.0.x line, as the others already have updated and we don't want to accidentially downgrade the version
     && if [[ "$PRODUCT" =~ ^4\.0\..* ]]; \
-    then echo "Superset 4.0.x detected, installing gunicorn 22.0.0 to fix CVE-2024-1135" \
-    && pip install gunicorn==22.0.0; \
+        then echo "Superset 4.0.x detected, installing gunicorn 22.0.0 to fix CVE-2024-1135" \
+        && pip install gunicorn==22.0.0; \
     fi \
     && pip install \
-    --no-cache-dir \
-    --upgrade \
-    python-json-logger \
-    cyclonedx-bom \
+        --no-cache-dir \
+        --upgrade \
+        python-json-logger \
+        cyclonedx-bom \
     && if [ -n "$AUTHLIB" ]; then pip install Authlib==${AUTHLIB}; fi && \
     pip install --no-cache-dir /tmp/opa_authorizer-0.1.0-py3-none-any.whl
 

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -46,25 +46,25 @@ COPY --from=opa-authorizer-builder /tmp/opa-authorizer/dist/opa_authorizer-0.1.0
 
 RUN microdnf update \
     && microdnf install \
-    cyrus-sasl-devel \
-    # Needed by ./configure to work out SQLite compilation flags, see snippet [1] at the end of file
-    diffutils \
-    # According to https://stackoverflow.com/q/19530974 normally sqlite3 should be shipped with the Python
-    # distribution. However, while addig ARM support we noticed that this does not seem to be the case for the
-    # Python installation shipped in the ARM image variant. So I guess Make is used to find out the sqlite
-    # compilation flags (and propably to not build sqlite from source(?)), see snippet [1] at the end of file
-    make \
-    gcc \
-    gcc-c++ \
-    libffi-devel \
-    openldap-devel \
-    openssl-devel \
-    patch \
-    python${PYTHON} \
-    python${PYTHON}-devel \
-    python${PYTHON}-pip \
-    python${PYTHON}-wheel \
-    libpq-devel \
+        cyrus-sasl-devel \
+        # Needed by ./configure to work out SQLite compilation flags, see snippet [1] at the end of file
+        diffutils \
+        # According to https://stackoverflow.com/q/19530974 normally sqlite3 should be shipped with the Python
+        # distribution. However, while addig ARM support we noticed that this does not seem to be the case for the
+        # Python installation shipped in the ARM image variant. So I guess Make is used to find out the sqlite
+        # compilation flags (and propably to not build sqlite from source(?)), see snippet [1] at the end of file
+        make \
+        gcc \
+        gcc-c++ \
+        libffi-devel \
+        openldap-devel \
+        openssl-devel \
+        patch \
+        python${PYTHON} \
+        python${PYTHON}-devel \
+        python${PYTHON}-pip \
+        python${PYTHON}-wheel \
+        libpq-devel \
     && microdnf clean all && \
     rm -rf /var/cache/yum
 
@@ -74,31 +74,31 @@ RUN microdnf update \
 RUN python3 -m venv /stackable/app \
     && source /stackable/app/bin/activate \
     && pip install \
-    --no-cache-dir \
-    --upgrade \
-    setuptools==75.2.0 \
-    pip \
-    && pip install \
-    --no-cache-dir \
-    --upgrade \
-    --constraint /tmp/constraints.txt \
-    apache-superset==${PRODUCT} \
-    gevent \
-    psycopg2-binary \
-    statsd \
-    pydruid \
-    python-ldap \
-    'trino[sqlalchemy]' \
-    # Add optional dependencies for use in custom Superset configurations.
-    # Since https://github.com/stackabletech/superset-operator/pull/530
-    # admins can add custom configuration to superset_conf.py.
-    Flask_OIDC==2.2.0 \
-    Flask-OpenID==1.3.1 \
-    # Redhat has removed `tzdata` from the ubi-minimal images: see https://bugzilla.redhat.com/show_bug.cgi?id=2223028.
-    # Superset relies on ZoneInfo (https://docs.python.org/3/library/zoneinfo.html#data-sources) to resolve time zones, and this is done
-    # by searching first under `TZPATH` (which is empty due to the point above) or for the tzdata python package.
-    # That package is therefore added here (airflow has tzdata in its list of dependencies, but superset does not).
-    tzdata \
+        --no-cache-dir \
+        --upgrade \
+        setuptools==75.2.0 \
+        pip \
+        && pip install \
+        --no-cache-dir \
+        --upgrade \
+        --constraint /tmp/constraints.txt \
+        apache-superset==${PRODUCT} \
+        gevent \
+        psycopg2-binary \
+        statsd \
+        pydruid \
+        python-ldap \
+        'trino[sqlalchemy]' \
+        # Add optional dependencies for use in custom Superset configurations.
+        # Since https://github.com/stackabletech/superset-operator/pull/530
+        # admins can add custom configuration to superset_conf.py.
+        Flask_OIDC==2.2.0 \
+        Flask-OpenID==1.3.1 \
+        # Redhat has removed `tzdata` from the ubi-minimal images: see https://bugzilla.redhat.com/show_bug.cgi?id=2223028.
+        # Superset relies on ZoneInfo (https://docs.python.org/3/library/zoneinfo.html#data-sources) to resolve time zones, and this is done
+        # by searching first under `TZPATH` (which is empty due to the point above) or for the tzdata python package.
+        # That package is therefore added here (airflow has tzdata in its list of dependencies, but superset does not).
+        tzdata \
     # We bumped this from 21.2.0 to 22.0.0 to fix CVE-2024-1135
     # Superset 4.1.0 will contain at least 22.0.0, the bump was done in https://github.com/apache/superset/commit/4f693c6db0dc5c7286a36b8d23e90541943ff13f
     # We only want to bump this for the 4.0.x line, as the others already have updated and we don't want to accidentially downgrade the version

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -172,10 +172,10 @@ EOF
 # - check file permissions and ownerships
 # ----------------------------------------
 
-# Check that permissions and ownership in /stackable are set correctly
+# Check that permissions and ownership in ${HOME} are set correctly
 # This will fail and stop the build if any mismatches are found.
 RUN <<EOF
-/bin/check-permissions-ownership.sh /stackable ${STACKABLE_USER_UID} 0
+/bin/check-permissions-ownership.sh ${HOME} ${STACKABLE_USER_UID} 0
 EOF
 
 # ----------------------------------------

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -78,7 +78,7 @@ RUN python3 -m venv /stackable/app \
         --upgrade \
         setuptools==75.2.0 \
         pip \
-        && pip install \
+    && pip install \
         --no-cache-dir \
         --upgrade \
         --constraint /tmp/constraints.txt \

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -46,25 +46,25 @@ COPY --from=opa-authorizer-builder /tmp/opa-authorizer/dist/opa_authorizer-0.1.0
 
 RUN microdnf update \
     && microdnf install \
-        cyrus-sasl-devel \
-        # Needed by ./configure to work out SQLite compilation flags, see snippet [1] at the end of file
-        diffutils \
-        # According to https://stackoverflow.com/q/19530974 normally sqlite3 should be shipped with the Python
-        # distribution. However, while addig ARM support we noticed that this does not seem to be the case for the
-        # Python installation shipped in the ARM image variant. So I guess Make is used to find out the sqlite
-        # compilation flags (and propably to not build sqlite from source(?)), see snippet [1] at the end of file
-        make \
-        gcc \
-        gcc-c++ \
-        libffi-devel \
-        openldap-devel \
-        openssl-devel \
-        patch \
-        python${PYTHON} \
-        python${PYTHON}-devel \
-        python${PYTHON}-pip \
-        python${PYTHON}-wheel \
-        libpq-devel \
+    cyrus-sasl-devel \
+    # Needed by ./configure to work out SQLite compilation flags, see snippet [1] at the end of file
+    diffutils \
+    # According to https://stackoverflow.com/q/19530974 normally sqlite3 should be shipped with the Python
+    # distribution. However, while addig ARM support we noticed that this does not seem to be the case for the
+    # Python installation shipped in the ARM image variant. So I guess Make is used to find out the sqlite
+    # compilation flags (and propably to not build sqlite from source(?)), see snippet [1] at the end of file
+    make \
+    gcc \
+    gcc-c++ \
+    libffi-devel \
+    openldap-devel \
+    openssl-devel \
+    patch \
+    python${PYTHON} \
+    python${PYTHON}-devel \
+    python${PYTHON}-pip \
+    python${PYTHON}-wheel \
+    libpq-devel \
     && microdnf clean all && \
     rm -rf /var/cache/yum
 
@@ -74,53 +74,55 @@ RUN microdnf update \
 RUN python3 -m venv /stackable/app \
     && source /stackable/app/bin/activate \
     && pip install \
-        --no-cache-dir \
-        --upgrade \
-        setuptools==75.2.0 \
-        pip \
+    --no-cache-dir \
+    --upgrade \
+    setuptools==75.2.0 \
+    pip \
     && pip install \
-        --no-cache-dir \
-        --upgrade \
-        --constraint /tmp/constraints.txt \
-        apache-superset==${PRODUCT} \
-        gevent \
-        psycopg2-binary \
-        statsd \
-        pydruid \
-        python-ldap \
-        'trino[sqlalchemy]' \
-        # Add optional dependencies for use in custom Superset configurations.
-        # Since https://github.com/stackabletech/superset-operator/pull/530
-        # admins can add custom configuration to superset_conf.py.
-        Flask_OIDC==2.2.0 \
-        Flask-OpenID==1.3.1 \
-        # Redhat has removed `tzdata` from the ubi-minimal images: see https://bugzilla.redhat.com/show_bug.cgi?id=2223028.
-        # Superset relies on ZoneInfo (https://docs.python.org/3/library/zoneinfo.html#data-sources) to resolve time zones, and this is done
-        # by searching first under `TZPATH` (which is empty due to the point above) or for the tzdata python package.
-        # That package is therefore added here (airflow has tzdata in its list of dependencies, but superset does not).
-        tzdata \
+    --no-cache-dir \
+    --upgrade \
+    --constraint /tmp/constraints.txt \
+    apache-superset==${PRODUCT} \
+    gevent \
+    psycopg2-binary \
+    statsd \
+    pydruid \
+    python-ldap \
+    'trino[sqlalchemy]' \
+    # Add optional dependencies for use in custom Superset configurations.
+    # Since https://github.com/stackabletech/superset-operator/pull/530
+    # admins can add custom configuration to superset_conf.py.
+    Flask_OIDC==2.2.0 \
+    Flask-OpenID==1.3.1 \
+    # Redhat has removed `tzdata` from the ubi-minimal images: see https://bugzilla.redhat.com/show_bug.cgi?id=2223028.
+    # Superset relies on ZoneInfo (https://docs.python.org/3/library/zoneinfo.html#data-sources) to resolve time zones, and this is done
+    # by searching first under `TZPATH` (which is empty due to the point above) or for the tzdata python package.
+    # That package is therefore added here (airflow has tzdata in its list of dependencies, but superset does not).
+    tzdata \
     # We bumped this from 21.2.0 to 22.0.0 to fix CVE-2024-1135
     # Superset 4.1.0 will contain at least 22.0.0, the bump was done in https://github.com/apache/superset/commit/4f693c6db0dc5c7286a36b8d23e90541943ff13f
     # We only want to bump this for the 4.0.x line, as the others already have updated and we don't want to accidentially downgrade the version
     && if [[ "$PRODUCT" =~ ^4\.0\..* ]]; \
-        then echo "Superset 4.0.x detected, installing gunicorn 22.0.0 to fix CVE-2024-1135" \
-        && pip install gunicorn==22.0.0; \
+    then echo "Superset 4.0.x detected, installing gunicorn 22.0.0 to fix CVE-2024-1135" \
+    && pip install gunicorn==22.0.0; \
     fi \
     && pip install \
-        --no-cache-dir \
-        --upgrade \
-        python-json-logger \
-        cyclonedx-bom \
+    --no-cache-dir \
+    --upgrade \
+    python-json-logger \
+    cyclonedx-bom \
     && if [ -n "$AUTHLIB" ]; then pip install Authlib==${AUTHLIB}; fi && \
     pip install --no-cache-dir /tmp/opa_authorizer-0.1.0-py3-none-any.whl
 
-COPY superset/stackable/patches /patches
-RUN /patches/apply_patches.sh ${PRODUCT}
-
-WORKDIR /stackable
-RUN source /stackable/app/bin/activate && cyclonedx-py environment --schema-version 1.5 --outfile app/superset-${PRODUCT}.cdx.json
-
 COPY --from=statsd_exporter-builder /statsd_exporter/statsd_exporter /stackable/statsd_exporter
+COPY superset/stackable/patches /patches
+
+RUN <<EOF
+/patches/apply_patches.sh ${PRODUCT}
+cd /stackable
+source /stackable/app/bin/activate && cyclonedx-py environment --schema-version 1.5 --outfile app/superset-${PRODUCT}.cdx.json
+chmod --recursive g=u /stackable
+EOF
 
 # Final image
 FROM stackable/image/vector
@@ -131,12 +133,12 @@ ARG RELEASE
 ARG STACKABLE_USER_UID
 
 LABEL name="Apache Superset" \
-      maintainer="info@stackable.tech" \
-      vendor="Stackable GmbH" \
-      version="${PRODUCT}" \
-      release="${RELEASE}" \
-      summary="The Stackable image for Apache Superset." \
-      description="This image is deployed by the Stackable Operator for Apache Superset."
+    maintainer="info@stackable.tech" \
+    vendor="Stackable GmbH" \
+    version="${PRODUCT}" \
+    release="${RELEASE}" \
+    summary="The Stackable image for Apache Superset." \
+    description="This image is deployed by the Stackable Operator for Apache Superset."
 
 ENV FLASK_APP="superset.app:create_app()" \
     FLASK_ENV="production" \
@@ -144,6 +146,10 @@ ENV FLASK_APP="superset.app:create_app()" \
     SUPERSET_PORT="8088"
 ENV PATH="${HOME}/app/bin:${PATH}" \
     PYTHONPATH="${HOME}/app/pythonpath"
+
+COPY superset/licenses /licenses
+
+COPY --from=builder --chown=${STACKABLE_USER_UID}:0 /stackable/ ${HOME}/
 
 RUN <<EOF
 microdnf update
@@ -157,22 +163,23 @@ microdnf install \
 
 microdnf clean all
 rm -rf /var/cache/yum
-
-# All files and folders owned by root group to support running as arbitrary users.
-# This is best practice as all container users will belong to the root group (0).
-chown -R "${STACKABLE_USER_UID}:0" /stackable
-chmod -R g=u /stackable
 EOF
 
-COPY superset/licenses /licenses
+# ----------------------------------------
+# Checks
+# This section is to run final checks to ensure the created final images
+# adhere to several minimal requirements like:
+# - check file permissions and ownerships
+# ----------------------------------------
 
-COPY --from=builder --chown=${STACKABLE_USER_UID}:0 /stackable/ ${HOME}/
+# Check that permissions and ownership in /stackable are set correctly
+# This will fail and stop the build if any mismatches are found.
+RUN <<EOF
+/bin/check-permissions-ownership.sh /stackable ${STACKABLE_USER_UID} 0
+EOF
 
 # ----------------------------------------
-# Attention: We are changing the group of all files in /stackable directly above
-# If you do any file based actions (copying / creating etc.) below this comment you
-# absolutely need to make sure that the correct permissions are applied!
-# chown ${STACKABLE_USER_UID}:0
+# Attention: Do not perform any file based actions (copying/creating etc.) below this comment because the permissions would not be checked.
 # ----------------------------------------
 
 USER ${STACKABLE_USER_UID}


### PR DESCRIPTION
# Description

part of https://github.com/stackabletech/docker-images/issues/961

No image size reduction, just consolidation.

- Does remove the recursive chmod/chown in the final image and attempts non recursive chmod/chown or doing as much as possible in the builder step.
- Uses check-permissions-ownership script to validate any wrong permissions / ownership in the /stackable folder