### PR TITLE
chore(java): Add JDK 24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
   `check-permissions-ownership.sh` provided in stackable-base image ([#1025]).
 - zookeeper: check for correct permissions and ownerships in /stackable folder via
   `check-permissions-ownership.sh` provided in stackable-base image ([#1043]).
+- java: Add JDK 24 ([#1097]).
 
 ### Changed
 
@@ -81,6 +82,7 @@ All notable changes to this project will be documented in this file.
 [#1055]: https://github.com/stackabletech/docker-images/pull/1055
 [#1056]: https://github.com/stackabletech/docker-images/pull/1056
 [#1090]: https://github.com/stackabletech/docker-images/pull/1090
+[#1097]: https://github.com/stackabletech/docker-images/pull/1097
 
 ## [25.3.0] - 2025-03-21
 

--- a/java-base/versions.py
+++ b/java-base/versions.py
@@ -23,4 +23,8 @@ versions = [
         "product": "23",
         "vector": "0.43.1",
     },
+    {
+        "product": "24",
+        "vector": "0.43.1",
+    },
 ]

--- a/java-devel/versions.py
+++ b/java-devel/versions.py
@@ -23,4 +23,8 @@ versions = [
         "product": "23",
         "stackable-devel": "1.0.0",
     },
+    {
+        "product": "24",
+        "stackable-devel": "1.0.0",
+    },
 ]


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1096.

> [!NOTE]
> This will be used by Trino 476 once it is released.
> See: https://github.com/stackabletech/docker-images/pull/1095

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
