### PR TITLE
chore(⏲): Add missing tool update tasks to templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-product.md
+++ b/.github/ISSUE_TEMPLATE/add-product.md
@@ -10,8 +10,8 @@ projects: ['stackabletech/10']
 assignees: ''
 ---
 
-```[tasklist]
-### Tasks
+## Tasks
+
 - [ ] Create a new top-level folder for the product. The name of the folder must
       use the lowercase product name.
 - [ ] Create a README.md file outlining special considerations required to
@@ -24,7 +24,6 @@ assignees: ''
       `.github/workflows` folder. Use existing local action whenever possible
       or consider creating a new one when there is no fitting action available.
 - [ ] Run `.scripts/update_readme_badges.sh` to generate the new status badge.
-```
 
 _Please consider updating this template if these instructions are wrong, or
 could be made clearer._

--- a/.github/ISSUE_TEMPLATE/early-pre-release.md
+++ b/.github/ISSUE_TEMPLATE/early-pre-release.md
@@ -58,3 +58,6 @@ Part of stackabletech/issues#xxx.
 - [ ] tools
 - [ ] testing-tools
 - [ ] statsd_exporter
+- [ ] cyclonedx-bom (pip)
+- [ ] cargo-cyclonedx (Look for: `CARGO_CYCLONEDX_CRATE_VERSION`)
+- [ ] cargo-auditable (Look for: `CARGO_AUDITABLE_CRATE_VERSION`)

--- a/.github/ISSUE_TEMPLATE/early-pre-release.md
+++ b/.github/ISSUE_TEMPLATE/early-pre-release.md
@@ -14,49 +14,47 @@ assignees: ''
 <!-- Update this with the parent tracking issue for the release -->
 Part of stackabletech/issues#xxx.
 
-## Container Image Updates for Stackable Release XX.(X)X
-
 > [!NOTE]
 > Update the product versions based on what has been decided upon in the _Product Spreadsheet[^1]_.
 
 [^1]: Currently this is a private spreadsheet
 
-Replace the items in the task lists below with the subsequent tracking issue.
+> [!IMPORTANT]
+> Replace the items in the task lists below with the subsequent tracking issue.
+
+## Product Container Images
 
 <!--
     Find templates for bases/products:
 
     find .github/ISSUE_TEMPLATE/update-*.md -printf "%f\n" \
     | sort \
-    | xargs -I {} echo "- [ ] https://github.com/stackabletech/docker-images/issues/new?template={}"
+    | xargs -I {} echo "- [ ] [Create issue from template: {}](https://github.com/stackabletech/docker-images/issues/new?template={})"
 -->
 
 <!-- todo: consider removing the ubi*-rust-builder from the release process. -->
-```[tasklist]
-### Product Container Images
-- [ ] https://github.com/stackabletech/docker-images/issues/new?template=update-base-java.md
-- [ ] https://github.com/stackabletech/docker-images/issues/new?template=update-base-stackable.md
-- [ ] https://github.com/stackabletech/docker-images/issues/new?template=update-base-ubi-rust-builders.md
-- [ ] https://github.com/stackabletech/docker-images/issues/new?template=update-base-vector.md
-- [ ] https://github.com/stackabletech/docker-images/issues/new?template=update-product-airflow.md
-- [ ] https://github.com/stackabletech/docker-images/issues/new?template=update-product-druid.md
-- [ ] https://github.com/stackabletech/docker-images/issues/new?template=update-product-hbase-phoenix-omid.md
-- [ ] https://github.com/stackabletech/docker-images/issues/new?template=update-product-hdfs.md
-- [ ] https://github.com/stackabletech/docker-images/issues/new?template=update-product-hive.md
-- [ ] https://github.com/stackabletech/docker-images/issues/new?template=update-product-kafka.md
-- [ ] https://github.com/stackabletech/docker-images/issues/new?template=update-product-nifi.md
-- [ ] https://github.com/stackabletech/docker-images/issues/new?template=update-product-opa.md
-- [ ] https://github.com/stackabletech/docker-images/issues/new?template=update-product-spark.md
-- [ ] https://github.com/stackabletech/docker-images/issues/new?template=update-product-superset.md
-- [ ] https://github.com/stackabletech/docker-images/issues/new?template=update-product-trino.md
-- [ ] https://github.com/stackabletech/docker-images/issues/new?template=update-product-zookeeper.md
-```
 
-```[tasklist]
-### Additional items which don't have a tracking issue
+- [ ] [Create issue from template: update-base-java.md](https://github.com/stackabletech/docker-images/issues/new?template=update-base-java.md)
+- [ ] [Create issue from template: update-base-stackable.md](https://github.com/stackabletech/docker-images/issues/new?template=update-base-stackable.md)
+- [ ] [Create issue from template: update-base-ubi-rust-builders.md](https://github.com/stackabletech/docker-images/issues/new?template=update-base-ubi-rust-builders.md)
+- [ ] [Create issue from template: update-base-vector.md](https://github.com/stackabletech/docker-images/issues/new?template=update-base-vector.md)
+- [ ] [Create issue from template: update-product-airflow.md](https://github.com/stackabletech/docker-images/issues/new?template=update-product-airflow.md)
+- [ ] [Create issue from template: update-product-druid.md](https://github.com/stackabletech/docker-images/issues/new?template=update-product-druid.md)
+- [ ] [Create issue from template: update-product-hbase-phoenix-omid.md](https://github.com/stackabletech/docker-images/issues/new?template=update-product-hbase-phoenix-omid.md)
+- [ ] [Create issue from template: update-product-hdfs.md](https://github.com/stackabletech/docker-images/issues/new?template=update-product-hdfs.md)
+- [ ] [Create issue from template: update-product-hive.md](https://github.com/stackabletech/docker-images/issues/new?template=update-product-hive.md)
+- [ ] [Create issue from template: update-product-kafka.md](https://github.com/stackabletech/docker-images/issues/new?template=update-product-kafka.md)
+- [ ] [Create issue from template: update-product-nifi.md](https://github.com/stackabletech/docker-images/issues/new?template=update-product-nifi.md)
+- [ ] [Create issue from template: update-product-opa.md](https://github.com/stackabletech/docker-images/issues/new?template=update-product-opa.md)
+- [ ] [Create issue from template: update-product-spark.md](https://github.com/stackabletech/docker-images/issues/new?template=update-product-spark.md)
+- [ ] [Create issue from template: update-product-superset.md](https://github.com/stackabletech/docker-images/issues/new?template=update-product-superset.md)
+- [ ] [Create issue from template: update-product-trino.md](https://github.com/stackabletech/docker-images/issues/new?template=update-product-trino.md)
+- [ ] [Create issue from template: update-product-zookeeper.md](https://github.com/stackabletech/docker-images/issues/new?template=update-product-zookeeper.md)
+
+## Additional items which don't have a tracking issue
+
 - [ ] hello-world
 - [ ] krb5
 - [ ] tools
 - [ ] testing-tools
 - [ ] statsd_exporter
-```

--- a/.github/ISSUE_TEMPLATE/early-pre-release.md
+++ b/.github/ISSUE_TEMPLATE/early-pre-release.md
@@ -1,7 +1,7 @@
 ---
 name: Early Pre-Release Container Image Updates
 about: This template can be used to track the container image updates leading up to the next Stackable release
-title: "chore: Update Container Images for Stackable Release XX.(X)X"
+title: "chore: Update Container Images for Stackable Release YY.M.X"
 labels: ['epic']
 assignees: ''
 ---

--- a/.github/ISSUE_TEMPLATE/update-base-java.md
+++ b/.github/ISSUE_TEMPLATE/update-base-java.md
@@ -39,25 +39,24 @@ we should also make new versions of Java available for use.
 > term `openjdk-headless`.
 > _It isn't perfect, as it will depend on what is available via microdnf._
 
-```[tasklist]
-### Update tasks
+## Update tasks
+
 - [ ] Add any new versions of java to both `java-base/versions.py` and `java-devel/versions.py`
 - [ ] Remove versions when there are no long any references (eg: `grep java- **/versions.py | grep "1.8.0"`)
-```
 
-```[tasklist]
-### Related Pull Requests
+## Related Pull Requests
+
 - [ ] _Link to the docker-images PR (product update)_
-```
 
-This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+## Acceptance
 
-```[tasklist]
-### Acceptance
+> [!TIP]
+> This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been
+> checked, the issue can be moved into _Development: Done_.
+
 - [ ] Can build a product image that uses the new version(s)
 - [ ] Both `java-base` and `java-devel` have the same Java versions in `versions.py`
 - [ ] Kuttl smoke test passes locally for a product using the new Java version
-```
 
 <details>
 <summary>Testing instructions</summary>

--- a/.github/ISSUE_TEMPLATE/update-base-java.md
+++ b/.github/ISSUE_TEMPLATE/update-base-java.md
@@ -4,7 +4,7 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(java-bases): Update container images ahead of Stackable Release XX.(X)X
+  chore(java-bases): Update container images ahead of Stackable Release YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']

--- a/.github/ISSUE_TEMPLATE/update-base-stackable.md
+++ b/.github/ISSUE_TEMPLATE/update-base-stackable.md
@@ -4,7 +4,7 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(stackable-base): Update container images ahead of Stackable Release XX.(X)X
+  chore(stackable-base): Update container images ahead of Stackable Release YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']

--- a/.github/ISSUE_TEMPLATE/update-base-stackable.md
+++ b/.github/ISSUE_TEMPLATE/update-base-stackable.md
@@ -25,28 +25,27 @@ Add/Change/Remove anything that isn't applicable anymore
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 
-```[tasklist]
-### Update tasks
+## Update tasks
+
 - [ ] Update UBI version hash in the Dockerfile (`FROM`)
 - [ ] Update `RUST_DEFAULT_TOOLCHAIN_VERSION`
 - [ ] Update `CARGO_CYCLONEDX_CRATE_VERSION`
 - [ ] Update `CARGO_AUDITABLE_CRATE_VERSION`
 - [ ] Update `PROTOC_VERSION`
 - [ ] Update `CONFIG_UTILS_VERSION`
-```
 
-```[tasklist]
-### Related Pull Requests
+## Related Pull Requests
+
 - [ ] _Link to the docker-images PR (product update)_
-```
 
-This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+## Acceptance
 
-```[tasklist]
-### Acceptance
+> [!TIP]
+> This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been
+> checked, the issue can be moved into _Development: Done_.
+
 - [ ] Can build the image locally
 - [ ] Can build the vector image
-```
 
 <details>
 <summary>Testing instructions</summary>

--- a/.github/ISSUE_TEMPLATE/update-base-ubi-rust-builders.md
+++ b/.github/ISSUE_TEMPLATE/update-base-ubi-rust-builders.md
@@ -31,31 +31,30 @@ Add/Change/Remove anything that isn't applicable anymore
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 
-```[tasklist]
-### Update tasks
+## Update tasks
+
 - [ ] Update UBI version hash in the Dockerfile (`FROM`)
 - [ ] Update `RUST_DEFAULT_TOOLCHAIN_VERSION`
 - [ ] Update `CARGO_CYCLONEDX_CRATE_VERSION`
 - [ ] Update `CARGO_AUDITABLE_CRATE_VERSION`
 - [ ] Update `PROTOC_VERSION`
-```
 
-```[tasklist]
-### Related Pull Requests
+## Related Pull Requests
+
 - [ ] _Link to the docker-images PR (product update)_
 - [ ] _Bump rust toolchain in operator-rs_
 - [ ] _Bump rust toolchain in operator-templating_
-```
 
-This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+## Acceptance
 
-```[tasklist]
-### Acceptance
+> [!TIP]
+> This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been
+> checked, the issue can be moved into _Development: Done_.
+
 - Done for [ubi8-rust-builder/Dockerfile](https://github.com/stackabletech/docker-images/blob/main/ubi8-rust-builder/Dockerfile)
 - Done for [ubi9-rust-builder/Dockerfile](https://github.com/stackabletech/docker-images/blob/main/ubi9-rust-builder/Dockerfile)
 - [ ] Can build the image locally
 - [ ] Can build an operator image
-```
 
 <details>
 <summary>Testing instructions</summary>

--- a/.github/ISSUE_TEMPLATE/update-base-ubi-rust-builders.md
+++ b/.github/ISSUE_TEMPLATE/update-base-ubi-rust-builders.md
@@ -4,7 +4,7 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(ubi-rust-builders): Update container images ahead of Stackable Release XX.(X)X
+  chore(ubi-rust-builders): Update container images ahead of Stackable Release YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']

--- a/.github/ISSUE_TEMPLATE/update-base-vector.md
+++ b/.github/ISSUE_TEMPLATE/update-base-vector.md
@@ -4,7 +4,7 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(vector): Update container images ahead of Stackable Release XX.(X)X
+  chore(vector): Update container images ahead of Stackable Release YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']

--- a/.github/ISSUE_TEMPLATE/update-base-vector.md
+++ b/.github/ISSUE_TEMPLATE/update-base-vector.md
@@ -31,8 +31,8 @@ Add/Change/Remove anything that isn't applicable anymore
 > - Uses [stackable-base](https://github.com/stackabletech/docker-images/blob/main/stackable-base/Dockerfile).
 > - Used as a base for [java-base](https://github.com/stackabletech/docker-images/blob/main/java-base/Dockerfile).
 
-```[tasklist]
-### Update tasks
+## Update tasks
+
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet (including the removal of old versions).
 - [ ] Update all `versions.py` files which reference vector.
 - [ ] Upload new version (see `vector/upload_new_vector_version.sh`).
@@ -40,31 +40,30 @@ Add/Change/Remove anything that isn't applicable anymore
 - [ ] Update other dependencies if applicable (eg: inotify_tools, etc).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
 - [ ] Update the version in demos. Add the PR(s) to the list below.
-```
 
-```[tasklist]
-### Related Pull Requests
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
-```
+## Related Pull Requests
 
 > [!TIP]
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+- [ ] _Link to the docker-images PR (product update)_
+- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
+- [ ] _Link to any other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (raise against the `main` branch)_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
-```[tasklist]
-### Acceptance
+## Acceptance
+
+> [!TIP]
+> This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been
+> checked, the issue can be moved into _Development: Done_.
+
 - [ ] Can build image (either locally, or in CI)
 - [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
-```
 
 <details>
 <summary>Testing instructions</summary>

--- a/.github/ISSUE_TEMPLATE/update-product-airflow.md
+++ b/.github/ISSUE_TEMPLATE/update-product-airflow.md
@@ -4,7 +4,7 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(airflow): Update container images ahead of Stackable Release XX.(X)X
+  chore(airflow): Update container images ahead of Stackable Release YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']

--- a/.github/ISSUE_TEMPLATE/update-product-airflow.md
+++ b/.github/ISSUE_TEMPLATE/update-product-airflow.md
@@ -25,38 +25,37 @@ Add/Change/Remove anything that isn't applicable anymore
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 
-```[tasklist]
-### Update tasks
+## Update tasks
+
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet (including the removal of old versions).
 - [ ] Download new constraints file (see `airflow/download_constraints.sh`).
 - [ ] Update other dependencies if applicable (eg: python, statsd_exporter, etc).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
 - [ ] Update the version in demos. Add the PR(s) to the list below.
-```
 
-```[tasklist]
-### Related Pull Requests
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to operator PR (getting_started / kuttl)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
-```
+## Related Pull Requests
 
 > [!TIP]
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+- [ ] _Link to the docker-images PR (product update)_
+- [ ] _Link to operator PR (getting_started / kuttl)_
+- [ ] _Link to any other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (raise against the `main` branch)_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
-```[tasklist]
-### Acceptance
+## Acceptance
+
+> [!TIP]
+> This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been
+> checked, the issue can be moved into _Development: Done_.
+
 - [ ] Can build image (either locally, or in CI)
 - [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
-```
 
 <details>
 <summary>Testing instructions</summary>

--- a/.github/ISSUE_TEMPLATE/update-product-druid.md
+++ b/.github/ISSUE_TEMPLATE/update-product-druid.md
@@ -4,7 +4,7 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(druid): Update container images ahead of Stackable Release XX.(X)X
+  chore(druid): Update container images ahead of Stackable Release YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']

--- a/.github/ISSUE_TEMPLATE/update-product-druid.md
+++ b/.github/ISSUE_TEMPLATE/update-product-druid.md
@@ -25,8 +25,8 @@ Add/Change/Remove anything that isn't applicable anymore
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 
-```[tasklist]
-### Update tasks
+## Update tasks
+
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet (including the removal of old versions).
 - [ ] Upload new version (see `druid/upload_new_druid_version.sh`).
 - [ ] Create a file: `druid/stackable/patches/x.y.z/.gitkeep`, add patches if applicable.
@@ -35,32 +35,31 @@ Add/Change/Remove anything that isn't applicable anymore
 - [ ] Update the [druid-opa-authorizer](https://github.com/stackabletech/druid-opa-authorizer/) with the new set of versions.
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
 - [ ] Update the version in demos. Add the PR(s) to the list below.
-```
 
-```[tasklist]
-### Related Pull Requests
+## Related Pull Requests
+
+> [!TIP]
+> Delete any items that do not apply so that all applicable items can be checked.
+> For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
+
 - [ ] _Link to the docker-images PR (product update)_
 - [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
 - [ ] _Link to any other operator PRs (getting_started / kuttl)_
 - [ ] _Link to demo PR (raise against the `main` branch)_
 - [ ] _Link to [druid-opa-authorizer](https://github.com/stackabletech/druid-opa-authorizer/) PR_
 - [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
-```
+
+## Acceptance
 
 > [!TIP]
-> Delete any items that do not apply so that all applicable items can be checked.
-> For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
+> This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been
+> checked, the issue can be moved into _Development: Done_.
 
-This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
-
-```[tasklist]
-### Acceptance
 - [ ] Can build image (either locally, or in CI)
 - [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
-```
 
 <details>
 <summary>Testing instructions</summary>

--- a/.github/ISSUE_TEMPLATE/update-product-hbase-phoenix-omid.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hbase-phoenix-omid.md
@@ -25,46 +25,46 @@ Add/Change/Remove anything that isn't applicable anymore
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 
-```[tasklist]
-### Update tasks (HBase, Phoenix)
+## Update tasks
+
+### HBase and Phoenix
+
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet (including the removal of old versions).
 - [ ] Upload new versions (see the `hbase/*.sh` scripts).
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
 - [ ] Update other dependencies if applicable (eg: phoenix, opa_authorizer, etc).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR to the list below.
-```
 
-```[tasklist]
-### Update tasks (Omid)
+### Omid
+
 - [ ] Update `omid/versions.py`to reflect the agreed upon versions in the spreadsheet (including the removal of old versions).
 - [ ] Upload new version (see `omid/upload_new_omid_version.sh`).
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
 - [ ] Update other dependencies if applicable (eg: jmx_exporter, etc).
-```
 
-```[tasklist]
-### Related Pull Requests
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to operator PR (getting_started / kuttl)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
-```
+## Related Pull Requests
 
 > [!TIP]
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+- [ ] _Link to the docker-images PR (product update)_
+- [ ] _Link to operator PR (getting_started / kuttl)_
+- [ ] _Link to any other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (raise against the `main` branch)_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
-```[tasklist]
-### Acceptance
+## Acceptance
+
+> [!TIP]
+> This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been
+> checked, the issue can be moved into _Development: Done_.
+
 - [ ] Can build image (either locally, or in CI)
 - [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
-```
 
 <details>
 <summary>Testing instructions</summary>

--- a/.github/ISSUE_TEMPLATE/update-product-hbase-phoenix-omid.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hbase-phoenix-omid.md
@@ -4,7 +4,7 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(hbase-phoenix-omid): Update container images ahead of Stackable Release XX.(X)X
+  chore(hbase-phoenix-omid): Update container images ahead of Stackable Release YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']

--- a/.github/ISSUE_TEMPLATE/update-product-hdfs.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hdfs.md
@@ -4,7 +4,7 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(hdfs): Update container images ahead of Stackable Release XX.(X)X
+  chore(hdfs): Update container images ahead of Stackable Release YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']

--- a/.github/ISSUE_TEMPLATE/update-product-hdfs.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hdfs.md
@@ -25,40 +25,39 @@ Add/Change/Remove anything that isn't applicable anymore
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 
-```[tasklist]
-### Update tasks
+## Update tasks
+
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet (including the removal of old versions).
 - [ ] Upload new version (see `hadoop/upload_new_hadoop_version.sh`).
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
 - [ ] Update other dependencies if applicable (eg: hdfs_utils, jmx_exporter, protobuf, etc).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
 - [ ] Update the version in demos. Add the PR(s) to the list below.
-```
 
-```[tasklist]
-### Related Pull Requests
+## Related Pull Requests
+
+> [!TIP]
+> Delete any items that do not apply so that all applicable items can be checked.
+> For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
+
 - [ ] _Link to the docker-images PR (product update)_
 - [ ] _Link to [hdfs-utils](https://github.com/stackabletech/hdfs-utils/) PR (if applicable)_
 - [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
 - [ ] _Link to any other operator PRs (getting_started / kuttl)_
 - [ ] _Link to demo PR (raise against the `main` branch)_
 - [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
-```
+
+## Acceptance
 
 > [!TIP]
-> Delete any items that do not apply so that all applicable items can be checked.
-> For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
+> This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been
+> checked, the issue can be moved into _Development: Done_.
 
-This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
-
-```[tasklist]
-### Acceptance
 - [ ] Can build image (either locally, or in CI)
 - [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
-```
 
 <details>
 <summary>Testing instructions</summary>

--- a/.github/ISSUE_TEMPLATE/update-product-hive.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hive.md
@@ -4,7 +4,7 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(hive): Update container images ahead of Stackable Release XX.(X)X
+  chore(hive): Update container images ahead of Stackable Release YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']

--- a/.github/ISSUE_TEMPLATE/update-product-hive.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hive.md
@@ -25,39 +25,38 @@ Add/Change/Remove anything that isn't applicable anymore
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 
-```[tasklist]
-### Update tasks
+## Update tasks
+
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet (including the removal of old versions).
 - [ ] Upload new version (see `hive/upload_new_hive_version.sh`).
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
 - [ ] Update other dependencies if applicable (eg: jmx_exporter, aws_java_sdk_bundle, etc).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
 - [ ] Update the version in demos. Add the PR(s) to the list below.
-```
 
-```[tasklist]
-### Related Pull Requests
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
-```
+## Related Pull Requests
 
 > [!TIP]
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+- [ ] _Link to the docker-images PR (product update)_
+- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
+- [ ] _Link to any other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (raise against the `main` branch)_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
-```[tasklist]
-### Acceptance
+## Acceptance
+
+> [!TIP]
+> This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been
+> checked, the issue can be moved into _Development: Done_.
+
 - [ ] Can build image (either locally, or in CI)
 - [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
-```
 
 <details>
 <summary>Testing instructions</summary>

--- a/.github/ISSUE_TEMPLATE/update-product-kafka.md
+++ b/.github/ISSUE_TEMPLATE/update-product-kafka.md
@@ -4,7 +4,7 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(kafka): Update container images ahead of Stackable Release XX.(X)X
+  chore(kafka): Update container images ahead of Stackable Release YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']

--- a/.github/ISSUE_TEMPLATE/update-product-kafka.md
+++ b/.github/ISSUE_TEMPLATE/update-product-kafka.md
@@ -25,50 +25,51 @@ Add/Change/Remove anything that isn't applicable anymore
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 
-```[tasklist]
-### Update tasks (kafka)
+## Update tasks
+
+### Kafka
+
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet (including the removal of old versions).
 - [ ] Upload new version (see `kafka/upload_new_kafka_version.sh`).
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
 - [ ] Update other dependencies if applicable (eg: jmx_exporter, kcat, scala, etc).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
 - [ ] Update the version in demos. Add the PR(s) to the list below.
-```
+
+### kcat and kafka-testing-tools
 
 <!-- todo: ensure this is the correct procedure -->
-```[tasklist]
-### Update tasks (kcat and kafka-testing-tools)
+
 - [ ] Update `kcat/versions.py`.
 - [ ] Update `kafka-testing-tools/versions.py`.
 - [ ] Upload new version (see `.scripts/upload_new_kcat_version.sh`).
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
 - [ ] Update the version in demos. Add the PR(s) to the list below.
-```
 
-```[tasklist]
-### Related Pull Requests
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
-```
+## Related Pull Requests
 
 > [!TIP]
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+- [ ] _Link to the docker-images PR (product update)_
+- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
+- [ ] _Link to any other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (raise against the `main` branch)_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
-```[tasklist]
-### Acceptance
+## Acceptance
+
+> [!TIP]
+> This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been
+> checked, the issue can be moved into _Development: Done_.
+
 - [ ] Can build image (either locally, or in CI)
 - [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
-```
 
 <details>
 <summary>Testing instructions</summary>

--- a/.github/ISSUE_TEMPLATE/update-product-nifi.md
+++ b/.github/ISSUE_TEMPLATE/update-product-nifi.md
@@ -4,7 +4,7 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(nifi): Update container images ahead of Stackable Release XX.(X)X
+  chore(nifi): Update container images ahead of Stackable Release YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']

--- a/.github/ISSUE_TEMPLATE/update-product-nifi.md
+++ b/.github/ISSUE_TEMPLATE/update-product-nifi.md
@@ -25,39 +25,38 @@ Add/Change/Remove anything that isn't applicable anymore
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 
-```[tasklist]
-### Update tasks
+## Update tasks
+
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet (including the removal of old versions).
 - [ ] Upload new version (see `nifi/upload_new_nifi_version.sh`).
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
 - [ ] Update other dependencies if applicable (eg: jmx_exporter, kcat, scala, etc).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
 - [ ] Update the version in demos. Add the PR(s) to the list below.
-```
 
-```[tasklist]
-### Related Pull Requests
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
-```
+## Related Pull Requests
 
 > [!TIP]
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+- [ ] _Link to the docker-images PR (product update)_
+- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
+- [ ] _Link to any other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (raise against the `main` branch)_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
-```[tasklist]
-### Acceptance
+## Acceptance
+
+> [!TIP]
+> This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been
+> checked, the issue can be moved into _Development: Done_.
+
 - [ ] Can build image (either locally, or in CI)
 - [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
-```
 
 <details>
 <summary>Testing instructions</summary>

--- a/.github/ISSUE_TEMPLATE/update-product-opa.md
+++ b/.github/ISSUE_TEMPLATE/update-product-opa.md
@@ -4,7 +4,7 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(opa): Update container images ahead of Stackable Release XX.(X)X
+  chore(opa): Update container images ahead of Stackable Release YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']

--- a/.github/ISSUE_TEMPLATE/update-product-opa.md
+++ b/.github/ISSUE_TEMPLATE/update-product-opa.md
@@ -25,38 +25,37 @@ Add/Change/Remove anything that isn't applicable anymore
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 
-```[tasklist]
-### Update tasks
+## Update tasks
+
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet (including the removal of old versions).
 - [ ] Upload new version (see `opa/upload_new_opa_version.sh`).
 - [ ] Update other dependencies if applicable (eg: opa_bundle_builder, etc).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
 - [ ] Update the version in demos. Add the PR(s) to the list below.
-```
 
-```[tasklist]
-### Related Pull Requests
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
-```
+## Related Pull Requests
 
 > [!TIP]
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+- [ ] _Link to the docker-images PR (product update)_
+- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
+- [ ] _Link to any other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (raise against the `main` branch)_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
-```[tasklist]
-### Acceptance
+## Acceptance
+
+> [!TIP]
+> This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been
+> checked, the issue can be moved into _Development: Done_.
+
 - [ ] Can build image (either locally, or in CI)
 - [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
-```
 
 <details>
 <summary>Testing instructions</summary>

--- a/.github/ISSUE_TEMPLATE/update-product-spark.md
+++ b/.github/ISSUE_TEMPLATE/update-product-spark.md
@@ -25,8 +25,8 @@ Add/Change/Remove anything that isn't applicable anymore
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 
-```[tasklist]
-### Update tasks
+## Update tasks
+
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet (including the removal of old versions).
 - [ ] Upload new version (see `spark/upload_new_spark_version.sh`).
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
@@ -34,31 +34,30 @@ Add/Change/Remove anything that isn't applicable anymore
 - [ ] Update other dependencies if applicable (eg: python, jmx_exporter, aws_java_sdk_bundle, etc).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
 - [ ] Update the version in demos. Add the PR(s) to the list below.
-```
 
-```[tasklist]
-### Related Pull Requests
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
-```
+## Related Pull Requests
 
 > [!TIP]
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+- [ ] _Link to the docker-images PR (product update)_
+- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
+- [ ] _Link to any other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (raise against the `main` branch)_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
-```[tasklist]
-### Acceptance
+## Acceptance
+
+> [!TIP]
+> This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been
+> checked, the issue can be moved into _Development: Done_.
+
 - [ ] Can build image (either locally, or in CI)
 - [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
-```
 
 <details>
 <summary>Testing instructions</summary>

--- a/.github/ISSUE_TEMPLATE/update-product-spark.md
+++ b/.github/ISSUE_TEMPLATE/update-product-spark.md
@@ -4,7 +4,7 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(spark): Update container images ahead of Stackable Release XX.(X)X
+  chore(spark): Update container images ahead of Stackable Release YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']

--- a/.github/ISSUE_TEMPLATE/update-product-superset.md
+++ b/.github/ISSUE_TEMPLATE/update-product-superset.md
@@ -4,7 +4,7 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(superset): Update container images ahead of Stackable Release XX.(X)X
+  chore(superset): Update container images ahead of Stackable Release YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']

--- a/.github/ISSUE_TEMPLATE/update-product-superset.md
+++ b/.github/ISSUE_TEMPLATE/update-product-superset.md
@@ -25,8 +25,8 @@ Add/Change/Remove anything that isn't applicable anymore
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 
-```[tasklist]
-### Update tasks
+## Update tasks
+
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet (including the removal of old versions).
 - [ ] Create a new constraints file (see `superset/README.md`).
 - [ ] Create a file: `superset/stackable/patches/x.y.z/.gitkeep`, add patches if applicable.
@@ -34,31 +34,30 @@ Add/Change/Remove anything that isn't applicable anymore
 - [ ] Update other dependencies if applicable (eg: python, auth_lib, etc).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
 - [ ] Update the version in demos. Add the PR(s) to the list below.
-```
 
-```[tasklist]
-### Related Pull Requests
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
-```
+## Related Pull Requests
 
 > [!TIP]
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+- [ ] _Link to the docker-images PR (product update)_
+- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
+- [ ] _Link to any other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (raise against the `main` branch)_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
-```[tasklist]
-### Acceptance
+## Acceptance
+
+> [!TIP]
+> This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been
+> checked, the issue can be moved into _Development: Done_.
+
 - [ ] Can build image (either locally, or in CI)
 - [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
-```
 
 <details>
 <summary>Testing instructions</summary>

--- a/.github/ISSUE_TEMPLATE/update-product-trino.md
+++ b/.github/ISSUE_TEMPLATE/update-product-trino.md
@@ -25,48 +25,48 @@ Add/Change/Remove anything that isn't applicable anymore
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 
-```[tasklist]
-### Update tasks (trino)
+## Update tasks
+
+### Trino
+
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet (including the removal of old versions).
 - [ ] Upload new version (see `trino/*.sh` scripts).
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
 - [ ] Update other dependencies if applicable (eg: jmx_exporter, opa_authorizer, storage_connector, etc).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
 - [ ] Update the version in demos. Add the PR(s) to the list below.
-```
 
-```[tasklist]
-### Update tasks (trino-cli)
+### trino-cli
+
 - [ ] Update `trino-cli/versions.py` to reflect the agreed upon versions in the spreadsheet (including the removal of old versions).
 - [ ] Upload new version (see `trino-cli/upload_new_trino_version.sh` scripts).
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
 - [ ] Update the version in demos. Add the PR(s) to the list below.
-```
 
-```[tasklist]
-### Related Pull Requests
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
-```
+## Related Pull Requests
 
 > [!TIP]
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+- [ ] _Link to the docker-images PR (product update)_
+- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
+- [ ] _Link to any other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (raise against the `main` branch)_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
-```[tasklist]
-### Acceptance
+## Acceptance
+
+> [!TIP]
+> This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been
+> checked, the issue can be moved into _Development: Done_.
+
 - [ ] Can build image (either locally, or in CI)
 - [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
-```
 
 <details>
 <summary>Testing instructions</summary>

--- a/.github/ISSUE_TEMPLATE/update-product-trino.md
+++ b/.github/ISSUE_TEMPLATE/update-product-trino.md
@@ -4,7 +4,7 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(trino): Update container images ahead of Stackable Release XX.(X)X
+  chore(trino): Update container images ahead of Stackable Release YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']

--- a/.github/ISSUE_TEMPLATE/update-product-zookeeper.md
+++ b/.github/ISSUE_TEMPLATE/update-product-zookeeper.md
@@ -4,7 +4,7 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(zookeeper): Update container images ahead of Stackable Release XX.(X)X
+  chore(zookeeper): Update container images ahead of Stackable Release YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']

--- a/.github/ISSUE_TEMPLATE/update-product-zookeeper.md
+++ b/.github/ISSUE_TEMPLATE/update-product-zookeeper.md
@@ -25,39 +25,38 @@ Add/Change/Remove anything that isn't applicable anymore
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 
-```[tasklist]
-### Update tasks
+## Update tasks
+
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet (including the removal of old versions).
 - [ ] Upload new version (see `zookeeper/upload_new_zookeeper_version.sh`).
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
 - [ ] Update other dependencies if applicable (eg: jmx_exporter, etc).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
 - [ ] Update the version in demos. Add the PR(s) to the list below.
-```
 
-```[tasklist]
-### Related Pull Requests
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
-```
+## Related Pull Requests
 
 > [!TIP]
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been checked, the issue can be moved into _Development: Done_.
+- [ ] _Link to the docker-images PR (product update)_
+- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
+- [ ] _Link to any other operator PRs (getting_started / kuttl)_
+- [ ] _Link to demo PR (raise against the `main` branch)_
+- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
-```[tasklist]
-### Acceptance
+## Acceptance
+
+> [!TIP]
+> This list should be completed by the assignee(s), once respective PRs have been merged. Once all items have been
+> checked, the issue can be moved into _Development: Done_.
+
 - [ ] Can build image (either locally, or in CI)
 - [ ] Kuttl smoke tests passes (either locally, or in CI)
 - [ ] Release notes added to documentation and linked as a PR above
 - [ ] Release notes written in a comment below
 - [ ] Applicable `release-note` label added to this issue
-```
 
 <details>
 <summary>Testing instructions</summary>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,14 +7,12 @@
 - Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
 - Please make sure all these things are done and tick the boxes
 
-```[tasklist]
 - [ ] Changes are OpenShift compatible
 - [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
 - [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
 - [ ] All packages should have (if available) signatures/hashes verified
 - [ ] Add an entry to the CHANGELOG.md file
 - [ ] Integration tests ran successfully
-```
 
 <details>
 <summary>TIP: Running integration tests with a new product image</summary>


### PR DESCRIPTION
# Description

> [!NOTE]
> This came out of the [25.3.0 Release Retro](https://github.com/stackabletech/issues/issues/694)

- Use YY.M.X placeholders for consistence across templates
- Remove deprecated `[tasklists]` :sob:
- Add missing tool update tasks for cyclonedx and auditable

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully
```

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
