### PR TITLE
chore(opa): Update versions ahead of 25.7.0

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -14,6 +14,7 @@ on:
           - registry.k8s.io/sig-storage/csi-node-driver-registrar
           - registry.k8s.io/sig-storage/csi-provisioner
           - registry.k8s.io/git-sync/git-sync
+          - registry-1.docker.io/library/golang
       image-index-manifest-tag:
         description: |
           The image index manifest tag, like 1.0.14 or v1.0.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
   `check-permissions-ownership.sh` provided in stackable-base image ([#1027]).
 - opa: check for correct permissions and ownerships in /stackable folder via
   `check-permissions-ownership.sh` provided in stackable-base image ([#1038]).
+- opa: Add `1.4.2` ([#1103]).
 - spark-k8s: check for correct permissions and ownerships in /stackable folder via
   `check-permissions-ownership.sh` provided in stackable-base image ([#1055]).
 - superset: check for correct permissions and ownerships in /stackable folder via
@@ -66,6 +67,8 @@ All notable changes to this project will be documented in this file.
   Also remove the old release workflow.
 - zookeeper: Remove 3.9.2 ([#1093]).
 - Remove ubi8-rust-builder image ([#1091]).
+- opa: Remove `0.67.1` ([#1103]).
+- opa: Remove legacy bundle-builder from container build ([#1103]).
 
 [#1025]: https://github.com/stackabletech/docker-images/pull/1025
 [#1027]: https://github.com/stackabletech/docker-images/pull/1027
@@ -90,6 +93,7 @@ All notable changes to this project will be documented in this file.
 [#1093]: https://github.com/stackabletech/docker-images/pull/1093
 [#1097]: https://github.com/stackabletech/docker-images/pull/1097
 [#1098]: https://github.com/stackabletech/docker-images/pull/1098
+[#1103]: https://github.com/stackabletech/docker-images/pull/1103
 
 ## [25.3.0] - 2025-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to this project will be documented in this file.
 - yq: Bump products to use `4.45.2` ([#1090]).
 - cyclonedx-bom: Bump airflow and superset to use `6.0.0` ([#1090]).
 - vector: Bump to `0.46.1` ([#1098]).
+- opa: Bump ubi9 base image ([#1103]).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable changes to this project will be documented in this file.
 - Add `--locked` flag to `cargo install` commands for reproducible builds ([#1044]).
 - nifi: reduce docker image size by removing the recursive chown/chmods in the final image ([#1027]).
 - opa: reduce docker image size by removing the recursive chown/chmods in the final image ([#1038]).
+- opa: Manually install Go 1.23.9 ([#1103]).
 - spark-k8s: reduce docker image size by removing the recursive chown/chmods in the final image ([#1042]).
 - trino: reduce docker image size by removing the recursive chown/chmods in the final image ([#1025]).
 - zookeeper: reduce docker image size by removing the recursive chown/chmods in the final image ([#1043]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file.
 - zookeeper: check for correct permissions and ownerships in /stackable folder via
   `check-permissions-ownership.sh` provided in stackable-base image ([#1043]).
 - java: Add JDK 24 ([#1097]).
+- ci: Add golang image to mirror workflow ([#1103]).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 
 - ubi-rust-builder: Bump Rust toolchain to 1.85.0, cargo-cyclonedx to 0.5.7, and cargo-auditable to 0.6.6 ([#1050]).
 - ubi9-rust-builder: Bump base image and update protoc to `30.2` ([#1091]).
+- stackable-devel: Bump ubi9 base image ([#1103]).
 - spark-k8s: Include spark-connect jars, replace OpenJDK with Temurin JDK, cleanup ([#1034]).
 - spark-connect-client: Image is now completely based on spark-k8s and includes JupyterLab and other demo dependencies ([#1071]).
 - jmx_exporter: Bump products to use `1.2.0` ([#1090]).
@@ -46,7 +47,6 @@ All notable changes to this project will be documented in this file.
 - yq: Bump products to use `4.45.2` ([#1090]).
 - cyclonedx-bom: Bump airflow and superset to use `6.0.0` ([#1090]).
 - vector: Bump to `0.46.1` ([#1098]).
-- opa: Bump ubi9 base image ([#1103]).
 
 ### Fixed
 

--- a/opa/Dockerfile
+++ b/opa/Dockerfile
@@ -1,5 +1,9 @@
 # syntax=docker/dockerfile:1.10.0@sha256:865e5dd094beca432e8c0a1d5e1c465db5f998dca4e439981029b3b81fb39ed5
-# check=error=true
+# check=error=true;skip=InvalidDefaultArgInFrom
+
+ARG GOLANG
+
+FROM oci.stackable.tech/sdp/library/golang:${GOLANG} AS golang-image
 
 FROM stackable/image/stackable-base AS multilog-builder
 
@@ -59,7 +63,7 @@ EOF
 COPY --chown=${STACKABLE_USER_UID}:0 opa/stackable/bin /stackable/opa/bin
 
 # Manually install Go since the dnf package is sometimes not recent enough
-COPY --from=oci.stackable.tech/sdp/library/golang:1.23.9 /usr/local/go/ /usr/local/go/
+COPY --from=golang-image /usr/local/go/ /usr/local/go/
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 RUN <<EOF

--- a/opa/Dockerfile
+++ b/opa/Dockerfile
@@ -47,18 +47,20 @@ ENV GOOS=$TARGETOS
 
 # gzip, tar - used to unpack the OPA source
 # git - needed by the cyclonedx-gomod tool to determine the version of OPA
-# golang - used to build OPA
 RUN <<EOF
 microdnf update
 microdnf install \
   git \
-  golang \
   gzip \
   tar
 microdnf clean all
 EOF
 
 COPY --chown=${STACKABLE_USER_UID}:0 opa/stackable/bin /stackable/opa/bin
+
+# Manually install Go since the dnf package is sometimes not recent enough
+COPY --from=registry-1.docker.io/library/golang:1.23.9 /usr/local/go/ /usr/local/go/
+ENV PATH="/usr/local/go/bin:${PATH}"
 
 RUN <<EOF
 # We use version 1.7.0, since a newer version of cyclonedx-gomod is not compatible with the version of Golang (>= 1.23.1)

--- a/opa/Dockerfile
+++ b/opa/Dockerfile
@@ -59,7 +59,7 @@ EOF
 COPY --chown=${STACKABLE_USER_UID}:0 opa/stackable/bin /stackable/opa/bin
 
 # Manually install Go since the dnf package is sometimes not recent enough
-COPY --from=registry-1.docker.io/library/golang:1.23.9 /usr/local/go/ /usr/local/go/
+COPY --from=oci.stackable.tech/sdp/library/golang:1.23.9 /usr/local/go/ /usr/local/go/
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 RUN <<EOF

--- a/opa/Dockerfile
+++ b/opa/Dockerfile
@@ -1,40 +1,6 @@
 # syntax=docker/dockerfile:1.10.0@sha256:865e5dd094beca432e8c0a1d5e1c465db5f998dca4e439981029b3b81fb39ed5
 # check=error=true
 
-FROM stackable/image/stackable-base AS opa-bundle-builder
-
-ARG BUNDLE_BUILDER_VERSION
-
-# Update image and install everything needed for Rustup & Rust
-RUN <<EOF
-microdnf update
-microdnf install \
-  cmake \
-  gcc \
-  gcc-c++ \
-  git \
-  make \
-  openssl-devel \
-  pkg-config \
-  systemd-devel \
-  unzip
-rm -rf /var/cache/yum
-EOF
-
-WORKDIR /
-
-# WARNING (@NickLarsenNZ): We should pin the rustup version
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-RUN git clone --depth 1 --branch ${BUNDLE_BUILDER_VERSION} https://github.com/stackabletech/opa-bundle-builder
-RUN <<EOF
-cd ./opa-bundle-builder
-. "$HOME/.cargo/env"
-rustup toolchain install
-cargo --quiet build --release
-# set correct groups
-chmod -R g=u /opa-bundle-builder/target/release/
-EOF
-
 FROM stackable/image/stackable-base AS multilog-builder
 
 ARG DAEMONTOOLS_VERSION=0.76
@@ -137,7 +103,6 @@ LABEL name="Open Policy Agent" \
 COPY --chown=${STACKABLE_USER_UID}:0 opa/licenses /licenses
 
 COPY --from=opa-builder --chown=${STACKABLE_USER_UID}:0 /stackable/opa /stackable/opa
-COPY --from=opa-bundle-builder --chown=${STACKABLE_USER_UID}:0 /opa-bundle-builder/target/release/stackable-opa-bundle-builder /stackable/opa-bundle-builder
 COPY --from=multilog-builder --chown=${STACKABLE_USER_UID}:0 /daemontools/admin/daemontools/command/multilog /stackable/multilog
 
 RUN <<EOF

--- a/opa/versions.py
+++ b/opa/versions.py
@@ -5,10 +5,4 @@ versions = [
         "bundle_builder_version": "1.1.2",
         "stackable-base": "1.0.0",
     },
-    {
-        "product": "0.67.1",
-        "vector": "0.46.1",
-        "bundle_builder_version": "1.1.2",
-        "stackable-base": "1.0.0",
-    },
 ]

--- a/opa/versions.py
+++ b/opa/versions.py
@@ -2,7 +2,6 @@ versions = [
     {
         "product": "1.0.1",
         "vector": "0.46.1",
-        "bundle_builder_version": "1.1.2",
         "stackable-base": "1.0.0",
     },
 ]

--- a/opa/versions.py
+++ b/opa/versions.py
@@ -1,5 +1,10 @@
 versions = [
     {
+        "product": "1.4.2",
+        "vector": "0.46.1",
+        "stackable-base": "1.0.0",
+    },
+    {
         "product": "1.0.1",
         "vector": "0.46.1",
         "stackable-base": "1.0.0",

--- a/opa/versions.py
+++ b/opa/versions.py
@@ -2,11 +2,13 @@ versions = [
     {
         "product": "1.4.2",
         "vector": "0.46.1",
+        "golang": "1.23.9",
         "stackable-base": "1.0.0",
     },
     {
         "product": "1.0.1",
         "vector": "0.46.1",
+        "golang": "1.23.9",
         "stackable-base": "1.0.0",
     },
 ]

--- a/stackable-devel/Dockerfile
+++ b/stackable-devel/Dockerfile
@@ -8,7 +8,7 @@
 # Find the latest version at https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5?container-tabs=gti
 # IMPORTANT: Make sure to use the "Manifest List Digest" that references the images for multiple architectures
 # rather than just the "Image Digest" that references the image for the selected architecture.
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:c0e70387664f30cd9cf2795b547e4a9a51002c44a4a86aa9335ab030134bf392
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:e1c4703364c5cb58f5462575dc90345bcd934ddc45e6c32f9c162f2b5617681c
 
 # intentionally unused
 ARG PRODUCT


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1084.

- [x] Remove `0.67.1`
- [x] Add `1.4.2`

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] ~All packages should have (if available) signatures/hashes verified~
- [x] Add an entry to the CHANGELOG.md file
- [x] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
