### PR TITLE
chore(⏲): Use fast download mirrors

### DIFF
--- a/.scripts/upload_new_async-profiler_version.sh
+++ b/.scripts/upload_new_async-profiler_version.sh
@@ -46,7 +46,7 @@ for arch in "${ARCHITECTURES[@]}"; do
     curl --fail -LO --progress-bar "https://github.com/async-profiler/async-profiler/releases/download/v$VERSION/$file"
 
     echo "Uploading $file to Nexus"
-    curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" \
+    curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" \
         --upload-file "$file" \
         'https://repo.stackable.tech/repository/packages/async-profiler/'
 done

--- a/.scripts/upload_new_async-profiler_version.sh
+++ b/.scripts/upload_new_async-profiler_version.sh
@@ -43,7 +43,7 @@ for arch in "${ARCHITECTURES[@]}"; do
     file=async-profiler-$VERSION-linux-$arch.tar.gz
 
     echo "Downloading $file from github.com"
-    curl --fail -LOs "https://github.com/async-profiler/async-profiler/releases/download/v$VERSION/$file"
+    curl --fail -LO --progress-bar "https://github.com/async-profiler/async-profiler/releases/download/v$VERSION/$file"
 
     echo "Uploading $file to Nexus"
     curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" \

--- a/.scripts/upload_new_inotify-tools_version.sh
+++ b/.scripts/upload_new_inotify-tools_version.sh
@@ -52,7 +52,7 @@ for arch in "${ARCHITECTURES[@]}"; do
     curl --fail -LO --progress-bar "https://dl.fedoraproject.org/pub/epel/$EPEL_VERSION/Everything/$arch/Packages/i/$file"
 
     echo "Uploading $file to Nexus"
-    curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" \
+    curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" \
         --upload-file "$file" \
         'https://repo.stackable.tech/repository/packages/inotify-tools/'
 done

--- a/.scripts/upload_new_inotify-tools_version.sh
+++ b/.scripts/upload_new_inotify-tools_version.sh
@@ -49,7 +49,7 @@ for arch in "${ARCHITECTURES[@]}"; do
     file=inotify-tools-$VERSION.$arch.rpm
 
     echo "Downloading $file from dl.fedoraproject.org"
-    curl --fail -LOs "https://dl.fedoraproject.org/pub/epel/$EPEL_VERSION/Everything/$arch/Packages/i/$file"
+    curl --fail -LO --progress-bar "https://dl.fedoraproject.org/pub/epel/$EPEL_VERSION/Everything/$arch/Packages/i/$file"
 
     echo "Uploading $file to Nexus"
     curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" \

--- a/.scripts/upload_new_jmx_exporter_version.sh
+++ b/.scripts/upload_new_jmx_exporter_version.sh
@@ -35,8 +35,8 @@ JAR_FILE="jmx_prometheus_javaagent-$VERSION.jar"
 SUM_FILE="$JAR_FILE.sha256"
 
 echo "Downloading JMX Exporter"
-curl --fail -LOs "https://github.com/prometheus/jmx_exporter/releases/download/$VERSION/$JAR_FILE"
-curl --fail -LOs "https://github.com/prometheus/jmx_exporter/releases/download/$VERSION/$SUM_FILE"
+curl --fail -LO --progress-bar "https://github.com/prometheus/jmx_exporter/releases/download/$VERSION/$JAR_FILE"
+curl --fail -LO --progress-bar "https://github.com/prometheus/jmx_exporter/releases/download/$VERSION/$SUM_FILE"
 
 # Check that sha256 sum matches before uploading
 sha256sum --check --status "$SUM_FILE" && echo "SHA256 Sum matches"

--- a/.scripts/upload_new_jmx_exporter_version.sh
+++ b/.scripts/upload_new_jmx_exporter_version.sh
@@ -42,8 +42,8 @@ curl --fail -LO --progress-bar "https://github.com/prometheus/jmx_exporter/relea
 sha256sum --check --status "$SUM_FILE" && echo "SHA256 Sum matches"
 
 echo "Uploading to Nexus"
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$JAR_FILE" 'https://repo.stackable.tech/repository/packages/jmx-exporter/'
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$SUM_FILE" 'https://repo.stackable.tech/repository/packages/jmx-exporter/'
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$JAR_FILE" 'https://repo.stackable.tech/repository/packages/jmx-exporter/'
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$SUM_FILE" 'https://repo.stackable.tech/repository/packages/jmx-exporter/'
 
 echo "Successfully uploaded new version of the JMX Exporter ($VERSION) Jar to Nexus"
 echo "https://repo.stackable.tech/service/rest/repository/browse/packages/jmx-exporter/"

--- a/.scripts/upload_new_kcat_version.sh
+++ b/.scripts/upload_new_kcat_version.sh
@@ -38,7 +38,7 @@ echo "Downloading kcat"
 curl --fail -Ls -o "kcat-$VERSION.tar.gz" "https://github.com/edenhill/kcat/archive/refs/tags/$VERSION.tar.gz"
 
 echo "Uploading to Nexus"
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "kcat-$VERSION.tar.gz" 'https://repo.stackable.tech/repository/packages/kcat/'
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "kcat-$VERSION.tar.gz" 'https://repo.stackable.tech/repository/packages/kcat/'
 
 
 echo "Successfully uploaded new version of kcat ($VERSION) to Nexus"

--- a/.scripts/upload_new_protoc_version.sh
+++ b/.scripts/upload_new_protoc_version.sh
@@ -50,7 +50,7 @@ for arch in "${ARCHITECTURES[@]}"; do
   FILE_NAME=$(basename "$DOWNLOAD_URL")
 
   echo "Uploading protoc to Nexus"
-  if ! curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$FILE_NAME" 'https://repo.stackable.tech/repository/packages/protoc/'; then
+  if ! curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$FILE_NAME" 'https://repo.stackable.tech/repository/packages/protoc/'; then
     echo "Failed to upload protoc to Nexus"
     exit 1
   fi

--- a/.scripts/upload_new_tini_version.sh
+++ b/.scripts/upload_new_tini_version.sh
@@ -41,7 +41,7 @@ for arch in "${ARCHITECTURES[@]}"; do
   curl --fail -Ls -o "tini-$VERSION-$arch" "https://github.com/krallin/tini/releases/download/v$VERSION/tini-$arch"
 
   echo "Uploading to Nexus"
-  curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "tini-$VERSION-$arch" 'https://repo.stackable.tech/repository/packages/tini/'
+  curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "tini-$VERSION-$arch" 'https://repo.stackable.tech/repository/packages/tini/'
 done
 
 echo "Successfully uploaded new version of TINI ($VERSION) to Nexus"

--- a/druid/upload_new_druid_version.sh
+++ b/druid/upload_new_druid_version.sh
@@ -60,9 +60,9 @@ fi
 
 echo "Uploading everything to Nexus"
 EXIT_STATUS=0
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}" 'https://repo.stackable.tech/repository/packages/druid/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}.asc" 'https://repo.stackable.tech/repository/packages/druid/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}.sha512" 'https://repo.stackable.tech/repository/packages/druid/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}" 'https://repo.stackable.tech/repository/packages/druid/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}.asc" 'https://repo.stackable.tech/repository/packages/druid/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}.sha512" 'https://repo.stackable.tech/repository/packages/druid/' || EXIT_STATUS=$?
 
 if [ $EXIT_STATUS -ne 0 ]; then
   echo "ERROR: Upload failed"

--- a/druid/upload_new_druid_version.sh
+++ b/druid/upload_new_druid_version.sh
@@ -38,7 +38,7 @@ cd "$WORK_DIR" || exit
 
 src_file="apache-druid-${VERSION}-src.tar.gz"
 
-echo "Downloading Druid (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
+echo "Downloading Druid source (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/${VERSION}/${src_file}"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/${VERSION}/${src_file}.asc"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/${VERSION}/${src_file}.sha512"

--- a/druid/upload_new_druid_version.sh
+++ b/druid/upload_new_druid_version.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 VERSION=${1:?"Missing version number argument (arg 1)"}
 NEXUS_USER=${2:?"Missing Nexus username argument (arg 2)"}
 
+# We prefer fast downloads...
+BASE_DOWNLOAD_URL="https://dlcdn.apache.org/druid"
+# However, if the version is not available, use the slow archive instead:
+# BASE_DOWNLOAD_URL="https://archive.apache.org/dist/druid"
+
 read -r -s -p "Nexus Password: " NEXUS_PASSWORD
 echo ""
 
@@ -33,10 +38,10 @@ cd "$WORK_DIR" || exit
 
 src_file="apache-druid-${VERSION}-src.tar.gz"
 
-echo "Downloading Druid (this can take a while, it is intentionally downloading from a slow mirror that contains all old versions)"
-curl --fail -LOs "https://archive.apache.org/dist/druid/${VERSION}/${src_file}"
-curl --fail -LOs "https://archive.apache.org/dist/druid/${VERSION}/${src_file}.asc"
-curl --fail -LOs "https://archive.apache.org/dist/druid/${VERSION}/${src_file}.sha512"
+echo "Downloading Druid (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/${VERSION}/${src_file}"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/${VERSION}/${src_file}.asc"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/${VERSION}/${src_file}.sha512"
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not
 echo "Validating SHA512 Checksum"
@@ -46,8 +51,7 @@ if ! (sha512sum "${src_file}" | cut -d " " -f 1 | diff -Z - "${src_file}.sha512"
 fi
 
 echo "Validating signature"
-echo '--> NOTE: Make sure you have downloaded and added the KEYS file (https://www.apache.org/dist/druid/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using "curl https://archive.apache.org/dist/druid/KEYS | gpg --import")'
-
+echo "--> NOTE: Make sure you have downloaded and added the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\")"
 if ! (gpg --verify "${src_file}.asc" "${src_file}" 2> /dev/null); then
   echo "ERROR: The signature could not be verified"
   exit 1

--- a/druid/upload_new_druid_version.sh
+++ b/druid/upload_new_druid_version.sh
@@ -39,9 +39,9 @@ cd "$WORK_DIR" || exit
 src_file="apache-druid-${VERSION}-src.tar.gz"
 
 echo "Downloading Druid (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/${VERSION}/${src_file}"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/${VERSION}/${src_file}.asc"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/${VERSION}/${src_file}.sha512"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/${VERSION}/${src_file}"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/${VERSION}/${src_file}.asc"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/${VERSION}/${src_file}.sha512"
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not
 echo "Validating SHA512 Checksum"

--- a/druid/upload_new_druid_version.sh
+++ b/druid/upload_new_druid_version.sh
@@ -51,9 +51,10 @@ if ! (sha512sum "${src_file}" | cut -d " " -f 1 | diff -Z - "${src_file}.sha512"
 fi
 
 echo "Validating signature"
-echo "--> NOTE: Make sure you have downloaded and added the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\")"
 if ! (gpg --verify "${src_file}.asc" "${src_file}" 2> /dev/null); then
   echo "ERROR: The signature could not be verified"
+  echo "--> Make sure you have imported the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) into GPG: https://www.apache.org/info/verification.html"
+  echo "--> e.g. \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\""
   exit 1
 fi
 

--- a/hadoop/upload_new_hadoop_version.sh
+++ b/hadoop/upload_new_hadoop_version.sh
@@ -39,15 +39,15 @@ cd "$WORK_DIR" || exit
 bin_file=hadoop-$VERSION.tar.gz
 src_file=hadoop-$VERSION-src.tar.gz
 
-echo "Downloading Hadoop (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
+echo "Downloading Hadoop binary (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hadoop-$VERSION/$bin_file"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hadoop-$VERSION/$bin_file.asc"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hadoop-$VERSION/$bin_file.sha512"
 
+echo "Downloading Hadoop source (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hadoop-$VERSION/$src_file"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hadoop-$VERSION/$src_file.asc"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hadoop-$VERSION/$src_file.sha512"
-
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not
 echo "Validating SHA512 Checksums"

--- a/hadoop/upload_new_hadoop_version.sh
+++ b/hadoop/upload_new_hadoop_version.sh
@@ -67,13 +67,13 @@ fi
 
 echo "Uploading everything to Nexus"
 EXIT_STATUS=0
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file" 'https://repo.stackable.tech/repository/packages/hadoop/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file.asc" 'https://repo.stackable.tech/repository/packages/hadoop/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file.sha512" 'https://repo.stackable.tech/repository/packages/hadoop/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file" 'https://repo.stackable.tech/repository/packages/hadoop/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file.asc" 'https://repo.stackable.tech/repository/packages/hadoop/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file.sha512" 'https://repo.stackable.tech/repository/packages/hadoop/' || EXIT_STATUS=$?
 
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file" 'https://repo.stackable.tech/repository/packages/hadoop/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.asc" 'https://repo.stackable.tech/repository/packages/hadoop/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.sha512" 'https://repo.stackable.tech/repository/packages/hadoop/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file" 'https://repo.stackable.tech/repository/packages/hadoop/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.asc" 'https://repo.stackable.tech/repository/packages/hadoop/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.sha512" 'https://repo.stackable.tech/repository/packages/hadoop/' || EXIT_STATUS=$?
 
 if [ $EXIT_STATUS -ne 0 ]; then
   echo "ERROR: Upload failed"

--- a/hadoop/upload_new_hadoop_version.sh
+++ b/hadoop/upload_new_hadoop_version.sh
@@ -58,10 +58,10 @@ if ! (sha512sum --tag "$bin_file" | diff - "$bin_file.sha512" && sha512sum --tag
 fi
 
 echo "Validating signatures"
-echo "--> NOTE: Make sure you have downloaded and added the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\")"
-
 if ! (gpg --verify "$bin_file.asc" "$bin_file" 2> /dev/null && gpg --verify "$src_file.asc" "$src_file" 2> /dev/null); then
   echo "ERROR: One of the signatures could not be verified"
+  echo "--> Make sure you have imported the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) into GPG: https://www.apache.org/info/verification.html"
+  echo "--> e.g. \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\""
   exit 1
 fi
 

--- a/hbase/upload_new_hbase-operator-tools_version.sh
+++ b/hbase/upload_new_hbase-operator-tools_version.sh
@@ -63,9 +63,9 @@ fi
 
 echo "Uploading everything to Nexus"
 EXIT_STATUS=0
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file" 'https://repo.stackable.tech/repository/packages/hbase-operator-tools/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.asc" 'https://repo.stackable.tech/repository/packages/hbase-operator-tools/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.sha512" 'https://repo.stackable.tech/repository/packages/hbase-operator-tools/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file" 'https://repo.stackable.tech/repository/packages/hbase-operator-tools/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.asc" 'https://repo.stackable.tech/repository/packages/hbase-operator-tools/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.sha512" 'https://repo.stackable.tech/repository/packages/hbase-operator-tools/' || EXIT_STATUS=$?
 
 
 if [ $EXIT_STATUS -ne 0 ]; then

--- a/hbase/upload_new_hbase-operator-tools_version.sh
+++ b/hbase/upload_new_hbase-operator-tools_version.sh
@@ -39,9 +39,9 @@ cd "$WORK_DIR" || exit
 src_file=hbase-operator-tools-$VERSION-src.tar.gz
 
 echo "Downloading hbase-operator-tools (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/hbase-operator-tools-$VERSION/$src_file"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/hbase-operator-tools-$VERSION/$src_file.asc"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/hbase-operator-tools-$VERSION/$src_file.sha512"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hbase-operator-tools-$VERSION/$src_file"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hbase-operator-tools-$VERSION/$src_file.asc"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hbase-operator-tools-$VERSION/$src_file.sha512"
 
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not

--- a/hbase/upload_new_hbase-operator-tools_version.sh
+++ b/hbase/upload_new_hbase-operator-tools_version.sh
@@ -52,9 +52,10 @@ if ! (gpg --print-md SHA512 "$src_file" | diff - "$src_file.sha512"); then
 fi
 
 echo "Validating signatures"
-echo "--> NOTE: Make sure you have downloaded and added the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\")"
 if ! (gpg --verify "$src_file.asc" "$src_file" 2> /dev/null); then
   echo "ERROR: One of the signatures could not be verified"
+  echo "--> Make sure you have imported the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) into GPG: https://www.apache.org/info/verification.html"
+  echo "--> e.g. \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\""
   exit 1
 fi
 

--- a/hbase/upload_new_hbase-operator-tools_version.sh
+++ b/hbase/upload_new_hbase-operator-tools_version.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 VERSION=${1:?"Missing version number argument (arg 1)"}
 NEXUS_USER=${2:?"Missing Nexus username argument (arg 2)"}
 
+# We prefer fast downloads...
+BASE_DOWNLOAD_URL="https://dlcdn.apache.org/hbase"
+# However, if the version is not available, use the slow archive instead:
+# BASE_DOWNLOAD_URL="https://archive.apache.org/dist/hbase"
+
 read -r -s -p "Nexus Password: " NEXUS_PASSWORD
 echo ""
 
@@ -33,10 +38,10 @@ cd "$WORK_DIR" || exit
 
 src_file=hbase-operator-tools-$VERSION-src.tar.gz
 
-echo "Downloading hbase-operator-tools (this can take a while, it is intentionally downloading from a slow mirror that contains all old versions)"
-curl --fail -LOs "https://archive.apache.org/dist/hbase/hbase-operator-tools-$VERSION/$src_file"
-curl --fail -LOs "https://archive.apache.org/dist/hbase/hbase-operator-tools-$VERSION/$src_file.asc"
-curl --fail -LOs "https://archive.apache.org/dist/hbase/hbase-operator-tools-$VERSION/$src_file.sha512"
+echo "Downloading hbase-operator-tools (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/hbase-operator-tools-$VERSION/$src_file"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/hbase-operator-tools-$VERSION/$src_file.asc"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/hbase-operator-tools-$VERSION/$src_file.sha512"
 
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not
@@ -47,7 +52,7 @@ if ! (gpg --print-md SHA512 "$src_file" | diff - "$src_file.sha512"); then
 fi
 
 echo "Validating signatures"
-echo '--> NOTE: Make sure you have downloaded and added the KEYS file (https://downloads.apache.org/hbase/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using "curl https://downloads.apache.org/hbase/KEYS | gpg --import")'
+echo "--> NOTE: Make sure you have downloaded and added the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\")"
 if ! (gpg --verify "$src_file.asc" "$src_file" 2> /dev/null); then
   echo "ERROR: One of the signatures could not be verified"
   exit 1

--- a/hbase/upload_new_hbase-operator-tools_version.sh
+++ b/hbase/upload_new_hbase-operator-tools_version.sh
@@ -38,11 +38,10 @@ cd "$WORK_DIR" || exit
 
 src_file=hbase-operator-tools-$VERSION-src.tar.gz
 
-echo "Downloading hbase-operator-tools (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
+echo "Downloading hbase-operator-tools source (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hbase-operator-tools-$VERSION/$src_file"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hbase-operator-tools-$VERSION/$src_file.asc"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hbase-operator-tools-$VERSION/$src_file.sha512"
-
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not
 echo "Validating SHA512 Checksums"

--- a/hbase/upload_new_hbase_version.sh
+++ b/hbase/upload_new_hbase_version.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 VERSION=${1:?"Missing version number argument (arg 1)"}
 NEXUS_USER=${2:?"Missing Nexus username argument (arg 2)"}
 
+# We prefer fast downloads...
+BASE_DOWNLOAD_URL="https://dlcdn.apache.org/hbase"
+# However, if the version is not available, use the slow archive instead:
+# BASE_DOWNLOAD_URL="https://archive.apache.org/dist/hbase"
+
 read -r -s -p "Nexus Password: " NEXUS_PASSWORD
 echo ""
 
@@ -33,11 +38,10 @@ cd "$WORK_DIR" || exit
 
 src_file=hbase-$VERSION-src.tar.gz
 
-echo "Downloading HBase source (this can take a while, it is intentionally downloading from a slow mirror that contains all old versions)"
-curl --fail -LOs "https://archive.apache.org/dist/hbase/$VERSION/$src_file"
-curl --fail -LOs "https://archive.apache.org/dist/hbase/$VERSION/$src_file.asc"
-curl --fail -LOs "https://archive.apache.org/dist/hbase/$VERSION/$src_file.sha512"
-
+echo "Downloading HBase source (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/$src_file"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/$src_file.asc"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/$src_file.sha512"
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not
 echo "Validating SHA512 Checksums"
@@ -47,7 +51,7 @@ if ! (gpg --print-md SHA512 "$src_file" | diff - "$src_file.sha512"); then
 fi
 
 echo "Validating signatures"
-echo '--> NOTE: Make sure you have downloaded and added the KEYS file (https://downloads.apache.org/hbase/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using "curl https://downloads.apache.org/hbase/KEYS | gpg --import")'
+echo "--> NOTE: Make sure you have downloaded and added the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\")"
 if ! (gpg --verify "$src_file.asc" "$src_file" 2> /dev/null); then
   echo "ERROR: One of the signatures could not be verified"
   exit 1

--- a/hbase/upload_new_hbase_version.sh
+++ b/hbase/upload_new_hbase_version.sh
@@ -51,9 +51,10 @@ if ! (gpg --print-md SHA512 "$src_file" | diff - "$src_file.sha512"); then
 fi
 
 echo "Validating signatures"
-echo "--> NOTE: Make sure you have downloaded and added the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\")"
 if ! (gpg --verify "$src_file.asc" "$src_file" 2> /dev/null); then
   echo "ERROR: One of the signatures could not be verified"
+  echo "--> Make sure you have imported the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) into GPG: https://www.apache.org/info/verification.html"
+  echo "--> e.g. \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\""
   exit 1
 fi
 

--- a/hbase/upload_new_hbase_version.sh
+++ b/hbase/upload_new_hbase_version.sh
@@ -39,9 +39,9 @@ cd "$WORK_DIR" || exit
 src_file=hbase-$VERSION-src.tar.gz
 
 echo "Downloading HBase source (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/$src_file"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/$src_file.asc"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/$src_file.sha512"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/$VERSION/$src_file"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/$VERSION/$src_file.asc"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/$VERSION/$src_file.sha512"
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not
 echo "Validating SHA512 Checksums"

--- a/hbase/upload_new_hbase_version.sh
+++ b/hbase/upload_new_hbase_version.sh
@@ -60,9 +60,9 @@ fi
 
 echo "Uploading everything to Nexus"
 EXIT_STATUS=0
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file" 'https://repo.stackable.tech/repository/packages/hbase/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.asc" 'https://repo.stackable.tech/repository/packages/hbase/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.sha512" 'https://repo.stackable.tech/repository/packages/hbase/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file" 'https://repo.stackable.tech/repository/packages/hbase/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.asc" 'https://repo.stackable.tech/repository/packages/hbase/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.sha512" 'https://repo.stackable.tech/repository/packages/hbase/' || EXIT_STATUS=$?
 
 if [ $EXIT_STATUS -ne 0 ]; then
   echo "ERROR: Upload failed"

--- a/hbase/upload_new_phoenix_version.sh
+++ b/hbase/upload_new_phoenix_version.sh
@@ -63,9 +63,9 @@ fi
 
 echo "Uploading everything to Nexus"
 EXIT_STATUS=0
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file" 'https://repo.stackable.tech/repository/packages/phoenix/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.asc" 'https://repo.stackable.tech/repository/packages/phoenix/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.sha512" 'https://repo.stackable.tech/repository/packages/phoenix/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file" 'https://repo.stackable.tech/repository/packages/phoenix/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.asc" 'https://repo.stackable.tech/repository/packages/phoenix/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.sha512" 'https://repo.stackable.tech/repository/packages/phoenix/' || EXIT_STATUS=$?
 
 
 if [ $EXIT_STATUS -ne 0 ]; then

--- a/hbase/upload_new_phoenix_version.sh
+++ b/hbase/upload_new_phoenix_version.sh
@@ -52,9 +52,10 @@ if ! (gpg --print-md SHA512 "$src_file" | diff - "$src_file.sha512"); then
 fi
 
 echo "Validating signatures"
-echo "--> NOTE: Make sure you have downloaded and added the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\")"
 if ! (gpg --verify "$src_file.asc" "$src_file" 2> /dev/null); then
   echo "ERROR: One of the signatures could not be verified"
+  echo "--> Make sure you have imported the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) into GPG: https://www.apache.org/info/verification.html"
+  echo "--> e.g. \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\""
   exit 1
 fi
 

--- a/hbase/upload_new_phoenix_version.sh
+++ b/hbase/upload_new_phoenix_version.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 VERSION=${1:?"Missing version number argument (arg 1)"}
 NEXUS_USER=${2:?"Missing Nexus username argument (arg 2)"}
 
+# We prefer fast downloads...
+BASE_DOWNLOAD_URL="https://dlcdn.apache.org/phoenix"
+# However, if the version is not available, use the slow archive instead:
+# BASE_DOWNLOAD_URL="https://archive.apache.org/dist/phoenix"
+
 read -r -s -p "Nexus Password: " NEXUS_PASSWORD
 echo ""
 
@@ -33,10 +38,10 @@ cd "$WORK_DIR" || exit
 
 src_file=phoenix-$VERSION-src.tar.gz
 
-echo "Downloading phoenix (this can take a while, it is intentionally downloading from a slow mirror that contains all old versions)"
-curl --fail -LOs "https://archive.apache.org/dist/phoenix/phoenix-$VERSION/$src_file"
-curl --fail -LOs "https://archive.apache.org/dist/phoenix/phoenix-$VERSION/$src_file.asc"
-curl --fail -LOs "https://archive.apache.org/dist/phoenix/phoenix-$VERSION/$src_file.sha512"
+echo "Downloading phoenix (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/phoenix-$VERSION/$src_file"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/phoenix-$VERSION/$src_file.asc"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/phoenix-$VERSION/$src_file.sha512"
 
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not
@@ -47,7 +52,7 @@ if ! (gpg --print-md SHA512 "$src_file" | diff - "$src_file.sha512"); then
 fi
 
 echo "Validating signatures"
-echo '--> NOTE: Make sure you have downloaded and added the KEYS file (https://downloads.apache.org/phoenix/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using "curl https://downloads.apache.org/phoenix/KEYS | gpg --import")'
+echo "--> NOTE: Make sure you have downloaded and added the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\")"
 if ! (gpg --verify "$src_file.asc" "$src_file" 2> /dev/null); then
   echo "ERROR: One of the signatures could not be verified"
   exit 1

--- a/hbase/upload_new_phoenix_version.sh
+++ b/hbase/upload_new_phoenix_version.sh
@@ -39,9 +39,9 @@ cd "$WORK_DIR" || exit
 src_file=phoenix-$VERSION-src.tar.gz
 
 echo "Downloading phoenix (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/phoenix-$VERSION/$src_file"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/phoenix-$VERSION/$src_file.asc"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/phoenix-$VERSION/$src_file.sha512"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/phoenix-$VERSION/$src_file"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/phoenix-$VERSION/$src_file.asc"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/phoenix-$VERSION/$src_file.sha512"
 
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not

--- a/hbase/upload_new_phoenix_version.sh
+++ b/hbase/upload_new_phoenix_version.sh
@@ -38,11 +38,10 @@ cd "$WORK_DIR" || exit
 
 src_file=phoenix-$VERSION-src.tar.gz
 
-echo "Downloading phoenix (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
+echo "Downloading phoenix source (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/phoenix-$VERSION/$src_file"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/phoenix-$VERSION/$src_file.asc"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/phoenix-$VERSION/$src_file.sha512"
-
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not
 echo "Validating SHA512 Checksums"

--- a/hive/upload_new_hive_version.sh
+++ b/hive/upload_new_hive_version.sh
@@ -39,16 +39,15 @@ cd "$WORK_DIR" || exit
 bin_file="apache-hive-${VERSION}-bin.tar.gz"
 src_file="apache-hive-$VERSION-src.tar.gz"
 
-echo "Downloading Hive Binary (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
+echo "Downloading Hive binary (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${bin_file}"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${bin_file}.asc"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${bin_file}.sha256"
 
-echo "Downloading Hive Source (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
+echo "Downloading Hive source (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${src_file}"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${src_file}.asc"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${src_file}.sha256"
-
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not
 echo "Validating SHA256 Checksums"

--- a/hive/upload_new_hive_version.sh
+++ b/hive/upload_new_hive_version.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 VERSION=${1:?"Missing version number argument (arg 1)"}
 NEXUS_USER=${2:?"Missing Nexus username argument (arg 2)"}
 
+# We prefer fast downloads...
+BASE_DOWNLOAD_URL="https://dlcdn.apache.org/hive"
+# However, if the version is not available, use the slow archive instead:
+# BASE_DOWNLOAD_URL="https://archive.apache.org/dist/hive"
+
 read -r -s -p "Nexus Password: " NEXUS_PASSWORD
 echo ""
 
@@ -34,15 +39,15 @@ cd "$WORK_DIR" || exit
 bin_file="apache-hive-${VERSION}-bin.tar.gz"
 src_file="apache-hive-$VERSION-src.tar.gz"
 
-echo "Downloading Hive (this can take a while, it is intentionally downloading from a slow mirror that contains all old versions)"
-curl --fail -LOs "https://dlcdn.apache.org/hive/hive-${VERSION}/${bin_file}"
-curl --fail -LOs "https://dlcdn.apache.org/hive/hive-${VERSION}/${bin_file}.asc"
-curl --fail -LOs "https://dlcdn.apache.org/hive/hive-${VERSION}/${bin_file}.sha256"
+echo "Downloading Hive (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${bin_file}"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${bin_file}.asc"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${bin_file}.sha256"
 
-echo "Downloading Hive (this can take a while, it is intentionally downloading from a slow mirror that contains all old versions)"
-curl --fail -LOs "https://dlcdn.apache.org/hive/hive-${VERSION}/${src_file}"
-curl --fail -LOs "https://dlcdn.apache.org/hive/hive-${VERSION}/${src_file}.asc"
-curl --fail -LOs "https://dlcdn.apache.org/hive/hive-${VERSION}/${src_file}.sha256"
+echo "Downloading Hive (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${src_file}"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${src_file}.asc"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${src_file}.sha256"
 
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not
@@ -53,8 +58,7 @@ if ! (sha256sum "${bin_file}" | diff - "${bin_file}.sha256" && sha256sum "${src_
 fi
 
 echo "Validating signatures"
-echo '--> NOTE: Make sure you have downloaded and added the KEYS file (https://dlcdn.apache.org/hive/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using "curl https://dlcdn.apache.org/hive/KEYS | gpg --import")'
-
+echo "--> NOTE: Make sure you have downloaded and added the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\")"
 if ! (gpg --verify "$bin_file.asc" "$bin_file" 2> /dev/null &&  gpg --verify "$src_file.asc" "$src_file" 2> /dev/null); then
   echo "ERROR: Signature could not be verified"
   exit 1

--- a/hive/upload_new_hive_version.sh
+++ b/hive/upload_new_hive_version.sh
@@ -58,9 +58,10 @@ if ! (sha256sum "${bin_file}" | diff - "${bin_file}.sha256" && sha256sum "${src_
 fi
 
 echo "Validating signatures"
-echo "--> NOTE: Make sure you have downloaded and added the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\")"
 if ! (gpg --verify "$bin_file.asc" "$bin_file" 2> /dev/null &&  gpg --verify "$src_file.asc" "$src_file" 2> /dev/null); then
   echo "ERROR: Signature could not be verified"
+  echo "--> Make sure you have imported the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) into GPG: https://www.apache.org/info/verification.html"
+  echo "--> e.g. \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\""
   exit 1
 fi
 

--- a/hive/upload_new_hive_version.sh
+++ b/hive/upload_new_hive_version.sh
@@ -40,14 +40,14 @@ bin_file="apache-hive-${VERSION}-bin.tar.gz"
 src_file="apache-hive-$VERSION-src.tar.gz"
 
 echo "Downloading Hive (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${bin_file}"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${bin_file}.asc"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${bin_file}.sha256"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${bin_file}"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${bin_file}.asc"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${bin_file}.sha256"
 
 echo "Downloading Hive (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${src_file}"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${src_file}.asc"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${src_file}.sha256"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${src_file}"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${src_file}.asc"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${src_file}.sha256"
 
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not

--- a/hive/upload_new_hive_version.sh
+++ b/hive/upload_new_hive_version.sh
@@ -67,13 +67,13 @@ fi
 
 echo "Uploading everything to Nexus"
 EXIT_STATUS=0
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file" 'https://repo.stackable.tech/repository/packages/hive/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file.asc" 'https://repo.stackable.tech/repository/packages/hive/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file.sha256" 'https://repo.stackable.tech/repository/packages/hive/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file" 'https://repo.stackable.tech/repository/packages/hive/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file.asc" 'https://repo.stackable.tech/repository/packages/hive/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file.sha256" 'https://repo.stackable.tech/repository/packages/hive/' || EXIT_STATUS=$?
 
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file" 'https://repo.stackable.tech/repository/packages/hive/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.asc" 'https://repo.stackable.tech/repository/packages/hive/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.sha256" 'https://repo.stackable.tech/repository/packages/hive/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file" 'https://repo.stackable.tech/repository/packages/hive/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.asc" 'https://repo.stackable.tech/repository/packages/hive/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.sha256" 'https://repo.stackable.tech/repository/packages/hive/' || EXIT_STATUS=$?
 
 
 if [ $EXIT_STATUS -ne 0 ]; then

--- a/hive/upload_new_hive_version.sh
+++ b/hive/upload_new_hive_version.sh
@@ -39,12 +39,12 @@ cd "$WORK_DIR" || exit
 bin_file="apache-hive-${VERSION}-bin.tar.gz"
 src_file="apache-hive-$VERSION-src.tar.gz"
 
-echo "Downloading Hive (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
+echo "Downloading Hive Binary (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${bin_file}"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${bin_file}.asc"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${bin_file}.sha256"
 
-echo "Downloading Hive (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
+echo "Downloading Hive Source (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${src_file}"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${src_file}.asc"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/hive-${VERSION}/${src_file}.sha256"

--- a/kafka/upload_new_kafka_version.sh
+++ b/kafka/upload_new_kafka_version.sh
@@ -40,13 +40,13 @@ bin_file=kafka_2.13-$VERSION.tgz
 src_file=kafka-$VERSION-src.tgz
 
 echo "Downloading Kafka (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/$bin_file"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/$bin_file.asc"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/$bin_file.sha512"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/$VERSION/$bin_file"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/$VERSION/$bin_file.asc"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/$VERSION/$bin_file.sha512"
 
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/$src_file"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/$src_file.asc"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/$src_file.sha512"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/$VERSION/$src_file"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/$VERSION/$src_file.asc"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/$VERSION/$src_file.sha512"
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not
 echo "Validating SHA512 Checksum"

--- a/kafka/upload_new_kafka_version.sh
+++ b/kafka/upload_new_kafka_version.sh
@@ -65,13 +65,13 @@ fi
 
 echo "Uploading everything to Nexus"
 EXIT_STATUS=0
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file" 'https://repo.stackable.tech/repository/packages/kafka/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file.asc" 'https://repo.stackable.tech/repository/packages/kafka/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file.sha512" 'https://repo.stackable.tech/repository/packages/kafka/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file" 'https://repo.stackable.tech/repository/packages/kafka/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file.asc" 'https://repo.stackable.tech/repository/packages/kafka/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file.sha512" 'https://repo.stackable.tech/repository/packages/kafka/' || EXIT_STATUS=$?
 
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file" 'https://repo.stackable.tech/repository/packages/kafka/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.asc" 'https://repo.stackable.tech/repository/packages/kafka/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.sha512" 'https://repo.stackable.tech/repository/packages/kafka/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file" 'https://repo.stackable.tech/repository/packages/kafka/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.asc" 'https://repo.stackable.tech/repository/packages/kafka/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.sha512" 'https://repo.stackable.tech/repository/packages/kafka/' || EXIT_STATUS=$?
 
 if [ $EXIT_STATUS -ne 0 ]; then
   echo "ERROR: Upload failed"

--- a/kafka/upload_new_kafka_version.sh
+++ b/kafka/upload_new_kafka_version.sh
@@ -56,10 +56,10 @@ if ! (gpg --print-md SHA512 "$bin_file" | diff - "$bin_file.sha512" && gpg --pri
 fi
 
 echo "Validating signatures"
-echo "--> NOTE: Make sure you have downloaded and added the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\")"
-
 if ! (gpg --verify "$bin_file.asc" "$bin_file" 2> /dev/null && gpg --verify "$src_file.asc" "$src_file" 2> /dev/null); then
   echo "ERROR: One of the signatures could not be verified"
+  echo "--> Make sure you have imported the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) into GPG: https://www.apache.org/info/verification.html"
+  echo "--> e.g. \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\""
   exit 1
 fi
 

--- a/kafka/upload_new_kafka_version.sh
+++ b/kafka/upload_new_kafka_version.sh
@@ -39,11 +39,12 @@ cd "$WORK_DIR" || exit
 bin_file=kafka_2.13-$VERSION.tgz
 src_file=kafka-$VERSION-src.tgz
 
-echo "Downloading Kafka (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
+echo "Downloading Kafka binary (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/$VERSION/$bin_file"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/$VERSION/$bin_file.asc"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/$VERSION/$bin_file.sha512"
 
+echo "Downloading Kafka source (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/$VERSION/$src_file"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/$VERSION/$src_file.asc"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/$VERSION/$src_file.sha512"

--- a/kafka/upload_new_kafka_version.sh
+++ b/kafka/upload_new_kafka_version.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 VERSION=${1:?"Missing version number argument (arg 1)"}
 NEXUS_USER=${2:?"Missing Nexus username argument (arg 2)"}
 
+# We prefer fast downloads...
+BASE_DOWNLOAD_URL="https://dlcdn.apache.org/kafka"
+# However, if the version is not available, use the slow archive instead:
+# BASE_DOWNLOAD_URL="https://archive.apache.org/dist/kafka"
+
 read -r -s -p "Nexus Password: " NEXUS_PASSWORD
 echo ""
 
@@ -34,14 +39,14 @@ cd "$WORK_DIR" || exit
 bin_file=kafka_2.13-$VERSION.tgz
 src_file=kafka-$VERSION-src.tgz
 
-echo "Downloading Kafka (this can take a while, it is intentionally downloading from a slow mirror that contains all old versions)"
-curl --fail -LOs "https://archive.apache.org/dist/kafka/$VERSION/$bin_file"
-curl --fail -LOs "https://archive.apache.org/dist/kafka/$VERSION/$bin_file.asc"
-curl --fail -LOs "https://archive.apache.org/dist/kafka/$VERSION/$bin_file.sha512"
+echo "Downloading Kafka (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/$bin_file"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/$bin_file.asc"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/$bin_file.sha512"
 
-curl --fail -LOs "https://archive.apache.org/dist/kafka/$VERSION/$src_file"
-curl --fail -LOs "https://archive.apache.org/dist/kafka/$VERSION/$src_file.asc"
-curl --fail -LOs "https://archive.apache.org/dist/kafka/$VERSION/$src_file.sha512"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/$src_file"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/$src_file.asc"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/$src_file.sha512"
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not
 echo "Validating SHA512 Checksum"
@@ -51,7 +56,7 @@ if ! (gpg --print-md SHA512 "$bin_file" | diff - "$bin_file.sha512" && gpg --pri
 fi
 
 echo "Validating signatures"
-echo '--> NOTE: Make sure you have downloaded and added the KEYS file (https://downloads.apache.org/kafka/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using "curl https://downloads.apache.org/kafka/KEYS | gpg --import")'
+echo "--> NOTE: Make sure you have downloaded and added the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\")"
 
 if ! (gpg --verify "$bin_file.asc" "$bin_file" 2> /dev/null && gpg --verify "$src_file.asc" "$src_file" 2> /dev/null); then
   echo "ERROR: One of the signatures could not be verified"

--- a/nifi/upload_new_nifi_version.sh
+++ b/nifi/upload_new_nifi_version.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 VERSION=${1:?"Missing version number argument (arg 1)"}
 NEXUS_USER=${2:?"Missing Nexus username argument (arg 2)"}
 
+# We prefer fast downloads...
+BASE_DOWNLOAD_URL="https://dlcdn.apache.org/nifi"
+# However, if the version is not available, use the slow archive instead:
+# BASE_DOWNLOAD_URL="https://archive.apache.org/dist/nifi"
+
 read -r -s -p "Nexus Password: " NEXUS_PASSWORD
 echo ""
 
@@ -32,12 +37,11 @@ trap cleanup EXIT
 cd "$WORK_DIR" || exit
 
 src_file="nifi-$VERSION-source-release.zip"
-download_url="https://archive.apache.org/dist/nifi/${VERSION}"
 
-echo "Downloading NiFi source (this can take a while, it is intentionally downloading from a slow mirror that contains all old versions)"
-curl --fail -LOs "${download_url}/${src_file}"
-curl --fail -LOs "${download_url}/${src_file}.asc"
-curl --fail -LOs "${download_url}/${src_file}.sha512"
+echo "Downloading NiFi source (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/${src_file}"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/${src_file}.asc"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/${src_file}.sha512"
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not
 echo "Validating SHA512 Checksums"
@@ -51,7 +55,7 @@ if ! (sha512sum "$src_file" | cut -d ' ' -f 1 | diff - <(echo -e "$(<"${src_file
 fi
 
 echo "Validating signatures"
-echo '--> NOTE: Make sure you have downloaded and added the KEYS file (https://archive.apache.org/dist/nifi/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using "curl https://archive.apache.org/dist/nifi/KEYS | gpg --import")'
+echo "--> NOTE: Make sure you have downloaded and added the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\")"
 
 if ! (gpg --verify "$src_file.asc" "$src_file" 2> /dev/null); then
   echo "ERROR: One of the signatures could not be verified"

--- a/nifi/upload_new_nifi_version.sh
+++ b/nifi/upload_new_nifi_version.sh
@@ -39,9 +39,9 @@ cd "$WORK_DIR" || exit
 src_file="nifi-$VERSION-source-release.zip"
 
 echo "Downloading NiFi source (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/${src_file}"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/${src_file}.asc"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/$VERSION/${src_file}.sha512"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/$VERSION/${src_file}"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/$VERSION/${src_file}.asc"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/$VERSION/${src_file}.sha512"
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not
 echo "Validating SHA512 Checksums"

--- a/nifi/upload_new_nifi_version.sh
+++ b/nifi/upload_new_nifi_version.sh
@@ -55,10 +55,10 @@ if ! (sha512sum "$src_file" | cut -d ' ' -f 1 | diff - <(echo -e "$(<"${src_file
 fi
 
 echo "Validating signatures"
-echo "--> NOTE: Make sure you have downloaded and added the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\")"
-
 if ! (gpg --verify "$src_file.asc" "$src_file" 2> /dev/null); then
   echo "ERROR: One of the signatures could not be verified"
+  echo "--> Make sure you have imported the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) into GPG: https://www.apache.org/info/verification.html"
+  echo "--> e.g. \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\""
   exit 1
 fi
 

--- a/nifi/upload_new_nifi_version.sh
+++ b/nifi/upload_new_nifi_version.sh
@@ -64,9 +64,9 @@ fi
 
 echo "Uploading everything to Nexus"
 EXIT_STATUS=0
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}" 'https://repo.stackable.tech/repository/packages/nifi/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}.asc" 'https://repo.stackable.tech/repository/packages/nifi/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}.sha512" 'https://repo.stackable.tech/repository/packages/nifi/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}" 'https://repo.stackable.tech/repository/packages/nifi/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}.asc" 'https://repo.stackable.tech/repository/packages/nifi/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}.sha512" 'https://repo.stackable.tech/repository/packages/nifi/' || EXIT_STATUS=$?
 
 if [ $EXIT_STATUS -ne 0 ]; then
   echo "ERROR: Upload failed"

--- a/omid/upload_new_omid_version.sh
+++ b/omid/upload_new_omid_version.sh
@@ -38,9 +38,9 @@ cd "$WORK_DIR" || exit
 src_file=phoenix-omid-$VERSION-src.tar.gz
 
 echo "Downloading Omid (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/phoenix-omid-${VERSION}/${src_file}"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/phoenix-omid-$VERSION/$src_file.asc"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/phoenix-omid-$VERSION/$src_file.sha512"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/phoenix-omid-${VERSION}/${src_file}"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/phoenix-omid-$VERSION/$src_file.asc"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/phoenix-omid-$VERSION/$src_file.sha512"
 
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not

--- a/omid/upload_new_omid_version.sh
+++ b/omid/upload_new_omid_version.sh
@@ -37,11 +37,10 @@ trap cleanup EXIT
 cd "$WORK_DIR" || exit
 src_file=phoenix-omid-$VERSION-src.tar.gz
 
-echo "Downloading Omid (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
+echo "Downloading Omid source (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/phoenix-omid-${VERSION}/${src_file}"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/phoenix-omid-$VERSION/$src_file.asc"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/phoenix-omid-$VERSION/$src_file.sha512"
-
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not
 echo "Validating SHA512 Checksums"

--- a/omid/upload_new_omid_version.sh
+++ b/omid/upload_new_omid_version.sh
@@ -51,9 +51,10 @@ if ! (gpg --print-md SHA512 "$src_file" | diff - "$src_file.sha512"); then
 fi
 
 echo "Validating signatures"
-echo "--> NOTE: Make sure you have downloaded and added the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\")"
 if ! (gpg --verify "$src_file.asc" "$src_file" 2> /dev/null); then
   echo "ERROR: One of the signatures could not be verified"
+  echo "--> Make sure you have imported the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) into GPG: https://www.apache.org/info/verification.html"
+  echo "--> e.g. \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\""
   exit 1
 fi
 

--- a/omid/upload_new_omid_version.sh
+++ b/omid/upload_new_omid_version.sh
@@ -60,9 +60,9 @@ fi
 
 echo "Uploading everything to Nexus"
 EXIT_STATUS=0
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file" 'https://repo.stackable.tech/repository/packages/omid/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.asc" 'https://repo.stackable.tech/repository/packages/omid/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.sha512" 'https://repo.stackable.tech/repository/packages/omid/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file" 'https://repo.stackable.tech/repository/packages/omid/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.asc" 'https://repo.stackable.tech/repository/packages/omid/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.sha512" 'https://repo.stackable.tech/repository/packages/omid/' || EXIT_STATUS=$?
 
 if [ $EXIT_STATUS -ne 0 ]; then
   echo "ERROR: Upload failed"

--- a/opa/upload_new_opa_version.sh
+++ b/opa/upload_new_opa_version.sh
@@ -40,7 +40,7 @@ curl --fail -L -o "${tar_gz_file}" "${download_url}"
 
 echo "Uploading OPA source to Nexus"
 EXIT_STATUS=0
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${tar_gz_file}" 'https://repo.stackable.tech/repository/packages/opa/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${tar_gz_file}" 'https://repo.stackable.tech/repository/packages/opa/' || EXIT_STATUS=$?
 
 if [ $EXIT_STATUS -ne 0 ]; then
   echo "ERROR: Upload failed"

--- a/spark-k8s/upload_new_hbase-connector_version.sh
+++ b/spark-k8s/upload_new_hbase-connector_version.sh
@@ -40,7 +40,7 @@ curl --fail -L -o "${tar_gz_file}" "${download_url}"
 
 echo "Uploading hbase-connectors source to Nexus"
 EXIT_STATUS=0
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${tar_gz_file}" 'https://repo.stackable.tech/repository/packages/hbase-connectors/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${tar_gz_file}" 'https://repo.stackable.tech/repository/packages/hbase-connectors/' || EXIT_STATUS=$?
 
 if [ $EXIT_STATUS -ne 0 ]; then
   echo "ERROR: Upload failed"

--- a/spark-k8s/upload_new_spark_version.sh
+++ b/spark-k8s/upload_new_spark_version.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 VERSION=${1:?"Missing version number argument (arg 1)"}
 NEXUS_USER=${2:?"Missing Nexus username argument (arg 2)"}
 
+# We prefer fast downloads...
+BASE_DOWNLOAD_URL="https://dlcdn.apache.org/spark"
+# However, if the version is not available, use the slow archive instead:
+# BASE_DOWNLOAD_URL="https://archive.apache.org/dist/spark"
+
 read -r -s -p "Nexus Password: " NEXUS_PASSWORD
 echo ""
 
@@ -33,10 +38,10 @@ cd "$WORK_DIR" || exit
 
 src_file="spark-${VERSION}.tgz"
 
-echo "Downloading Spark (this can take a while, it is intentionally downloading from a slow mirror that contains all old versions)"
-curl --fail -LOs "https://archive.apache.org/dist/spark/spark-${VERSION}/${src_file}"
-curl --fail -LOs "https://archive.apache.org/dist/spark/spark-${VERSION}/${src_file}.asc"
-curl --fail -LOs "https://archive.apache.org/dist/spark/spark-${VERSION}/${src_file}.sha512"
+echo "Downloading Spark (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/spark-${VERSION}/${src_file}"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/spark-${VERSION}/${src_file}.asc"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/spark-${VERSION}/${src_file}.sha512"
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not
 echo "Validating SHA512 Checksum"
@@ -46,7 +51,7 @@ if ! (sha512sum "${src_file}" | diff - "${src_file}.sha512"); then
 fi
 
 echo "Validating signature"
-echo '--> NOTE: Make sure you have downloaded and added the KEYS file (https://archive.apache.org/dist/spark/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using "curl https://archive.apache.org/dist/spark/KEYS | gpg --import")'
+echo "--> NOTE: Make sure you have downloaded and added the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\")"
 
 if ! (gpg --verify "${src_file}.asc" "${src_file}" 2>/dev/null); then
   echo "ERROR: The signature could not be verified"

--- a/spark-k8s/upload_new_spark_version.sh
+++ b/spark-k8s/upload_new_spark_version.sh
@@ -39,9 +39,9 @@ cd "$WORK_DIR" || exit
 src_file="spark-${VERSION}.tgz"
 
 echo "Downloading Spark (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/spark-${VERSION}/${src_file}"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/spark-${VERSION}/${src_file}.asc"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/spark-${VERSION}/${src_file}.sha512"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/spark-${VERSION}/${src_file}"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/spark-${VERSION}/${src_file}.asc"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/spark-${VERSION}/${src_file}.sha512"
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not
 echo "Validating SHA512 Checksum"

--- a/spark-k8s/upload_new_spark_version.sh
+++ b/spark-k8s/upload_new_spark_version.sh
@@ -60,9 +60,9 @@ fi
 
 echo "Uploading everything to Nexus"
 EXIT_STATUS=0
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}" 'https://repo.stackable.tech/repository/packages/spark/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}.asc" 'https://repo.stackable.tech/repository/packages/spark/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}.sha512" 'https://repo.stackable.tech/repository/packages/spark/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}" 'https://repo.stackable.tech/repository/packages/spark/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}.asc" 'https://repo.stackable.tech/repository/packages/spark/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}.sha512" 'https://repo.stackable.tech/repository/packages/spark/' || EXIT_STATUS=$?
 
 if [ $EXIT_STATUS -ne 0 ]; then
   echo "ERROR: Upload failed"

--- a/spark-k8s/upload_new_spark_version.sh
+++ b/spark-k8s/upload_new_spark_version.sh
@@ -38,7 +38,7 @@ cd "$WORK_DIR" || exit
 
 src_file="spark-${VERSION}.tgz"
 
-echo "Downloading Spark (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
+echo "Downloading Spark source (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/spark-${VERSION}/${src_file}"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/spark-${VERSION}/${src_file}.asc"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/spark-${VERSION}/${src_file}.sha512"

--- a/spark-k8s/upload_new_spark_version.sh
+++ b/spark-k8s/upload_new_spark_version.sh
@@ -51,10 +51,10 @@ if ! (sha512sum "${src_file}" | diff - "${src_file}.sha512"); then
 fi
 
 echo "Validating signature"
-echo "--> NOTE: Make sure you have downloaded and added the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\")"
-
 if ! (gpg --verify "${src_file}.asc" "${src_file}" 2>/dev/null); then
   echo "ERROR: The signature could not be verified"
+  echo "--> Make sure you have imported the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) into GPG: https://www.apache.org/info/verification.html"
+  echo "--> e.g. \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\""
   exit 1
 fi
 

--- a/statsd_exporter/upload_new_statsd_exporter_version.sh
+++ b/statsd_exporter/upload_new_statsd_exporter_version.sh
@@ -35,7 +35,7 @@ echo "Downloading STATSD EXPORTER source code"
 curl --fail -LO --progress-bar "https://github.com/prometheus/statsd_exporter/archive/refs/tags/v$VERSION.tar.gz" && mv "v$VERSION.tar.gz" "statsd_exporter-$VERSION.src.tar.gz"
 
 echo "Uploading to Nexus"
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "statsd_exporter-$VERSION.src.tar.gz" 'https://repo.stackable.tech/repository/packages/statsd_exporter/'
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "statsd_exporter-$VERSION.src.tar.gz" 'https://repo.stackable.tech/repository/packages/statsd_exporter/'
 
 echo "Successfully uploaded new version of STATSD-EXPORTER source code ($VERSION) to Nexus"
 echo "https://repo.stackable.tech/service/rest/repository/browse/packages/statsd_exporter/"

--- a/statsd_exporter/upload_new_statsd_exporter_version.sh
+++ b/statsd_exporter/upload_new_statsd_exporter_version.sh
@@ -32,7 +32,7 @@ trap cleanup EXIT
 cd "$WORK_DIR" || exit
 
 echo "Downloading STATSD EXPORTER source code"
-curl --fail -LOs "https://github.com/prometheus/statsd_exporter/archive/refs/tags/v$VERSION.tar.gz" && mv "v$VERSION.tar.gz" "statsd_exporter-$VERSION.src.tar.gz"
+curl --fail -LO --progress-bar "https://github.com/prometheus/statsd_exporter/archive/refs/tags/v$VERSION.tar.gz" && mv "v$VERSION.tar.gz" "statsd_exporter-$VERSION.src.tar.gz"
 
 echo "Uploading to Nexus"
 curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "statsd_exporter-$VERSION.src.tar.gz" 'https://repo.stackable.tech/repository/packages/statsd_exporter/'

--- a/trino-cli/upload_new_trino_version.sh
+++ b/trino-cli/upload_new_trino_version.sh
@@ -34,9 +34,9 @@ cd "$WORK_DIR" || exit
 bin_file=trino-cli-${VERSION}-executable.jar
 
 echo "Downloading Trino (this can take a while, it is intentionally downloading from a slow mirror that contains all old versions)"
-curl --fail -LOs "https://repo1.maven.org/maven2/io/trino/trino-cli/${VERSION}/${bin_file}"
-curl --fail -LOs "https://repo1.maven.org/maven2/io/trino/trino-cli/${VERSION}/${bin_file}.asc"
-curl --fail -LOs "https://repo1.maven.org/maven2/io/trino/trino-cli/${VERSION}/${bin_file}.sha1"
+curl --fail -LO --progress-bar "https://repo1.maven.org/maven2/io/trino/trino-cli/${VERSION}/${bin_file}"
+curl --fail -LO --progress-bar "https://repo1.maven.org/maven2/io/trino/trino-cli/${VERSION}/${bin_file}.asc"
+curl --fail -LO --progress-bar "https://repo1.maven.org/maven2/io/trino/trino-cli/${VERSION}/${bin_file}.sha1"
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not
 echo "Validating SHA1 Checksum"

--- a/trino-cli/upload_new_trino_version.sh
+++ b/trino-cli/upload_new_trino_version.sh
@@ -89,9 +89,9 @@ fi
 
 echo "Uploading everything to Nexus"
 EXIT_STATUS=0
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${bin_file}" 'https://repo.stackable.tech/repository/packages/trino-cli/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${bin_file}.asc" 'https://repo.stackable.tech/repository/packages/trino-cli/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${bin_file}.sha1" 'https://repo.stackable.tech/repository/packages/trino-cli/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${bin_file}" 'https://repo.stackable.tech/repository/packages/trino-cli/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${bin_file}.asc" 'https://repo.stackable.tech/repository/packages/trino-cli/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${bin_file}.sha1" 'https://repo.stackable.tech/repository/packages/trino-cli/' || EXIT_STATUS=$?
 
 if [ $EXIT_STATUS -ne 0 ]; then
   echo "ERROR: Upload failed"

--- a/trino-storage-connector/upload_new_trino_storage_connector_version.sh
+++ b/trino-storage-connector/upload_new_trino_storage_connector_version.sh
@@ -43,8 +43,8 @@ sha256sum "${src_file}" | cut --delimiter=' ' --field=1 > "${src_file}.sha256"
 
 echo "Uploading everything to Nexus"
 EXIT_STATUS=0
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}" 'https://repo.stackable.tech/repository/packages/trino-storage/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}.sha256" 'https://repo.stackable.tech/repository/packages/trino-storage/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}" 'https://repo.stackable.tech/repository/packages/trino-storage/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}.sha256" 'https://repo.stackable.tech/repository/packages/trino-storage/' || EXIT_STATUS=$?
 
 if [ $EXIT_STATUS -ne 0 ]; then
   echo "ERROR: Upload failed"

--- a/trino/upload_new_trino_version.sh
+++ b/trino/upload_new_trino_version.sh
@@ -43,8 +43,8 @@ sha256sum "${src_file}" | cut --delimiter=' ' --field=1 > "${src_file}.sha256"
 
 echo "Uploading everything to Nexus"
 EXIT_STATUS=0
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}" 'https://repo.stackable.tech/repository/packages/trino-server/' || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}.sha256" 'https://repo.stackable.tech/repository/packages/trino-server/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}" 'https://repo.stackable.tech/repository/packages/trino-server/' || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "${src_file}.sha256" 'https://repo.stackable.tech/repository/packages/trino-server/' || EXIT_STATUS=$?
 
 if [ $EXIT_STATUS -ne 0 ]; then
   echo "ERROR: Upload failed"

--- a/vector/upload_new_vector_version.sh
+++ b/vector/upload_new_vector_version.sh
@@ -32,11 +32,6 @@ for arch in "${ARCHITECTURES[@]}"; do
         "https://yum.vector.dev/stable/vector-$major_version/$arch/$file"
 
     echo "Validating signature"
-    echo "--> NOTE: Make sure you have downloaded and added Datadog's \
-public key (https://keys.datadoghq.com/DATADOG_RPM_KEY_B01082D3.public) \
-to the RPM package database:
-rpmkeys --import --dbpath $RPM_PACKAGE_DB_PATH DATADOG_APT_KEY_CURRENT.public"
-
     EXIT_STATUS=0
     # `rpmkeys --checksig` also succeeds if the digests of an unsigned
     # package are okay. Therefore, test explicitly if the output
@@ -50,6 +45,10 @@ rpmkeys --import --dbpath $RPM_PACKAGE_DB_PATH DATADOG_APT_KEY_CURRENT.public"
         EXIT_STATUS=$?
     if [ $EXIT_STATUS -ne 0 ]; then
       echo "ERROR: The signature could not be verified."
+    echo "--> NOTE: Make sure you have downloaded and added Datadog's \
+public key (https://keys.datadoghq.com/DATADOG_RPM_KEY_B01082D3.public) \
+to the RPM package database:
+rpmkeys --import --dbpath $RPM_PACKAGE_DB_PATH DATADOG_APT_KEY_CURRENT.public"
       exit 1
     fi
 

--- a/vector/upload_new_vector_version.sh
+++ b/vector/upload_new_vector_version.sh
@@ -53,7 +53,7 @@ rpmkeys --import --dbpath $RPM_PACKAGE_DB_PATH DATADOG_APT_KEY_CURRENT.public"
     fi
 
     echo "Uploading $file to Nexus"
-    curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" \
+    curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" \
         --upload-file "$file" \
         'https://repo.stackable.tech/repository/packages/vector/'
 

--- a/zookeeper/upload_new_zookeeper_version.sh
+++ b/zookeeper/upload_new_zookeeper_version.sh
@@ -40,14 +40,14 @@ bin_file=apache-zookeeper-$VERSION-bin.tar.gz
 src_file=apache-zookeeper-$VERSION.tar.gz
 
 echo "Downloading ZooKeeper (this can take a while, it is intentionally downloading from a slow mirror that contains all old versions)"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$bin_file"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$bin_file.asc"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$bin_file.sha512"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$bin_file"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$bin_file.asc"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$bin_file.sha512"
 
 echo "Downloading ZooKeeper sources (this can take a while, it is intentionally downloading from a slow mirror that contains all old versions)"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$src_file"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$src_file.asc"
-curl --fail -LOs "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$src_file.sha512"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$src_file"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$src_file.asc"
+curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$src_file.sha512"
 
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not

--- a/zookeeper/upload_new_zookeeper_version.sh
+++ b/zookeeper/upload_new_zookeeper_version.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 VERSION=${1:?"Missing version number argument (arg 1)"}
 NEXUS_USER=${2:?"Missing Nexus username argument (arg 2)"}
 
+# We prefer fast downloads...
+BASE_DOWNLOAD_URL="https://dlcdn.apache.org/zookeeper"
+# However, if the version is not available, use the slow archive instead:
+# BASE_DOWNLOAD_URL="https://archive.apache.org/dist/zookeeper"
+
 read -r -s -p "Nexus Password: " NEXUS_PASSWORD
 echo ""
 
@@ -33,17 +38,16 @@ cd "$WORK_DIR" || exit
 
 bin_file=apache-zookeeper-$VERSION-bin.tar.gz
 src_file=apache-zookeeper-$VERSION.tar.gz
-download_url=https://archive.apache.org/dist/zookeeper
 
 echo "Downloading ZooKeeper (this can take a while, it is intentionally downloading from a slow mirror that contains all old versions)"
-curl --fail -LOs "$download_url/zookeeper-$VERSION/$bin_file"
-curl --fail -LOs "$download_url/zookeeper-$VERSION/$bin_file.asc"
-curl --fail -LOs "$download_url/zookeeper-$VERSION/$bin_file.sha512"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$bin_file"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$bin_file.asc"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$bin_file.sha512"
 
 echo "Downloading ZooKeeper sources (this can take a while, it is intentionally downloading from a slow mirror that contains all old versions)"
-curl --fail -LOs "$download_url/zookeeper-$VERSION/$src_file"
-curl --fail -LOs "$download_url/zookeeper-$VERSION/$src_file.asc"
-curl --fail -LOs "$download_url/zookeeper-$VERSION/$src_file.sha512"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$src_file"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$src_file.asc"
+curl --fail -LOs "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$src_file.sha512"
 
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not

--- a/zookeeper/upload_new_zookeeper_version.sh
+++ b/zookeeper/upload_new_zookeeper_version.sh
@@ -39,16 +39,15 @@ cd "$WORK_DIR" || exit
 bin_file=apache-zookeeper-$VERSION-bin.tar.gz
 src_file=apache-zookeeper-$VERSION.tar.gz
 
-echo "Downloading ZooKeeper (this can take a while, it is intentionally downloading from a slow mirror that contains all old versions)"
+echo "Downloading ZooKeeper binary (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$bin_file"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$bin_file.asc"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$bin_file.sha512"
 
-echo "Downloading ZooKeeper sources (this can take a while, it is intentionally downloading from a slow mirror that contains all old versions)"
+echo "Downloading ZooKeeper source (if this fails, try switching the BASE_DOWNLOAD_URL to the archive)"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$src_file"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$src_file.asc"
 curl --fail -LO --progress-bar "${BASE_DOWNLOAD_URL}/zookeeper-$VERSION/$src_file.sha512"
-
 
 # It is probably redundant to check both the checksum and the signature but it's cheap and why not
 echo "Validating SHA512 Checksums for binary releases"

--- a/zookeeper/upload_new_zookeeper_version.sh
+++ b/zookeeper/upload_new_zookeeper_version.sh
@@ -63,17 +63,19 @@ if ! (sha512sum "$src_file" | diff -Z - "$src_file.sha512"); then
 fi
 
 echo "Validating signatures for binary releases"
-echo '--> NOTE: Make sure you have downloaded and added the KEYS file (https://archive.apache.org/dist/zookeeper/KEYS) to GPG: https://www.apache.org/info/verification.html (e.g. by using "curl https://archive.apache.org/dist/zookeeper/KEYS | gpg --import")'
-
 if ! (gpg --verify "$bin_file.asc" "$bin_file" 2> /dev/null); then
   echo "ERROR: One of the signatures could not be verified for a binary release"
+  echo "--> Make sure you have imported the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) into GPG: https://www.apache.org/info/verification.html"
+  echo "--> e.g. \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\""
   exit 1
 fi
 
 echo "Validating signatures for source releases"
 if ! (gpg --verify "$src_file.asc" "$src_file" 2> /dev/null); then
-   echo "ERROR: One of the signatures could not be verified for a source release"
-   exit 1
+  echo "ERROR: One of the signatures could not be verified for a source release"
+  echo "--> Make sure you have imported the KEYS file (${BASE_DOWNLOAD_URL}/KEYS) into GPG: https://www.apache.org/info/verification.html"
+  echo "--> e.g. \"curl ${BASE_DOWNLOAD_URL}/KEYS | gpg --import\""
+  exit 1
 fi
 
 echo "Uploading everything to Nexus"

--- a/zookeeper/upload_new_zookeeper_version.sh
+++ b/zookeeper/upload_new_zookeeper_version.sh
@@ -82,13 +82,13 @@ echo "Uploading everything to Nexus"
 EXIT_STATUS=0
 repo_url=https://repo.stackable.tech/repository/packages/zookeeper/
 
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file" "$repo_url" || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file.asc" "$repo_url" || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file.sha512" "$repo_url" || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file" "$repo_url" || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file.asc" "$repo_url" || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$bin_file.sha512" "$repo_url" || EXIT_STATUS=$?
 
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file" "$repo_url" || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.asc" "$repo_url" || EXIT_STATUS=$?
-curl --fail -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.sha512" "$repo_url" || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file" "$repo_url" || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.asc" "$repo_url" || EXIT_STATUS=$?
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$src_file.sha512" "$repo_url" || EXIT_STATUS=$?
 
 if [ $EXIT_STATUS -ne 0 ]; then
   echo "ERROR: Upload failed"


### PR DESCRIPTION
# Description

> [!NOTE]
> This came out of the [25.3.0 Release Retro](https://github.com/stackabletech/issues/issues/694).
>
> I did not add a flag as was discussed in the retro, but I believe the help text for switching URLs is easy enough.

- Use fast download mirrors (help text is emitted so that the user can change the `BASE_DOWNLOAD_URL` to the archive URL for example.
- Add a download/upload progress-bar since this is run by people.
- Only emit GPG key warning/help if the verification failed.
