### PR TITLE
ci(mirror): Include image name and version in run-name

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -1,7 +1,7 @@
 ---
 name: Mirror Container Image
 run-name: |
-  Mirror Container Image (${{ inputs.image-repository-uri }}, ${{ inputs.image-index-manifest-tag }}, attempt #${{ github.run_attempt }})
+  Mirror Container Image (${{ inputs.image-repository-uri }}:${{ inputs.image-index-manifest-tag }}, attempt #${{ github.run_attempt }})
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This adds the name and version of the mirrored image to the `run-name` of the workflow to more easily see what was mirrored on the workflow overview page.