### PR TITLE
fix: Bump vector to 0.46.1 for java-base:24

### DIFF
--- a/java-base/versions.py
+++ b/java-base/versions.py
@@ -25,6 +25,6 @@ versions = [
     },
     {
         "product": "24",
-        "vector": "0.43.1",
+        "vector": "0.46.1",
     },
 ]


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1085.

This was missed by https://github.com/stackabletech/docker-images/pull/1098 due to changes from https://github.com/stackabletech/docker-images/pull/1097 coming in and being missed during merge-conflict resolution.
