### PR TITLE
fix: Hadoop build permissions

### DIFF
--- a/hadoop/Dockerfile
+++ b/hadoop/Dockerfile
@@ -24,8 +24,11 @@ microdnf update
 microdnf install boost1.78-devel automake libtool
 microdnf clean all
 rm -rf /var/cache/yum
+mkdir /opt/protobuf
+chown ${STACKABLE_USER_UID}:0 /opt/protobuf
 EOF
 
+USER ${STACKABLE_USER_UID}
 # This Protobuf version is the exact version as used in the Hadoop Dockerfile
 # See https://github.com/apache/hadoop/blob/trunk/dev-support/docker/pkg-resolver/install-protobuf.sh
 # (this was hardcoded in the Dockerfile in earlier versions of Hadoop, make sure to look at the exact version in Github)
@@ -58,7 +61,6 @@ chmod -x "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar"
 ln -s "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar" /stackable/jmx/jmx_prometheus_javaagent.jar
 EOF
 
-USER ${STACKABLE_USER_UID}
 WORKDIR /build
 COPY --chown=${STACKABLE_USER_UID}:0 hadoop/stackable/patches/patchable.toml /build/src/hadoop/stackable/patches/patchable.toml
 COPY --chown=${STACKABLE_USER_UID}:0 hadoop/stackable/patches/${PRODUCT} /build/src/hadoop/stackable/patches/${PRODUCT}


### PR DESCRIPTION
# Description

https://github.com/stackabletech/docker-images/pull/1133 broke the Hadoop build, since the last `chmod` step failed as it's executed by `stackable` now and the protobuf directory was created by `root`. Protobuf, async-profiler and JMX exporter are now also built using the `stackable` user. 

I tested building Hadoop and Hive locally and also briefly tested the built Hadoop image in a Kind cluster. Worked fine.   

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [x] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] All packages should have (if available) signatures/hashes verified
- [x] Add an entry to the CHANGELOG.md file
- [x] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
