### PR TITLE
chore(vector): Bump to 0.46.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file.
 - kubectl: Bump products to use `1.33.0` ([#1090]).
 - yq: Bump products to use `4.45.2` ([#1090]).
 - cyclonedx-bom: Bump airflow and superset to use `6.0.0` ([#1090]).
+- vector: Bump to `0.46.1` ([#1098]).
 
 ### Fixed
 
@@ -81,6 +82,7 @@ All notable changes to this project will be documented in this file.
 [#1055]: https://github.com/stackabletech/docker-images/pull/1055
 [#1056]: https://github.com/stackabletech/docker-images/pull/1056
 [#1090]: https://github.com/stackabletech/docker-images/pull/1090
+[#1098]: https://github.com/stackabletech/docker-images/pull/1098
 
 ## [25.3.0] - 2025-03-21
 

--- a/airflow/versions.py
+++ b/airflow/versions.py
@@ -7,7 +7,7 @@ versions = [
         "cyclonedx_bom": "6.0.0",
         "statsd_exporter": "0.28.0",
         "tini": "0.19.0",
-        "vector": "0.43.1",
+        "vector": "0.46.1",
     },
     {
         "product": "2.10.4",
@@ -17,6 +17,6 @@ versions = [
         "cyclonedx_bom": "6.0.0",
         "statsd_exporter": "0.28.0",
         "tini": "0.19.0",
-        "vector": "0.43.1",
+        "vector": "0.46.1",
     },
 ]

--- a/java-base/versions.py
+++ b/java-base/versions.py
@@ -1,26 +1,26 @@
 versions = [
     {
         "product": "8",
-        "vector": "0.43.1",
+        "vector": "0.46.1",
     },
     {
         "product": "11",
-        "vector": "0.43.1",
+        "vector": "0.46.1",
     },
     {
         "product": "17",
-        "vector": "0.43.1",
+        "vector": "0.46.1",
     },
     {
         "product": "21",
-        "vector": "0.43.1",
+        "vector": "0.46.1",
     },
     {
         "product": "22",
-        "vector": "0.43.1",
+        "vector": "0.46.1",
     },
     {
         "product": "23",
-        "vector": "0.43.1",
+        "vector": "0.46.1",
     },
 ]

--- a/opa/versions.py
+++ b/opa/versions.py
@@ -1,13 +1,13 @@
 versions = [
     {
         "product": "1.0.1",
-        "vector": "0.43.1",
+        "vector": "0.46.1",
         "bundle_builder_version": "1.1.2",
         "stackable-base": "1.0.0",
     },
     {
         "product": "0.67.1",
-        "vector": "0.43.1",
+        "vector": "0.46.1",
         "bundle_builder_version": "1.1.2",
         "stackable-base": "1.0.0",
     },

--- a/spark-k8s/versions.py
+++ b/spark-k8s/versions.py
@@ -12,7 +12,7 @@ versions = [
         "jackson_dataformat_xml": "2.15.2",  # https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.13/3.5.1
         "stax2_api": "4.2.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.2
         "woodstox_core": "6.5.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.2
-        "vector": "0.43.1",
+        "vector": "0.46.1",
         "jmx_exporter": "1.2.0",
         "tini": "0.19.0",
         "hbase_connector": "1.0.1",
@@ -30,7 +30,7 @@ versions = [
         "jackson_dataformat_xml": "2.15.2",  # https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.13/3.5.2
         "stax2_api": "4.2.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.2
         "woodstox_core": "6.5.1",  # https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.2
-        "vector": "0.43.1",
+        "vector": "0.46.1",
         "jmx_exporter": "1.2.0",
         "tini": "0.19.0",
         "hbase_connector": "1.0.1",

--- a/superset/versions.py
+++ b/superset/versions.py
@@ -3,7 +3,7 @@ versions = [
         "product": "4.0.2",
         "python": "3.9",
         "cyclonedx_bom": "6.0.0",
-        "vector": "0.43.1",
+        "vector": "0.46.1",
         "statsd_exporter": "0.28.0",
         "authlib": "1.2.1",  # https://github.com/dpgaspar/Flask-AppBuilder/blob/release/4.4.1/requirements/extra.txt#L7
         "stackable-base": "1.0.0",
@@ -12,7 +12,7 @@ versions = [
         "product": "4.1.1",
         "python": "3.9",  # 3.11 support was merged in January 2025 (two months after 4.1.1 release), 3.10 is not available in our UBI image, so we need to stay on 3.9 for now
         "cyclonedx_bom": "6.0.0",
-        "vector": "0.43.1",
+        "vector": "0.46.1",
         "statsd_exporter": "0.28.0",
         "authlib": "1.2.1",  # https://github.com/dpgaspar/Flask-AppBuilder/blob/release/4.5.0/requirements/extra.txt#L7
         "stackable-base": "1.0.0",

--- a/vector/versions.py
+++ b/vector/versions.py
@@ -1,6 +1,6 @@
 versions = [
     {
-        "product": "0.43.1",
+        "product": "0.46.1",
         "rpm_release": "1",
         "stackable-base": "1.0.0",
         "inotify_tools": "3.22.1.0-1.el9",


### PR DESCRIPTION
Closes https://github.com/stackabletech/issues/issues/687.

Part of https://github.com/stackabletech/docker-images/issues/1085

- Bump vector to 0.46.1.

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
