### PR TITLE
ci(ubi-rust-builder): Restrict paths that trigger a build

### DIFF
--- a/.github/workflows/ubi-rust-builder.yml
+++ b/.github/workflows/ubi-rust-builder.yml
@@ -7,6 +7,12 @@ on:
   push:
     branches:
       - main
+    paths:
+      - ubi9-rust-builder/**
+      - ubi10-rust-builder/**
+      - .github/actions/**
+      - .github/workflows/ubi-rust-builder.yml
+      - .github/workflows/reusable_build_image.yaml
   schedule:
     - cron: '30 4 * * *'
   workflow_dispatch:


### PR DESCRIPTION
Builds were being triggered on all unrelated changes

I added a trigger for the upcoming ubi10 builder too.

I purposefully left this change out of the changelog as it isn't very relevant to the changelog audience.