### PR TITLE
Revert "Change default user id and gid (#916)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,6 @@ All notable changes to this project will be documented in this file.
 - yq: Bump products to use `4.45.2` ([#1090]).
 - cyclonedx-bom: Bump airflow and superset to use `6.0.0` ([#1090]).
 - vector: Bump to `0.46.1` ([#1098]).
-- Changed default user & group IDs from 1000/1000 to 782252253/574654813 ([#916])
 
 ### Fixed
 
@@ -77,7 +76,6 @@ All notable changes to this project will be documented in this file.
 - opa: Remove `0.67.1` ([#1103]).
 - opa: Remove legacy bundle-builder from container build ([#1103]).
 
-[#916]: https://github.com/stackabletech/docker-images/pull/916
 [#1025]: https://github.com/stackabletech/docker-images/pull/1025
 [#1027]: https://github.com/stackabletech/docker-images/pull/1027
 [#1028]: https://github.com/stackabletech/docker-images/pull/1028

--- a/conf.py
+++ b/conf.py
@@ -98,7 +98,7 @@ cache = [
 
 args = {
     "STACKABLE_USER_NAME": "stackable",
-    "STACKABLE_USER_UID": "782252253",  # This is a random high id to not conflict with any existing user
-    "STACKABLE_USER_GID": "574654813",  # This is a random high id to not conflict with any existing group
+    "STACKABLE_USER_UID": "1000",
+    "STACKABLE_USER_GID": "1000",
     "DELETE_CACHES": "true",
 }


### PR DESCRIPTION
# Description

This reverts commit b4b5a33ff42df0b513ccc0efeab5ec96045e3d2b.

It turns out that all operators need to be adapted first because even though they do hardcode user id & gid 1000 that does cause problems. The reason is that they rely on a user with id 1000 to actually be there and it isn't.

I don't know what I was thinking to be honest.