### PR TITLE
fix(trino): Restore CycloneDX patch for 451

### DIFF
--- a/trino/storage-connector/stackable/patches/451/0001-Add-CycloneDX-plugin.patch
+++ b/trino/storage-connector/stackable/patches/451/0001-Add-CycloneDX-plugin.patch
@@ -1,0 +1,38 @@
+From c14ba9cd92451a2c8a7ad7da2ff2e3f5cdbf2201 Mon Sep 17 00:00:00 2001
+From: Lukas Voetmand <lukas.voetmand@stackable.tech>
+Date: Fri, 6 Sep 2024 17:53:52 +0200
+Subject: Add CycloneDX plugin
+
+---
+ pom.xml | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/pom.xml b/pom.xml
+index 7304dac..d73dacf 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -544,6 +544,24 @@
+                     </dependency>
+                 </dependencies>
+             </plugin>
++            <plugin>
++                <groupId>org.cyclonedx</groupId>
++                <artifactId>cyclonedx-maven-plugin</artifactId>
++                <version>2.8.0</version>
++                <configuration>
++                    <projectType>application</projectType>
++                    <schemaVersion>1.5</schemaVersion>
++                    <skipNotDeployed>false</skipNotDeployed>
++                </configuration>
++                <executions>
++                    <execution>
++                        <goals>
++                            <goal>makeBom</goal>
++                        </goals>
++                        <phase>package</phase>
++                    </execution>
++                </executions>
++            </plugin>
+         </plugins>
+     </build>
+ </project>


### PR DESCRIPTION
The patch went missing during a merge in https://github.com/stackabletech/docker-images/pull/1095