### PR TITLE
chore(issue_template): Add reminder to update prereqs for select products

### DIFF
--- a/.github/ISSUE_TEMPLATE/update-product-airflow.md
+++ b/.github/ISSUE_TEMPLATE/update-product-airflow.md
@@ -31,6 +31,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - [ ] Download new constraints file (see `airflow/download_constraints.sh`).
 - [ ] Update other dependencies if applicable (eg: python, statsd_exporter, etc).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
+- [ ] Ensure prerequisites are up to date (required-external-components.adoc)
 - [ ] Update the version in demos. Add the PR(s) to the list below.
 
 ## Related Pull Requests

--- a/.github/ISSUE_TEMPLATE/update-product-airflow.md
+++ b/.github/ISSUE_TEMPLATE/update-product-airflow.md
@@ -31,7 +31,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - [ ] Download new constraints file (see `airflow/download_constraints.sh`).
 - [ ] Update other dependencies if applicable (eg: python, statsd_exporter, etc).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
-- [ ] Ensure prerequisites are up to date (required-external-components.adoc)
+- [ ] Ensure prerequisites are up to date (required-external-components.adoc).
 - [ ] Update the version in demos. Add the PR(s) to the list below.
 
 ## Related Pull Requests

--- a/.github/ISSUE_TEMPLATE/update-product-druid.md
+++ b/.github/ISSUE_TEMPLATE/update-product-druid.md
@@ -34,6 +34,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
 - [ ] Update the [druid-opa-authorizer](https://github.com/stackabletech/druid-opa-authorizer/) with the new set of versions.
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
+- [ ] Ensure prerequisites are up to date (required-external-components.adoc)
 - [ ] Update the version in demos. Add the PR(s) to the list below.
 
 ## Related Pull Requests

--- a/.github/ISSUE_TEMPLATE/update-product-druid.md
+++ b/.github/ISSUE_TEMPLATE/update-product-druid.md
@@ -34,7 +34,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
 - [ ] Update the [druid-opa-authorizer](https://github.com/stackabletech/druid-opa-authorizer/) with the new set of versions.
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
-- [ ] Ensure prerequisites are up to date (required-external-components.adoc)
+- [ ] Ensure prerequisites are up to date (required-external-components.adoc).
 - [ ] Update the version in demos. Add the PR(s) to the list below.
 
 ## Related Pull Requests

--- a/.github/ISSUE_TEMPLATE/update-product-hive.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hive.md
@@ -32,6 +32,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
 - [ ] Update other dependencies if applicable (eg: jmx_exporter, aws_java_sdk_bundle, etc).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
+- [ ] Ensure prerequisites are up to date (required-external-components.adoc)
 - [ ] Update the version in demos. Add the PR(s) to the list below.
 
 ## Related Pull Requests

--- a/.github/ISSUE_TEMPLATE/update-product-hive.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hive.md
@@ -32,7 +32,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
 - [ ] Update other dependencies if applicable (eg: jmx_exporter, aws_java_sdk_bundle, etc).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
-- [ ] Ensure prerequisites are up to date (required-external-components.adoc)
+- [ ] Ensure prerequisites are up to date (required-external-components.adoc).
 - [ ] Update the version in demos. Add the PR(s) to the list below.
 
 ## Related Pull Requests

--- a/.github/ISSUE_TEMPLATE/update-product-superset.md
+++ b/.github/ISSUE_TEMPLATE/update-product-superset.md
@@ -33,6 +33,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - [ ] Delete old constraint files and patch directories.
 - [ ] Update other dependencies if applicable (eg: python, auth_lib, etc).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
+- [ ] Ensure prerequisites are up to date (required-external-components.adoc)
 - [ ] Update the version in demos. Add the PR(s) to the list below.
 
 ## Related Pull Requests

--- a/.github/ISSUE_TEMPLATE/update-product-superset.md
+++ b/.github/ISSUE_TEMPLATE/update-product-superset.md
@@ -33,7 +33,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - [ ] Delete old constraint files and patch directories.
 - [ ] Update other dependencies if applicable (eg: python, auth_lib, etc).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
-- [ ] Ensure prerequisites are up to date (required-external-components.adoc)
+- [ ] Ensure prerequisites are up to date (required-external-components.adoc).
 - [ ] Update the version in demos. Add the PR(s) to the list below.
 
 ## Related Pull Requests


### PR DESCRIPTION
This came from https://github.com/stackabletech/airflow-operator/pull/625#issuecomment-2864302787

```
❯ fd required-external-components.adoc
airflow-operator/docs/modules/airflow/pages/required-external-components.adoc
druid-operator/docs/modules/druid/pages/required-external-components.adoc
hive-operator/docs/modules/hive/pages/required-external-components.adoc
superset-operator/docs/modules/superset/pages/required-external-components.adoc
```