### PR TITLE
fix(nifi): Conditionally disable Host Port Validation in NiFi 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable changes to this project will be documented in this file.
 - vector: Bump to `0.46.1` ([#1098]).
 - spark: update dependencies for 3.5.5 ([#1094])
 - nifi: include NAR SBOMs ([#1119])
+- nifi: update patch allowing to bypass host header validation starting with NiFi 2.4.0 ([#1125]).
 - BREAKING: kcat: Stop building kcat image ([#1124]).
 
 ### Fixed
@@ -140,6 +141,7 @@ All notable changes to this project will be documented in this file.
 [#1119]: https://github.com/stackabletech/docker-images/pull/1119
 [#1121]: https://github.com/stackabletech/docker-images/pull/1121
 [#1124]: https://github.com/stackabletech/docker-images/pull/1124
+[#1125]: https://github.com/stackabletech/docker-images/pull/1125
 
 ## [25.3.0] - 2025-03-21
 

--- a/nifi/stackable/patches/2.4.0/0003-disable-host-port-validation-if-list-of-allowed-host.patch
+++ b/nifi/stackable/patches/2.4.0/0003-disable-host-port-validation-if-list-of-allowed-host.patch
@@ -1,0 +1,48 @@
+From 5eb0363521dbb30e3e47ec8a604f5a5c678bf4fb Mon Sep 17 00:00:00 2001
+From: Benedikt Labrenz <benedikt@labrenz.org>
+Date: Thu, 22 May 2025 14:47:24 +0200
+Subject: disable host port validation if list of allowed hosts only contains
+ '*'
+
+---
+ .../connector/FrameworkServerConnectorFactory.java  | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/connector/FrameworkServerConnectorFactory.java b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/connector/FrameworkServerConnectorFactory.java
+index ec1bee66fb..b58c886f4f 100644
+--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/connector/FrameworkServerConnectorFactory.java
++++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/connector/FrameworkServerConnectorFactory.java
+@@ -54,6 +54,8 @@ public class FrameworkServerConnectorFactory extends StandardServerConnectorFact
+ 
+     private final String excludeCipherSuites;
+ 
++    private final boolean disableHostPortValidator;
++
+     private final Set<Integer> validPorts;
+ 
+     private SslContextFactory.Server sslContextFactory;
+@@ -72,6 +74,11 @@ public class FrameworkServerConnectorFactory extends StandardServerConnectorFact
+         headerSize = DataUnit.parseDataSize(properties.getWebMaxHeaderSize(), DataUnit.B).intValue();
+         validPorts = getValidPorts(properties);
+ 
++        // Check if the property for allowed hosts has only the wildcard entry and
++        // if so store this in disableHostPortValidator for later use
++        List<String> configuredHostNames = properties.getAllowedHostsAsList();
++        disableHostPortValidator = configuredHostNames.size() == 1 && configuredHostNames.contains("*");
++
+         if (properties.isHTTPSConfigured()) {
+             if (properties.isClientAuthRequiredForRestApi()) {
+                 setNeedClientAuth(true);
+@@ -102,8 +109,10 @@ public class FrameworkServerConnectorFactory extends StandardServerConnectorFact
+         // Add HostHeaderCustomizer to set Host Header for HTTP/2 and HostHeaderHandler
+         httpConfiguration.addCustomizer(new HostHeaderCustomizer());
+ 
+-        final HostPortValidatorCustomizer hostPortValidatorCustomizer = new HostPortValidatorCustomizer(validPorts);
+-        httpConfiguration.addCustomizer(hostPortValidatorCustomizer);
++        if (!disableHostPortValidator) {
++            final HostPortValidatorCustomizer hostPortValidatorCustomizer = new HostPortValidatorCustomizer(validPorts);
++            httpConfiguration.addCustomizer(hostPortValidatorCustomizer);
++        }
+ 
+         return httpConfiguration;
+     }


### PR DESCRIPTION
# Description

Starting in NiFi 2.4.0 the host header validation has been replaced by host port validation: https://github.com/apache/nifi/pull/9680

This adds a patch that replaces `0002-Allow-bypassing-check-for-host-header.patch` which was used to turn host header validation off if the list of allowed hosts contained only `*`.

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [x] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] All packages should have (if available) signatures/hashes verified
- [x] Add an entry to the CHANGELOG.md file
- [x] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
