### PR TITLE
Use check permissions script and consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 - spark-connect-client: A new image for Spark connect tests and demos ([#1034])
 - nifi: check for correct permissions and ownerships in /stackable folder via
   `check-permissions-ownership.sh` provided in stackable-base image ([#1027]).
+- spark-k8s: check for correct permissions and ownerships in /stackable folder via
+  `check-permissions-ownership.sh` provided in stackable-base image ([#1055]).
 
 ### Changed
 
@@ -26,6 +28,7 @@ All notable changes to this project will be documented in this file.
 [#1042]: https://github.com/stackabletech/docker-images/pull/1042
 [#1044]: https://github.com/stackabletech/docker-images/pull/1044
 [#1050]: https://github.com/stackabletech/docker-images/pull/1050
+[#1055]: https://github.com/stackabletech/docker-images/pull/1055
 
 ## [25.3.0] - 2025-03-21
 

--- a/spark-k8s/Dockerfile
+++ b/spark-k8s/Dockerfile
@@ -337,6 +337,7 @@ chown -h ${STACKABLE_USER_UID}:0 /stackable/spark/examples/jars/spark-examples.j
 # fix permissions
 chmod g=u /stackable/spark
 chmod g=u /stackable/jmx
+chmod g=u /stackable/run-spark.sh
 EOF
 
 # ----------------------------------------

--- a/spark-k8s/Dockerfile
+++ b/spark-k8s/Dockerfile
@@ -333,17 +333,30 @@ ln -s /usr/bin/pip-${PYTHON} /usr/bin/pip
 # Symlink example jar, so that we can easily use it in tests
 ln -s /stackable/spark/examples/jars/spark-examples_*.jar /stackable/spark/examples/jars/spark-examples.jar
 chown -h ${STACKABLE_USER_UID}:0 /stackable/spark/examples/jars/spark-examples.jar
+
+# fix permissions
+chmod g=u /stackable/spark
+chmod g=u /stackable/jmx
 EOF
 
+# ----------------------------------------
+# Checks
+# This section is to run final checks to ensure the created final images
+# adhere to several minimal requirements like:
+# - check file permissions and ownerships
+# ----------------------------------------
+
+# Check that permissions and ownership in /stackable are set correctly
+# This will fail and stop the build if any mismatches are found.
+RUN <<EOF
+/bin/check-permissions-ownership.sh /stackable ${STACKABLE_USER_UID} 0
+EOF
 
 # ----------------------------------------
-# Attention:
-# If you do any file based actions (copying / creating etc.) below this comment you
-# absolutely need to make sure that the correct permissions are applied!
-# chown ${STACKABLE_USER_UID}:0
+# Attention: Do not perform any file based actions (copying/creating etc.) below this comment because the permissions would not be checked.
 # ----------------------------------------
 
 USER ${STACKABLE_USER_UID}
 
-WORKDIR /stackable/spark
+WORKDIR ${SPARK_HOME}
 ENTRYPOINT [ "/stackable/run-spark.sh" ]


### PR DESCRIPTION
# Description

part of https://github.com/stackabletech/docker-images/issues/961

No image size reduction, just consolidation.

- Does remove the recursive chmod/chown in the final image and attempts non recursive chmod/chown or doing as much as possible in the builder step.
- Uses check-permissions-ownership script to validate any wrong permissions / ownership in the /stackable folder