### PR TITLE
chore(testing-tools): Update the base image

### DIFF
--- a/.github/ISSUE_TEMPLATE/early-pre-release.md
+++ b/.github/ISSUE_TEMPLATE/early-pre-release.md
@@ -54,9 +54,8 @@ Part of stackabletech/issues#xxx.
 
 - [ ] jmx_exporter (validate via hdfs-operator smoke tests)
 - [ ] krb5
-- [ ] tools
-- [ ] testing-tools
+- [ ] tools (update the versions in version.py)
+- [ ] testing-tools (update the base, maybe keycloak)
 - [ ] statsd_exporter
-- [ ] cyclonedx-bom (pip)
 - [ ] csi-provisioner for secret-operator
 - [ ] csi-provisioner for listener-operator

--- a/.github/ISSUE_TEMPLATE/early-pre-release.md
+++ b/.github/ISSUE_TEMPLATE/early-pre-release.md
@@ -36,7 +36,6 @@ Part of stackabletech/issues#xxx.
 
 - [ ] [Create issue from template: update-base-java.md](https://github.com/stackabletech/docker-images/issues/new?template=update-base-java.md)
 - [ ] [Create issue from template: update-base-stackable.md](https://github.com/stackabletech/docker-images/issues/new?template=update-base-stackable.md)
-- [ ] [Create issue from template: update-base-ubi-rust-builders.md](https://github.com/stackabletech/docker-images/issues/new?template=update-base-ubi-rust-builders.md)
 - [ ] [Create issue from template: update-base-vector.md](https://github.com/stackabletech/docker-images/issues/new?template=update-base-vector.md)
 - [ ] [Create issue from template: update-product-airflow.md](https://github.com/stackabletech/docker-images/issues/new?template=update-product-airflow.md)
 - [ ] [Create issue from template: update-product-druid.md](https://github.com/stackabletech/docker-images/issues/new?template=update-product-druid.md)

--- a/.github/ISSUE_TEMPLATE/update-product-airflow.md
+++ b/.github/ISSUE_TEMPLATE/update-product-airflow.md
@@ -29,7 +29,7 @@ Add/Change/Remove anything that isn't applicable anymore
 
 - [ ] Update `versions.py` to reflect the agreed upon versions in the spreadsheet (including the removal of old versions).
 - [ ] Download new constraints file (see `airflow/download_constraints.sh`).
-- [ ] Update other dependencies if applicable (eg: python, statsd_exporter, etc).
+- [ ] Update other dependencies if applicable (eg: python, statsd_exporter, cyclonedx-bom, etc).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
 - [ ] Ensure prerequisites are up to date (required-external-components.adoc).
 - [ ] Update the version in demos. Add the PR(s) to the list below.

--- a/.github/ISSUE_TEMPLATE/update-product-superset.md
+++ b/.github/ISSUE_TEMPLATE/update-product-superset.md
@@ -31,7 +31,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - [ ] Create a new constraints file (see `superset/README.md`).
 - [ ] Create a file: `superset/stackable/patches/x.y.z/.gitkeep`, add patches if applicable.
 - [ ] Delete old constraint files and patch directories.
-- [ ] Update other dependencies if applicable (eg: python, auth_lib, etc).
+- [ ] Update other dependencies if applicable (eg: python, auth_lib, cyclonedx-bom, etc).
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
 - [ ] Ensure prerequisites are up to date (required-external-components.adoc).
 - [ ] Update the version in demos. Add the PR(s) to the list below.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ All notable changes to this project will be documented in this file.
 - druid: Bump druiod-opa-authorizer to `0.7.0` ([#1139]).
 - vector: Bump to `0.47.0` ([#1152]).
 - zookeeper: backport ZOOKEEPER-4846, ZOOKEEPER-4921, ZOOKEEPER-4925 into Zookeeper 3.9.3 ([#1150]).
+- testing-tools: Update base image ([#1165]).
 
 ### Fixed
 
@@ -184,6 +185,7 @@ All notable changes to this project will be documented in this file.
 [#1152]: https://github.com/stackabletech/docker-images/pull/1152
 [#1156]: https://github.com/stackabletech/docker-images/pull/1156
 [#1163]: https://github.com/stackabletech/docker-images/pull/1163
+[#1165]: https://github.com/stackabletech/docker-images/pull/1165
 
 ## [25.3.0] - 2025-03-21
 

--- a/testing-tools/Dockerfile
+++ b/testing-tools/Dockerfile
@@ -3,7 +3,7 @@
 
 # Manifest list digest because of multi architecture builds ( https://www.redhat.com/architect/pull-container-image#:~:text=A%20manifest%20list%20exists%20to,system%20on%20a%20specific%20architecture )
 # https://hub.docker.com/_/python/tags
-# Unfortunately docker hub doesn't show the manifest list digest, so you should do:
+# In Docker Hub, open up the tag and look for Index Digest. Otherwise do:
 # docker pull python:3.12-slim-bullseye and see the digest that appears in the output.
 FROM python:3.12-slim-bullseye@sha256:229b2897e6b5c630d83a721e42dd1c96e3ec996323bb822b076eb865e2c6c0b2
 

--- a/testing-tools/Dockerfile
+++ b/testing-tools/Dockerfile
@@ -3,7 +3,9 @@
 
 # Manifest list digest because of multi architecture builds ( https://www.redhat.com/architect/pull-container-image#:~:text=A%20manifest%20list%20exists%20to,system%20on%20a%20specific%20architecture )
 # https://hub.docker.com/_/python/tags
-FROM python:3.12-slim-bullseye@sha256:57ab68549579e5e7bdf485fd33792577b5f4c14336fdc9a9a5a9fb6af0af1776
+# Unfortunately docker hub doesn't show the manifest list digest, so you should do:
+# docker pull python:3.12-slim-bullseye and see the digest that appears in the output.
+FROM python:3.12-slim-bullseye@sha256:229b2897e6b5c630d83a721e42dd1c96e3ec996323bb822b076eb865e2c6c0b2
 
 ARG PRODUCT
 ARG RELEASE


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1066.

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
