### PR TITLE
Zookeeper: Fix CVE-2025-24970

### DIFF
--- a/zookeeper/stackable/patches/3.9.3/0006-Bumping-netty-to-4.1.119.Final-to-fix-CVE-2025-24970.patch
+++ b/zookeeper/stackable/patches/3.9.3/0006-Bumping-netty-to-4.1.119.Final-to-fix-CVE-2025-24970.patch
@@ -1,0 +1,22 @@
+From 60f6980c40d9bdc3b9a447d68fd9c4c02da7d3de Mon Sep 17 00:00:00 2001
+From: Maxi Wittich <maximilian.wittich@stackable.tech>
+Date: Tue, 17 Jun 2025 16:53:38 +0200
+Subject: Bumping netty to 4.1.119.Final to fix CVE-2025-24970
+
+---
+ pom.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pom.xml b/pom.xml
+index 9c201245..4d725e5e 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -559,7 +559,7 @@
+     <mockito.version>4.9.0</mockito.version>
+     <hamcrest.version>2.2</hamcrest.version>
+     <commons-cli.version>1.5.0</commons-cli.version>
+-    <netty.version>4.1.113.Final</netty.version>
++    <netty.version>4.1.119.Final</netty.version>
+     <jetty.version>9.4.57.v20241219</jetty.version>
+     <jackson.version>2.15.2</jackson.version>
+     <jline.version>2.14.6</jline.version>


### PR DESCRIPTION
# Description

Fixing  https://secobserve.stackable.tech/#/observations/1628708/show


- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
