### PR TITLE
feat(airflow): Update the kubernetes provider to 10.5.0

### DIFF
--- a/airflow/stackable/constraints/3.0.1/constraints-python3.12.txt
+++ b/airflow/stackable/constraints/3.0.1/constraints-python3.12.txt
@@ -122,7 +122,14 @@ apache-airflow-providers-asana==2.9.1
 apache-airflow-providers-atlassian-jira==3.0.2
 apache-airflow-providers-celery==3.10.6
 apache-airflow-providers-cloudant==4.1.1
-apache-airflow-providers-cncf-kubernetes==10.4.3
+# Stackable patch:
+# The 10.4.3 Kubernetes provider shipped with Airflow 3.0.1 has a problem.
+# https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/10.5.0/changelog.html#id1
+# It uses a busybox sidecar container to start tasks using the kubernetes executor
+# Two problems with that:
+# 1) The securityContext says "runAsNonRoot" but the busybox image defaults to root so it fails to be scheduled (at least on a standard OpenShift)
+# 2) The busybox image might not be available on air-gapped clusters
+apache-airflow-providers-cncf-kubernetes==10.5.0
 apache-airflow-providers-cohere==1.4.3
 apache-airflow-providers-common-compat==1.6.1
 apache-airflow-providers-common-io==1.5.4


### PR DESCRIPTION
# Description

The 10.4.3 Kubernetes provider shipped with Airflow 3.0.1 has a problem.
https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/10.5.0/changelog.html#id1
It uses a busybox sidecar container to start tasks using the kubernetes executor
Two problems with that:
1) The securityContext says "runAsNonRoot" but the busybox image defaults to root so it fails to be scheduled (at least on a standard OpenShift)
2) The busybox image might not be available on air-gapped clusters

I ran a few integration tests on OpenShift and they all passed :partying_face:

Not sure if this requires a CHANGELOG entry?

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [x] Changes are OpenShift compatible
- [ ] Add an entry to the CHANGELOG.md file
- [x] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
