### PR TITLE
chore(ubi-minimal): Update manifest SHA before SDP 25.7.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/early-pre-release.md
+++ b/.github/ISSUE_TEMPLATE/early-pre-release.md
@@ -53,6 +53,7 @@ Part of stackabletech/issues#xxx.
 
 ## Additional items which don't have a tracking issue
 
+- [ ] jmx_exporter (validate via hdfs-operator smoke tests)
 - [ ] krb5
 - [ ] tools
 - [ ] testing-tools

--- a/.github/ISSUE_TEMPLATE/early-pre-release.md
+++ b/.github/ISSUE_TEMPLATE/early-pre-release.md
@@ -53,7 +53,6 @@ Part of stackabletech/issues#xxx.
 
 ## Additional items which don't have a tracking issue
 
-- [ ] hello-world
 - [ ] krb5
 - [ ] tools
 - [ ] testing-tools

--- a/.github/ISSUE_TEMPLATE/update-base-java.md
+++ b/.github/ISSUE_TEMPLATE/update-base-java.md
@@ -46,7 +46,7 @@ we should also make new versions of Java available for use.
 
 ## Related Pull Requests
 
-- [ ] _Link to the docker-images PR (product update)_
+- _Link to the docker-images PR (product update)_
 
 ## Acceptance
 

--- a/.github/ISSUE_TEMPLATE/update-base-stackable.md
+++ b/.github/ISSUE_TEMPLATE/update-base-stackable.md
@@ -13,13 +13,6 @@ assignees: ''
 
 Part of #xxx.
 
-<!--
-This gives hints to the person doing the work.
-Add/Change/Remove anything that isn't applicable anymore
--->
-- Add: `x.x.x`
-- Remove: `y.y.y`
-
 > [!TIP]
 > Please add the `scheduled-for/20XX-XX` label, and add to the [Stackable Engineering][1] project.
 >
@@ -35,9 +28,9 @@ Add/Change/Remove anything that isn't applicable anymore
 ### `stackable-devel`
 
 - [ ] Update `FROM ...ubi-minimal` version hash in the Dockerfile
-- [ ] Update `RUST_DEFAULT_TOOLCHAIN_VERSION`
-- [ ] Update `CARGO_CYCLONEDX_CRATE_VERSION`
-- [ ] Update `CARGO_AUDITABLE_CRATE_VERSION`
+- [ ] Update `RUST_DEFAULT_TOOLCHAIN_VERSION` (if tools need it, eg: patchable, config-utils)
+- [ ] Update `CARGO_CYCLONEDX_CRATE_VERSION` (if necessary)
+- [ ] Update `CARGO_AUDITABLE_CRATE_VERSION` (if necessary)
 
 ## Related Pull Requests
 

--- a/.github/ISSUE_TEMPLATE/update-base-stackable.md
+++ b/.github/ISSUE_TEMPLATE/update-base-stackable.md
@@ -40,7 +40,7 @@ Part of #xxx.
 
 ## Related Pull Requests
 
-- [ ] _Link to the docker-images PR (product update)_
+- _Link to the docker-images PR (product update)_
 
 ## Acceptance
 

--- a/.github/ISSUE_TEMPLATE/update-base-stackable.md
+++ b/.github/ISSUE_TEMPLATE/update-base-stackable.md
@@ -20,6 +20,12 @@ Part of #xxx.
 
 ## Update tasks
 
+> [!NOTE]
+> When updating the base image, you will likely get a build failure related to the CA certificates.
+> This means you will need to update the `ca-certificates-*` package and try again. The build will
+> fail if the blocked certificates are still found.
+> The package check exists so that we can remove it once (if ever) the _bad_ CA has been removed.
+
 ### `stackable-base`
 
 - [ ] Update `FROM ...ubi-minimal` version hash in the Dockerfile

--- a/.github/ISSUE_TEMPLATE/update-base-ubi-rust-builders.md
+++ b/.github/ISSUE_TEMPLATE/update-base-ubi-rust-builders.md
@@ -41,9 +41,9 @@ Add/Change/Remove anything that isn't applicable anymore
 
 ## Related Pull Requests
 
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Bump rust toolchain in operator-rs_
-- [ ] _Bump rust toolchain in operator-templating_
+- _Link to the docker-images PR (product update)_
+- _Bump rust toolchain in operator-rs_
+- _Bump rust toolchain in operator-templating_
 
 ## Acceptance
 

--- a/.github/ISSUE_TEMPLATE/update-base-vector.md
+++ b/.github/ISSUE_TEMPLATE/update-base-vector.md
@@ -47,11 +47,11 @@ Add/Change/Remove anything that isn't applicable anymore
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
+- _Link to the docker-images PR (product update)_
+- _Link to the operator PR (getting_started / kuttl / supported-versions)_
+- _Link to any other operator PRs (getting_started / kuttl)_
+- _Link to demo PR (raise against the `main` branch)_
+- _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
 ## Acceptance
 

--- a/.github/ISSUE_TEMPLATE/update-product-airflow.md
+++ b/.github/ISSUE_TEMPLATE/update-product-airflow.md
@@ -40,11 +40,11 @@ Add/Change/Remove anything that isn't applicable anymore
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to operator PR (getting_started / kuttl)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
+- _Link to the docker-images PR (product update)_
+- _Link to operator PR (getting_started / kuttl)_
+- _Link to any other operator PRs (getting_started / kuttl)_
+- _Link to demo PR (raise against the `main` branch)_
+- _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
 ## Acceptance
 

--- a/.github/ISSUE_TEMPLATE/update-product-druid.md
+++ b/.github/ISSUE_TEMPLATE/update-product-druid.md
@@ -44,12 +44,12 @@ Add/Change/Remove anything that isn't applicable anymore
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-- [ ] _Link to [druid-opa-authorizer](https://github.com/stackabletech/druid-opa-authorizer/) PR_
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
+- _Link to [druid-opa-authorizer](https://github.com/stackabletech/druid-opa-authorizer/) PR_
+- _Link to the docker-images PR (product update)_
+- _Link to the operator PR (getting_started / kuttl / supported-versions)_
+- _Link to any other operator PRs (getting_started / kuttl)_
+- _Link to demo PR (raise against the `main` branch)_
+- _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
 ## Acceptance
 

--- a/.github/ISSUE_TEMPLATE/update-product-hbase-phoenix-omid.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hbase-phoenix-omid.md
@@ -48,11 +48,11 @@ Add/Change/Remove anything that isn't applicable anymore
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to operator PR (getting_started / kuttl)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
+- _Link to the docker-images PR (product update)_
+- _Link to operator PR (getting_started / kuttl)_
+- _Link to any other operator PRs (getting_started / kuttl)_
+- _Link to demo PR (raise against the `main` branch)_
+- _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
 ## Acceptance
 

--- a/.github/ISSUE_TEMPLATE/update-product-hdfs.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hdfs.md
@@ -40,12 +40,12 @@ Add/Change/Remove anything that isn't applicable anymore
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to [hdfs-utils](https://github.com/stackabletech/hdfs-utils/) PR (if applicable)_
-- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
+- _Link to the docker-images PR (product update)_
+- _Link to [hdfs-utils](https://github.com/stackabletech/hdfs-utils/) PR (if applicable)_
+- _Link to the operator PR (getting_started / kuttl / supported-versions)_
+- _Link to any other operator PRs (getting_started / kuttl)_
+- _Link to demo PR (raise against the `main` branch)_
+- _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
 ## Acceptance
 

--- a/.github/ISSUE_TEMPLATE/update-product-hive.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hive.md
@@ -41,11 +41,11 @@ Add/Change/Remove anything that isn't applicable anymore
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
+- _Link to the docker-images PR (product update)_
+- _Link to the operator PR (getting_started / kuttl / supported-versions)_
+- _Link to any other operator PRs (getting_started / kuttl)_
+- _Link to demo PR (raise against the `main` branch)_
+- _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
 ## Acceptance
 

--- a/.github/ISSUE_TEMPLATE/update-product-kafka.md
+++ b/.github/ISSUE_TEMPLATE/update-product-kafka.md
@@ -53,11 +53,11 @@ Add/Change/Remove anything that isn't applicable anymore
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
+- _Link to the docker-images PR (product update)_
+- _Link to the operator PR (getting_started / kuttl / supported-versions)_
+- _Link to any other operator PRs (getting_started / kuttl)_
+- _Link to demo PR (raise against the `main` branch)_
+- _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
 ## Acceptance
 

--- a/.github/ISSUE_TEMPLATE/update-product-nifi.md
+++ b/.github/ISSUE_TEMPLATE/update-product-nifi.md
@@ -40,11 +40,11 @@ Add/Change/Remove anything that isn't applicable anymore
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
+- _Link to the docker-images PR (product update)_
+- _Link to the operator PR (getting_started / kuttl / supported-versions)_
+- _Link to any other operator PRs (getting_started / kuttl)_
+- _Link to demo PR (raise against the `main` branch)_
+- _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
 ## Acceptance
 

--- a/.github/ISSUE_TEMPLATE/update-product-opa.md
+++ b/.github/ISSUE_TEMPLATE/update-product-opa.md
@@ -39,11 +39,11 @@ Add/Change/Remove anything that isn't applicable anymore
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
+- _Link to the docker-images PR (product update)_
+- _Link to the operator PR (getting_started / kuttl / supported-versions)_
+- _Link to any other operator PRs (getting_started / kuttl)_
+- _Link to demo PR (raise against the `main` branch)_
+- _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
 ## Acceptance
 

--- a/.github/ISSUE_TEMPLATE/update-product-spark.md
+++ b/.github/ISSUE_TEMPLATE/update-product-spark.md
@@ -41,11 +41,11 @@ Add/Change/Remove anything that isn't applicable anymore
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
+- _Link to the docker-images PR (product update)_
+- _Link to the operator PR (getting_started / kuttl / supported-versions)_
+- _Link to any other operator PRs (getting_started / kuttl)_
+- _Link to demo PR (raise against the `main` branch)_
+- _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
 ## Acceptance
 

--- a/.github/ISSUE_TEMPLATE/update-product-superset.md
+++ b/.github/ISSUE_TEMPLATE/update-product-superset.md
@@ -42,11 +42,11 @@ Add/Change/Remove anything that isn't applicable anymore
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
+- _Link to the docker-images PR (product update)_
+- _Link to the operator PR (getting_started / kuttl / supported-versions)_
+- _Link to any other operator PRs (getting_started / kuttl)_
+- _Link to demo PR (raise against the `main` branch)_
+- _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
 ## Acceptance
 

--- a/.github/ISSUE_TEMPLATE/update-product-trino.md
+++ b/.github/ISSUE_TEMPLATE/update-product-trino.md
@@ -52,11 +52,11 @@ Add/Change/Remove anything that isn't applicable anymore
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
+- _Link to the docker-images PR (product update)_
+- _Link to the operator PR (getting_started / kuttl / supported-versions)_
+- _Link to any other operator PRs (getting_started / kuttl)_
+- _Link to demo PR (raise against the `main` branch)_
+- _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
 ## Acceptance
 

--- a/.github/ISSUE_TEMPLATE/update-product-trino.md
+++ b/.github/ISSUE_TEMPLATE/update-product-trino.md
@@ -35,6 +35,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
 - [ ] Maybe update versions in `tests/templates/kuttl/opa-authorization/check-opa.py.j2` (if tests fail)
 - [ ] Update the version in demos. Add the PR(s) to the list below.
+- [ ] Update versions used in the documentation repository
 
 ### trino-cli
 
@@ -43,6 +44,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
 - [ ] Update the version in demos. Add the PR(s) to the list below.
+- [ ] Update versions used in the documentation repository
 
 ## Related Pull Requests
 

--- a/.github/ISSUE_TEMPLATE/update-product-trino.md
+++ b/.github/ISSUE_TEMPLATE/update-product-trino.md
@@ -33,7 +33,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - [ ] Update `versions.py` to the latest supported version of JVM (base and devel).
 - [ ] Update other dependencies if applicable (eg: jmx_exporter, opa_authorizer, storage_connector, etc).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
-- [ ] Update versions in `tests/templates/kuttl/opa-authorization/check-opa.py.j2`
+- [ ] Maybe update versions in `tests/templates/kuttl/opa-authorization/check-opa.py.j2` (if tests fail)
 - [ ] Update the version in demos. Add the PR(s) to the list below.
 
 ### trino-cli

--- a/.github/ISSUE_TEMPLATE/update-product-zookeeper.md
+++ b/.github/ISSUE_TEMPLATE/update-product-zookeeper.md
@@ -40,11 +40,11 @@ Add/Change/Remove anything that isn't applicable anymore
 > Delete any items that do not apply so that all applicable items can be checked.
 > For example, if you add release notes to the documentation repository, you do not need the latter two criteria.
 
-- [ ] _Link to the docker-images PR (product update)_
-- [ ] _Link to the operator PR (getting_started / kuttl / supported-versions)_
-- [ ] _Link to any other operator PRs (getting_started / kuttl)_
-- [ ] _Link to demo PR (raise against the `main` branch)_
-- [ ] _Link to the Release Notes PR in the documentation repo (if not a comment below)_
+- _Link to the docker-images PR (product update)_
+- _Link to the operator PR (getting_started / kuttl / supported-versions)_
+- _Link to any other operator PRs (getting_started / kuttl)_
+- _Link to demo PR (raise against the `main` branch)_
+- _Link to the Release Notes PR in the documentation repo (if not a comment below)_
 
 ## Acceptance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,9 @@ All notable changes to this project will be documented in this file.
 
 - airflow,superset: Use `uv` to build the product ([#1116]).
 - ubi-rust-builder: Bump Rust toolchain to 1.85.0, cargo-cyclonedx to 0.5.7, and cargo-auditable to 0.6.6 ([#1050]).
-- ubi9-rust-builder: Bump base image and update protoc to `30.2` ([#1091]).
-- stackable-devel: Bump ubi9 base image ([#1103], [#1137]).
+- ubi9-rust-builder: Bump base image and update protoc to `30.2` ([#1091], [#1163]).
+- stackable-base: Bump ubi9 base image ([#1163]).
+- stackable-devel: Bump ubi9 base image ([#1103], [#1137], [#1163]).
 - spark-k8s: Include spark-connect jars, replace OpenJDK with Temurin JDK, cleanup ([#1034]).
 - spark-connect-client: Image is now completely based on spark-k8s and includes JupyterLab and other demo dependencies ([#1071]).
 - jmx_exporter: Bump products to use `1.3.0` ([#1090], [#1156]).
@@ -182,6 +183,7 @@ All notable changes to this project will be documented in this file.
 [#1151]: https://github.com/stackabletech/docker-images/pull/1151
 [#1152]: https://github.com/stackabletech/docker-images/pull/1152
 [#1156]: https://github.com/stackabletech/docker-images/pull/1156
+[#1163]: https://github.com/stackabletech/docker-images/pull/1163
 
 ## [25.3.0] - 2025-03-21
 

--- a/stackable-base/Dockerfile
+++ b/stackable-base/Dockerfile
@@ -153,11 +153,14 @@ chown ${STACKABLE_USER_UID}:0 /stackable/.curlrc
 # CVE-2023-37920: Remove "e-Tugra" root certificates
 # e-Tugra's root certificates were subject to an investigation prompted by reporting of security issues in their systems
 # Until they are removed by default from ca-certificates, we should remove them manually
-if [ "$(rpm -qa ca-certificates)" != "ca-certificates-2024.2.69_v8.0.303-91.4.el9_4.noarch" ]; then
-  echo "The ca-certificates package was updated. Please check if the e-Tugra root certificates are present. \
+EXPECTED_CERTS_PACKAGE="ca-certificates-2024.2.69_v8.0.303-91.4.el9_4.noarch"
+ACTUAL_CERTS_PACKAGE="$(rpm -qa ca-certificates)"
+if [ "$ACTUAL_CERTS_PACKAGE" != "$EXPECTED_CERTS_PACKAGE" ]; then
+  echo "The ca-certificates package was updated to $ACTUAL_CERTS_PACKAGE. Please check if the e-Tugra root certificates are present. \
 When they have been removed, manually blacklisting them should be removed"
   echo "Let me help you by running trust list --filter=ca-anchors | grep 'E-Tugra'"
   trust list --filter=ca-anchors | grep 'E-Tugra'
+  echo "If the cert appears above, please update the expected package: EXPECTED_CERTS_PACKAGE=\"$ACTUAL_CERTS_PACKAGE\""
   exit 1;
 fi
 EOF

--- a/stackable-base/Dockerfile
+++ b/stackable-base/Dockerfile
@@ -36,7 +36,7 @@ EOF
 # Find the latest version at https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5?container-tabs=gti
 # IMPORTANT: Make sure to use the "Manifest List Digest" that references the images for multiple architectures
 # rather than just the "Image Digest" that references the image for the selected architecture.
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:92b1d5747a93608b6adb64dfd54515c3c5a360802db4706765ff3d8470df6290 AS final
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:f172b3082a3d1bbe789a1057f03883c1113243564f01cd3020e27548b911d3f8 AS final
 
 # intentionally unused
 ARG PRODUCT

--- a/stackable-devel/Dockerfile
+++ b/stackable-devel/Dockerfile
@@ -11,7 +11,7 @@
 # Find the latest version at https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5?container-tabs=gti
 # IMPORTANT: Make sure to use the "Manifest List Digest" that references the images for multiple architectures
 # rather than just the "Image Digest" that references the image for the selected architecture.
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:92b1d5747a93608b6adb64dfd54515c3c5a360802db4706765ff3d8470df6290
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:f172b3082a3d1bbe789a1057f03883c1113243564f01cd3020e27548b911d3f8
 
 # intentionally unused
 ARG PRODUCT

--- a/ubi9-rust-builder/Dockerfile
+++ b/ubi9-rust-builder/Dockerfile
@@ -3,7 +3,7 @@
 
 # Find the latest version at https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5?container-tabs=gti
 # IMPORTANT: Be sure to use the Manifest List Digest for multi-arch support
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:92b1d5747a93608b6adb64dfd54515c3c5a360802db4706765ff3d8470df6290 AS builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:f172b3082a3d1bbe789a1057f03883c1113243564f01cd3020e27548b911d3f8 AS builder
 
 LABEL maintainer="Stackable GmbH"
 


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1162.

> [!CAUTION]
> Merging this will trigger a lot of builds across the images and consume all of the runners.

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [x] Add an entry to the CHANGELOG.md file

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
