### PR TITLE
feat: custom version for OPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ All notable changes to this project will be documented in this file.
 - vector: Bump to `0.47.0` ([#1152]).
 - zookeeper: backport ZOOKEEPER-4846, ZOOKEEPER-4921, ZOOKEEPER-4925 into Zookeeper 3.9.3 ([#1150]).
 - testing-tools: Update base image ([#1165]).
+- opa: Enable custom versions ([#1170]).
 
 ### Fixed
 
@@ -190,6 +191,7 @@ All notable changes to this project will be documented in this file.
 [#1163]: https://github.com/stackabletech/docker-images/pull/1163
 [#1165]: https://github.com/stackabletech/docker-images/pull/1165
 [#1161]: https://github.com/stackabletech/docker-images/pull/1161
+[#1170]: https://github.com/stackabletech/docker-images/pull/1170
 
 ## [25.3.0] - 2025-03-21
 

--- a/opa/Dockerfile
+++ b/opa/Dockerfile
@@ -77,8 +77,13 @@ go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.7.0
 
 cd "$(/stackable/patchable --images-repo-root=src checkout opa ${PRODUCT})"
 
+ORIGINAL_VERSION=${PRODUCT}
+NEW_VERSION="${PRODUCT}-stackable${RELEASE}"
+
+sed -i 's/var Version = "'${ORIGINAL_VERSION}'"/var Version = "'${NEW_VERSION}'"/g' v1/version/version.go
+
 # Create snapshot of the source code including custom patches
-tar -czf /stackable/opa-${PRODUCT}-src.tar.gz .
+tar -czf /stackable/opa-${NEW_VERSION}-src.tar.gz .
 
 # Unfortunately, we need to create a dummy Git repository to allow cyclonedx-gomod to determine the version of OPA
 rm .git
@@ -86,14 +91,15 @@ git init
 git config user.email "fake.commiter@stackable.tech"
 git config user.name "Fake commiter"
 git commit --allow-empty --message "Fake commit, so that we can create a tag"
-git tag "v${PRODUCT}"
+git tag "v${NEW_VERSION}"
 go build -o opa -buildmode=exe
 # move artifact to /stackable/*/ to copy in final image
-~/go/bin/cyclonedx-gomod app -json -output-version 1.5 -output /stackable/opa/"opa_${PRODUCT}.cdx.json" -packages -files
+~/go/bin/cyclonedx-gomod app -json -output-version 1.5 -output /stackable/opa/"opa_${NEW_VERSION}.cdx.json" -packages -files
+sed -i "s/${NEW_VERSION}/${ORIGINAL_VERSION}/g" /stackable/opa/"opa_${NEW_VERSION}.cdx.json"
 # move artifact to /stackable/* to copy in final image
 mv opa /stackable/opa/
 # set correct groups
-chmod -R g=u /stackable/opa /stackable/opa-${PRODUCT}-src.tar.gz
+chmod -R g=u /stackable/opa /stackable/opa-${NEW_VERSION}-src.tar.gz
 EOF
 
 FROM stackable/image/vector
@@ -113,7 +119,7 @@ LABEL name="Open Policy Agent" \
 COPY --chown=${STACKABLE_USER_UID}:0 opa/licenses /licenses
 
 COPY --from=opa-builder --chown=${STACKABLE_USER_UID}:0 /stackable/opa /stackable/opa
-COPY --from=opa-builder --chown=${STACKABLE_USER_UID}:0 /stackable/opa-${PRODUCT}-src.tar.gz /stackable/opa-${PRODUCT}-src.tar.gz
+COPY --from=opa-builder --chown=${STACKABLE_USER_UID}:0 /stackable/opa-${PRODUCT}-stackable${RELEASE}-src.tar.gz /stackable/opa-${PRODUCT}-stackable${RELEASE}-src.tar.gz
 COPY --from=multilog-builder --chown=${STACKABLE_USER_UID}:0 /daemontools/admin/daemontools/command/multilog /stackable/multilog
 
 RUN <<EOF


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/docker-images/issues/1068

This PR enables custom versions (with a suffix like `-stackable0.0.0-dev`) for OPA.

In the SBOM, the custom version is replaced by the original one (using `sed`), so vulnerabilities filed directly against OPA are still detected by scanners when scanning the SBOM.

I built OPA 1.4.2, tested it with the smoke test and manually validated that it reported the correct version.

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] All packages should have (if available) signatures/hashes verified
- [x] Add an entry to the CHANGELOG.md file
- [x] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
