### PR TITLE
fix: trino storage plugin SBOM

### DIFF
--- a/trino/Dockerfile
+++ b/trino/Dockerfile
@@ -15,6 +15,7 @@ COPY --chown=${STACKABLE_USER_UID}:0 trino/stackable/patches/patchable.toml /sta
 COPY --chown=${STACKABLE_USER_UID}:0 trino/stackable/patches/${PRODUCT} /stackable/src/trino/stackable/patches/${PRODUCT}
 
 COPY --from=trino-storage-connector-image /stackable/src/trino-storage-connector/patchable-work/worktree/${PRODUCT}/target/trino-storage-${PRODUCT} /stackable/trino-server-${PRODUCT}/plugin/trino-storage-${PRODUCT}
+COPY --from=trino-storage-connector-image /stackable/src/trino-storage-connector/patchable-work/worktree/${PRODUCT}/target/bom.json /stackable/trino-server-${PRODUCT}/plugin/trino-storage-${PRODUCT}/trino-storage-${PRODUCT}.cdx.json
 COPY --from=trino-storage-connector-image /stackable/trino-storage-connector-${PRODUCT}-src.tar.gz /stackable
 COPY --chown=${STACKABLE_USER_UID}:0 trino/stackable/jmx /stackable/jmx
 

--- a/trino/storage-connector/stackable/patches/451/0001-Add-CycloneDX-plugin.patch
+++ b/trino/storage-connector/stackable/patches/451/0001-Add-CycloneDX-plugin.patch
@@ -1,17 +1,17 @@
-From 6af1b7fa0f62a4413f1fc072a46ce1be3594d7bc Mon Sep 17 00:00:00 2001
+From c14ba9cd92451a2c8a7ad7da2ff2e3f5cdbf2201 Mon Sep 17 00:00:00 2001
 From: Lukas Voetmand <lukas.voetmand@stackable.tech>
 Date: Fri, 6 Sep 2024 17:53:52 +0200
 Subject: Add CycloneDX plugin
 
 ---
- pom.xml | 17 +++++++++++++++++
- 1 file changed, 17 insertions(+)
+ pom.xml | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
 
 diff --git a/pom.xml b/pom.xml
-index 7304dac..5ba854d 100644
+index 7304dac..d73dacf 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -544,6 +544,23 @@
+@@ -544,6 +544,24 @@
                      </dependency>
                  </dependencies>
              </plugin>
@@ -22,6 +22,7 @@ index 7304dac..5ba854d 100644
 +                <configuration>
 +                    <projectType>application</projectType>
 +                    <schemaVersion>1.5</schemaVersion>
++                    <skipNotDeployed>false</skipNotDeployed>
 +                </configuration>
 +                <executions>
 +                    <execution>

--- a/trino/storage-connector/stackable/patches/455/0001-Add-CycloneDX-plugin.patch
+++ b/trino/storage-connector/stackable/patches/455/0001-Add-CycloneDX-plugin.patch
@@ -1,17 +1,17 @@
-From 4d6d55cbc2e05d9b64186885da86ac367070d0f1 Mon Sep 17 00:00:00 2001
+From 16f22c658fa54a9b4d7cc5ece65bcc92f104816d Mon Sep 17 00:00:00 2001
 From: Lukas Voetmand <lukas.voetmand@stackable.tech>
 Date: Fri, 6 Sep 2024 17:53:52 +0200
 Subject: Add CycloneDX plugin
 
 ---
- pom.xml | 17 +++++++++++++++++
- 1 file changed, 17 insertions(+)
+ pom.xml | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
 
 diff --git a/pom.xml b/pom.xml
-index 6471642..fc0f376 100644
+index 6471642..492e222 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -555,6 +555,23 @@
+@@ -555,6 +555,24 @@
                      </dependency>
                  </dependencies>
              </plugin>
@@ -22,6 +22,7 @@ index 6471642..fc0f376 100644
 +                <configuration>
 +                    <projectType>application</projectType>
 +                    <schemaVersion>1.5</schemaVersion>
++                    <skipNotDeployed>false</skipNotDeployed>
 +                </configuration>
 +                <executions>
 +                    <execution>

--- a/trino/storage-connector/stackable/patches/470/0001-Add-CycloneDX-plugin.patch
+++ b/trino/storage-connector/stackable/patches/470/0001-Add-CycloneDX-plugin.patch
@@ -1,17 +1,17 @@
-From 1f5f2f18056f650b89f0399c188e3446975e1764 Mon Sep 17 00:00:00 2001
+From 3c2f4038b72ac3b62bc12c89d40d643a87796ee2 Mon Sep 17 00:00:00 2001
 From: Lukas Voetmand <lukas.voetmand@stackable.tech>
 Date: Fri, 6 Sep 2024 17:53:52 +0200
 Subject: Add CycloneDX plugin
 
 ---
- pom.xml | 17 +++++++++++++++++
- 1 file changed, 17 insertions(+)
+ pom.xml | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
 
 diff --git a/pom.xml b/pom.xml
-index ddd620e..bbfcb96 100644
+index ddd620e..62e60b5 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -545,6 +545,23 @@
+@@ -545,6 +545,24 @@
                      </dependency>
                  </dependencies>
              </plugin>
@@ -22,6 +22,7 @@ index ddd620e..bbfcb96 100644
 +                <configuration>
 +                    <projectType>application</projectType>
 +                    <schemaVersion>1.6</schemaVersion>
++                    <skipNotDeployed>false</skipNotDeployed>
 +                </configuration>
 +                <executions>
 +                    <execution>


### PR DESCRIPTION
# Description

We added the CycloneDX Plugin to the Trino storage plugin, but it didn't generate the SBOM, from the build log:
> Skipping CycloneDX goal, because module skips deploy

Also, we forgot to copy the SBOM to the final image.
This PR actually generates the SBOM and also copies it to the final image.

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [x] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] All packages should have (if available) signatures/hashes verified
- [x] Add an entry to the CHANGELOG.md file
- [x] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
