### PR TITLE
feat(hadoop): Enable boolean metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ All notable changes to this project will be documented in this file.
 - airflow: Pin Cython version ([#1116]).
 - druid: reduce docker image size by removing the recursive chown/chmods in the final image ([#1039]).
 - hadoop: reduce docker image size by removing the recursive chown/chmods in the final image ([#1029]).
+- hadoop: adapt the JMX exporter configuration to also export boolean metrics ([#1140]).
 - hbase: reduce docker image size by removing the recursive chown/chmods in the final image ([#1028]).
 - hive: reduce docker image size by removing the recursive chown/chmods in the final image ([#1040]).
 - kafka: reduce docker image size by removing the recursive chown/chmods in the final image ([#1041]).

--- a/hadoop/stackable/jmx/datanode.yaml
+++ b/hadoop/stackable/jmx/datanode.yaml
@@ -12,10 +12,9 @@ blacklistObjectNames:
   - 'Hadoop:service=DataNode,name=UgiMetrics'
 rules:
   # MetricsSystem
-  - pattern: 'Hadoop<service=(.*), name=MetricsSystem, sub=(.*)><>(.*): (\d+)'
+  - pattern: 'Hadoop<service=(.*), name=MetricsSystem, sub=(.*)><>(.*):'
     attrNameSnakeCase: true
     name: hadoop_$1_$3
-    value: $4
     labels:
       service: HDFS
       role: $1
@@ -24,10 +23,9 @@ rules:
     type: GAUGE
   # FSDatasetState with _total suffix (also extracts the FSDataset ID),
   # e.g. Hadoop:name=FSDatasetState,attribute=EstimatedCapacityLostTotal
-  - pattern: 'Hadoop<service=(.*), name=FSDatasetState-(.*)><>(.*_total): (\d+)'
+  - pattern: 'Hadoop<service=(.*), name=FSDatasetState-(.*)><>(.*_total):'
     attrNameSnakeCase: true
     name: hadoop_$1_$3
-    value: $4
     labels:
       service: HDFS
       role: $1
@@ -35,10 +33,9 @@ rules:
       kind: 'FSDatasetState'
     type: COUNTER
   # FSDatasetState (also extracts the FSDataset ID)
-  - pattern: 'Hadoop<service=(.*), name=FSDatasetState-(.*)><>(.*): (\d+)'
+  - pattern: 'Hadoop<service=(.*), name=FSDatasetState-(.*)><>(.*):'
     attrNameSnakeCase: true
     name: hadoop_$1_$3
-    value: $4
     labels:
       service: HDFS
       role: $1
@@ -47,10 +44,9 @@ rules:
     type: GAUGE
   # DataNodeActivity with _info suffix (also extracts hostname and port),
   # e.g. Hadoop:name=DataNodeActivity-hdfs-datanode-default-0-9866,attribute=BlocksGetLocalPathInfo
-  - pattern: 'Hadoop<service=(.*), name=DataNodeActivity-(.*)-(\d+)><>(.*_info): (\d+)'
+  - pattern: 'Hadoop<service=(.*), name=DataNodeActivity-(.*)-(\d+)><>(.*_info):'
     attrNameSnakeCase: true
     name: hadoop_$1_$4_
-    value: $5
     labels:
       service: HDFS
       role: $1
@@ -58,10 +54,9 @@ rules:
       port: $3
       kind: 'DataNodeActivity'
     type: GAUGE
-  - pattern: 'Hadoop<service=(.*), name=DataNodeActivity-(.*)-(\d+)><>(.*): (\d+)'
+  - pattern: 'Hadoop<service=(.*), name=DataNodeActivity-(.*)-(\d+)><>(.*):'
     attrNameSnakeCase: true
     name: hadoop_$1_$4
-    value: $5
     labels:
       service: HDFS
       role: $1
@@ -70,10 +65,9 @@ rules:
       kind: 'DataNodeActivity'
     type: GAUGE
   # Generic counter, e.g. Hadoop:name=FSDatasetState,attribute=EstimatedCapacityLostTotal
-  - pattern: 'Hadoop<service=(.*), name=(.*)><>(.*_total): (\d+)'
+  - pattern: 'Hadoop<service=(.*), name=(.*)><>(.*_total):'
     attrNameSnakeCase: true
     name: hadoop_$1_$3
-    value: $4
     labels:
       service: HDFS
       role: $1
@@ -81,20 +75,18 @@ rules:
     type: COUNTER
   # Metrics suffixed with _info, e.g. Hadoop:name=JvmMetrics,attribute=LogInfo
   # The suffix _info is reserved for static information, therefore an underscore is appended.
-  - pattern: 'Hadoop<service=(.*), name=(.*)><>(.*_info): (.*)'
+  - pattern: 'Hadoop<service=(.*), name=(.*)><>(.*_info):'
     attrNameSnakeCase: true
     name: hadoop_$1_$3_
-    value: $4
     labels:
       service: HDFS
       role: $1
       kind: $2
     type: GAUGE
   # All other Hadoop metrics
-  - pattern: 'Hadoop<service=(.*), name=(.*)><>(.*): (.*)'
+  - pattern: 'Hadoop<service=(.*), name=(.*)><>(.*):'
     attrNameSnakeCase: true
     name: hadoop_$1_$3
-    value: $4
     labels:
       service: HDFS
       role: $1

--- a/hadoop/stackable/jmx/journalnode.yaml
+++ b/hadoop/stackable/jmx/journalnode.yaml
@@ -13,10 +13,9 @@ blacklistObjectNames:
   - 'Hadoop:service=JournalNode,name=UgiMetrics'
 rules:
   # MetricsSystem
-  - pattern: 'Hadoop<service=(.*), name=MetricsSystem, sub=(.*)><>(.*): (\d+)'
+  - pattern: 'Hadoop<service=(.*), name=MetricsSystem, sub=(.*)><>(.*):'
     attrNameSnakeCase: true
     name: hadoop_$1_$3
-    value: $4
     labels:
       service: HDFS
       role: $1
@@ -25,20 +24,18 @@ rules:
     type: GAUGE
   # Metrics suffixed with _info, e.g. Hadoop:name=JvmMetrics,attribute=LogInfo
   # The suffix _info is reserved for static information, therefore an underscore is appended.
-  - pattern: 'Hadoop<service=(.*), name=(.*)><>(.*_info): (.*)'
+  - pattern: 'Hadoop<service=(.*), name=(.*)><>(.*_info):'
     attrNameSnakeCase: true
     name: hadoop_$1_$3_
-    value: $4
     labels:
       service: HDFS
       role: $1
       kind: $2
     type: GAUGE
   # All other Hadoop metrics
-  - pattern: 'Hadoop<service=(.*), name=(.*)><>(.*): (.*)'
+  - pattern: 'Hadoop<service=(.*), name=(.*)><>(.*):'
     attrNameSnakeCase: true
     name: hadoop_$1_$3
-    value: $4
     labels:
       service: HDFS
       role: $1

--- a/hadoop/stackable/jmx/namenode.yaml
+++ b/hadoop/stackable/jmx/namenode.yaml
@@ -13,10 +13,9 @@ blacklistObjectNames:
   - 'Hadoop:service=NameNode,name=UgiMetrics'
 rules:
   # MetricsSystem
-  - pattern: 'Hadoop<service=(.*), name=MetricsSystem, sub=(.*)><>(.*): (\d+)'
+  - pattern: 'Hadoop<service=(.*), name=MetricsSystem, sub=(.*)><>(.*):'
     attrNameSnakeCase: true
     name: hadoop_$1_$3
-    value: $4
     labels:
       service: HDFS
       role: $1
@@ -24,20 +23,18 @@ rules:
       sub: $2
     type: GAUGE
   # Total raw capacity in bytes, e.g. Hadoop:name=NameNodeInfo,attribute=Total
-  - pattern: 'Hadoop<service=(.*), name=(.*)><>(total): (\d+)'
+  - pattern: 'Hadoop<service=(.*), name=(.*)><>(total):'
     attrNameSnakeCase: true
     name: hadoop_$1_$3
-    value: $4
     labels:
       service: HDFS
       role: $1
       kind: $2
     type: COUNTER
   # Generic counter, e.g. Hadoop:name=FSNamesystem,attribute=FilesTotal
-  - pattern: 'Hadoop<service=(.*), name=(.*)><>(.*_total): (\d+)'
+  - pattern: 'Hadoop<service=(.*), name=(.*)><>(.*_total):'
     attrNameSnakeCase: true
     name: hadoop_$1_$3
-    value: $4
     labels:
       service: HDFS
       role: $1
@@ -45,10 +42,9 @@ rules:
     type: COUNTER
   # Metrics suffixed with _created, e.g. Hadoop:name=NameNodeActivity,attribute=FilesCreated
   # The suffix _created is reserved for timestamps, therefore an underscore is appended.
-  - pattern: 'Hadoop<service=(.*), name=(.*)><>(.*_created): (.*)'
+  - pattern: 'Hadoop<service=(.*), name=(.*)><>(.*_created):'
     attrNameSnakeCase: true
     name: hadoop_$1_$3_
-    value: $4
     labels:
       service: HDFS
       role: $1
@@ -56,20 +52,18 @@ rules:
     type: GAUGE
   # Metrics suffixed with _info, e.g. Hadoop:name=JvmMetrics,attribute=LogInfo
   # The suffix _info is reserved for static information, therefore an underscore is appended.
-  - pattern: 'Hadoop<service=(.*), name=(.*)><>(.*_info): (.*)'
+  - pattern: 'Hadoop<service=(.*), name=(.*)><>(.*_info):'
     attrNameSnakeCase: true
     name: hadoop_$1_$3_
-    value: $4
     labels:
       service: HDFS
       role: $1
       kind: $2
     type: GAUGE
   # All other Hadoop metrics
-  - pattern: 'Hadoop<service=(.*), name=(.*)><>(.*): (.*)'
+  - pattern: 'Hadoop<service=(.*), name=(.*)><>(.*):'
     attrNameSnakeCase: true
     name: hadoop_$1_$3
-    value: $4
     labels:
       service: HDFS
       role: $1


### PR DESCRIPTION
# Description

Allow boolean metrics to be exported for HDFS.

If a value field is provided in the JMX exporter rules, then the value is parsed as Double (see https://github.com/prometheus/jmx_exporter/blob/1.2.0/collector/src/main/java/io/prometheus/jmx/JmxCollector.java#L699-L714).
If the value field is "not specified the scraped mBean value will be used." (see http://prometheus.github.io/jmx_exporter/1.2.0/http-mode/rules/). This seems to be the usual case anyway.

If the bean value is used, numbers and booleans are supported (see https://github.com/prometheus/jmx_exporter/blob/1.2.0/collector/src/main/java/io/prometheus/jmx/JmxCollector.java#L800-L811).

With this change, e.g. the metric `hadoop_namenode_security_enabled` is exported:

```
# HELP hadoop_namenode_security_enabled Hadoop:name=NameNodeStatus,type=null,attribute=SecurityEnabled
# TYPE hadoop_namenode_security_enabled gauge
hadoop_namenode_security_enabled{kind="NameNodeStatus",role="NameNode",service="HDFS"} 0.0
```


> [!NOTE]
> This pull request is just the byproduct of a research task for a customer. Instead of documenting the issue, I just fixed it.

## Definition of Done Checklist

Please make sure all these things are done and tick the boxes

- [x] Add an entry to the CHANGELOG.md file
- [x] Integration tests ran successfully (stackabletech/hdfs-operator#690)

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
