### PR TITLE
fix: add missing patchable config for Kafka 3.8.0

### DIFF
--- a/kafka/stackable/patches/3.8.0/0001-Add-CycloneDX-plugin.patch
+++ b/kafka/stackable/patches/3.8.0/0001-Add-CycloneDX-plugin.patch
@@ -1,5 +1,14 @@
+From 9bc39c677cb825c4ddae900005e41420bb63a48c Mon Sep 17 00:00:00 2001
+From: dervoeti <lukas.krug@stackable.tech>
+Date: Thu, 24 Apr 2025 17:24:47 +0200
+Subject: Add CycloneDX plugin
+
+---
+ build.gradle | 42 ++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 42 insertions(+)
+
 diff --git a/build.gradle b/build.gradle
-index 92082fe..e3d6c72 100644
+index 92082fe7cf..e3d6c722b6 100644
 --- a/build.gradle
 +++ b/build.gradle
 @@ -48,6 +48,48 @@ plugins {

--- a/kafka/stackable/patches/3.8.0/0002-Change-Gradle-to-use-the-Nexus-Build-Repo.patch
+++ b/kafka/stackable/patches/3.8.0/0002-Change-Gradle-to-use-the-Nexus-Build-Repo.patch
@@ -1,14 +1,14 @@
-From e5102449fe825cfbba20ce6ace1f51cd91550780 Mon Sep 17 00:00:00 2001
-From: Lars Francke <git@lars-francke.de>
-Date: Thu, 12 Dec 2024 10:09:47 +0100
-Subject: [PATCH] Change Gradle to use the Nexus Build Repo
+From 5cead6a5c6cc28dbfbb2cd4088d9598989287feb Mon Sep 17 00:00:00 2001
+From: dervoeti <lukas.krug@stackable.tech>
+Date: Thu, 24 Apr 2025 17:25:17 +0200
+Subject: Change Gradle to use the Nexus Build Repo
 
 ---
  build.gradle | 8 ++++++--
  1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/build.gradle b/build.gradle
-index 92082fe7cf..3b56a2ad98 100644
+index e3d6c722b6..8eec9a4a96 100644
 --- a/build.gradle
 +++ b/build.gradle
 @@ -20,7 +20,9 @@ import java.nio.charset.StandardCharsets
@@ -22,7 +22,7 @@ index 92082fe7cf..3b56a2ad98 100644
    }
    apply from: "$rootDir/gradle/dependencies.gradle"
  
-@@ -126,7 +128,9 @@ ext {
+@@ -168,7 +170,9 @@ ext {
  allprojects {
  
    repositories {
@@ -33,6 +33,3 @@ index 92082fe7cf..3b56a2ad98 100644
    }
  
    dependencyUpdates {
--- 
-2.47.1
-

--- a/kafka/stackable/patches/3.8.0/patchable.toml
+++ b/kafka/stackable/patches/3.8.0/patchable.toml
@@ -1,0 +1,2 @@
+upstream = "https://github.com/apache/kafka.git"
+base = "771b9576b00ecf5b64ab6e8bedf04156fbdb5cd6"


### PR DESCRIPTION
Builds are failing since https://github.com/stackabletech/docker-images/pull/1032 because the Patchable config for Kafka 3.8.0 is missing