### PR TITLE
Revert "chore(zookeeper): remove jmx exporter (#1161)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,6 @@ All notable changes to this project will be documented in this file.
 - kafka: Remove `3.7.1` and `3.8.0` ([#1117]).
 - spark-connect-client: Remove `3.5.5` ([#1142]).
 - spark-k8s: Remove the JMX exporter jar ([#1157]).
-- zookeeper: Remove jmx exporter ([#1161]).
 
 [nifi-iceberg-bundle]: https://github.com/stackabletech/nifi-iceberg-bundle
 [#1025]: https://github.com/stackabletech/docker-images/pull/1025
@@ -189,7 +188,6 @@ All notable changes to this project will be documented in this file.
 [#1157]: https://github.com/stackabletech/docker-images/pull/1157
 [#1163]: https://github.com/stackabletech/docker-images/pull/1163
 [#1165]: https://github.com/stackabletech/docker-images/pull/1165
-[#1161]: https://github.com/stackabletech/docker-images/pull/1161
 
 ## [25.3.0] - 2025-03-21
 

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -7,11 +7,14 @@
 FROM stackable/image/java-devel AS builder
 
 ARG PRODUCT
+ARG JMX_EXPORTER
 ARG STACKABLE_USER_UID
 
 # Copy patches into the builder
 COPY --chown=${STACKABLE_USER_UID}:0 zookeeper/stackable/patches/patchable.toml /stackable/src/zookeeper/stackable/patches/patchable.toml
 COPY --chown=${STACKABLE_USER_UID}:0 zookeeper/stackable/patches/${PRODUCT} /stackable/src/zookeeper/stackable/patches/${PRODUCT}
+# Copy JMX config into the builder
+COPY --chown=${STACKABLE_USER_UID}:0 zookeeper/stackable/jmx /stackable/jmx
 
 USER ${STACKABLE_USER_UID}
 WORKDIR /stackable
@@ -34,6 +37,12 @@ tar -C /stackable -xvzf /stackable/apache-zookeeper-${PRODUCT}-bin.tar.gz
 mv zookeeper-assembly/target/bom.json /stackable/apache-zookeeper-${PRODUCT}-bin/apache-zookeeper-${PRODUCT}.cdx.json
 rm -rf /stackable/apache-zookeeper-${PRODUCT}-bin/docs
 rm /stackable/apache-zookeeper-${PRODUCT}-bin/README_packaging.md
+
+# Download the JMX exporter jar from our own repo
+curl "https://repo.stackable.tech/repository/packages/jmx-exporter/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar" \
+  -o "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar"
+chmod +x "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar"
+ln -s "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar" /stackable/jmx/jmx_prometheus_javaagent.jar
 
 # set correct groups
 chmod -R g=u /stackable
@@ -63,6 +72,7 @@ LABEL  \
 # Copy over the ZooKeeper binary folder
 COPY --chown=${STACKABLE_USER_UID}:0 --from=builder /stackable/apache-zookeeper-${PRODUCT}-bin /stackable/apache-zookeeper-${PRODUCT}-bin/
 COPY --chown=${STACKABLE_USER_UID}:0 --from=builder /stackable/zookeeper-${PRODUCT}-src.tar.gz /stackable
+COPY --chown=${STACKABLE_USER_UID}:0 --from=builder /stackable/jmx /stackable/jmx/
 COPY zookeeper/licenses /licenses
 
 RUN <<EOF
@@ -79,6 +89,7 @@ ln -s /stackable/apache-zookeeper-${PRODUCT}-bin/ /stackable/zookeeper
 chown -h ${STACKABLE_USER_UID}:0 /stackable/zookeeper
 
 # fix missing permissions
+chmod g=u /stackable/jmx
 chmod g=u /stackable/apache-zookeeper-${PRODUCT}-bin/
 EOF
 

--- a/zookeeper/stackable/jmx/server.yaml
+++ b/zookeeper/stackable/jmx/server.yaml
@@ -1,0 +1,36 @@
+---
+rules:
+  # replicated Zookeeper
+  - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+)><>(\\w+)"
+    name: "zookeeper_$2"
+    type: GAUGE
+  - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+)><>(\\w+)"
+    name: "zookeeper_$3"
+    type: GAUGE
+    labels:
+      replicaId: "$2"
+  - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+)><>(Packets\\w+)"
+    name: "zookeeper_$4"
+    type: COUNTER
+    labels:
+      replicaId: "$2"
+      memberType: "$3"
+  - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+)><>(\\w+)"
+    name: "zookeeper_$4"
+    type: GAUGE
+    labels:
+      replicaId: "$2"
+      memberType: "$3"
+  - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+), name3=(\\w+)><>(\\w+)"
+    name: "zookeeper_$4_$5"
+    type: GAUGE
+    labels:
+      replicaId: "$2"
+      memberType: "$3"
+  # standalone Zookeeper
+  - pattern: "org.apache.ZooKeeperService<name0=StandaloneServer_port(\\d+)><>(\\w+)"
+    type: GAUGE
+    name: "zookeeper_$2"
+  - pattern: "org.apache.ZooKeeperService<name0=StandaloneServer_port(\\d+), name1=InMemoryDataTree><>(\\w+)"
+    type: GAUGE
+    name: "zookeeper_$2"

--- a/zookeeper/versions.py
+++ b/zookeeper/versions.py
@@ -7,5 +7,6 @@ versions = [
         # zookeeper: Execution spotbugs of goal com.github.spotbugs:spotbugs-maven-plugin:4.0.0:spotbugs failed: Java
         # returned: 1 -> [Help 1]
         "java-devel": "11",
+        "jmx_exporter": "1.3.0",
     },
 ]


### PR DESCRIPTION
This reverts commit fcdb3dc3f8e1365fd371944c5dcd7b69a182312b.

# Description

Due to the decision of keeping both jmx exporter and native prometheus metrics of products in for at least one release this needs reverting.

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
