### PR TITLE
fix: spark connect client Harbor credentials

### DIFF
--- a/.github/workflows/build_spark-connect-client.yaml
+++ b/.github/workflows/build_spark-connect-client.yaml
@@ -26,7 +26,7 @@ jobs:
     name: Reusable Workflow
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
-      harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
+      harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_STACKABLE_GITHUB_ACTION_BUILD_SECRET }}
       slack-token: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}
     with:
       product-name: spark-connect-client

--- a/.github/workflows/reusable_build_image.yaml
+++ b/.github/workflows/reusable_build_image.yaml
@@ -67,7 +67,7 @@ jobs:
         uses: stackabletech/actions/publish-image@2d3d7ddad981ae09901d45a0f6bf30c2658b1b78 # 0.7.0
         with:
           image-registry-uri: oci.stackable.tech
-          image-registry-username: robot$sdp+github-action-build
+          image-registry-username: robot$${{ inputs.registry-namespace }}+github-action-build
           image-registry-password: ${{ secrets.harbor-robot-secret }}
           image-repository: ${{ inputs.registry-namespace }}/${{ inputs.product-name }}
           image-manifest-tag: ${{ steps.build.outputs.image-manifest-tag }}


### PR DESCRIPTION
Makes the workflow use the correct credentials for the robot account with access to the "stackable" repo

Test run: https://github.com/stackabletech/docker-images/actions/runs/14832966758