### PR TITLE
fix: Hive 4.0.0 build

### DIFF
--- a/hive/Dockerfile
+++ b/hive/Dockerfile
@@ -47,7 +47,8 @@ cp -r /stackable/patched-libs/maven/* /stackable/.m2/repository
 
 NEW_VERSION="${PRODUCT}-stackable${RELEASE}"
 
-mvn versions:set -DnewVersion=$NEW_VERSION -DartifactId=* -DgroupId=*
+# generateBackupPoms=false is needed for the Hive 4.0.0 build to succeed, otherwise it fails with the obscure reason: `Too many files with unapproved license`
+mvn versions:set -DnewVersion=$NEW_VERSION -DartifactId=* -DgroupId=* -DgenerateBackupPoms=false
 
 # Create snapshot of the source code including custom patches
 tar -czf /stackable/hive-${NEW_VERSION}-src.tar.gz .


### PR DESCRIPTION
# Description

The Hive 4.0.0 build [is currently failing](https://github.com/stackabletech/docker-images/actions/runs/15727808470/job/44321591563) because of https://github.com/stackabletech/docker-images/pull/1173.

It's a strange and somewhat unrelated error:
```
[ERROR] Failed to execute goal org.apache.rat:apache-rat-plugin:0.13:check (default) on project hive: Too many files with unapproved license: 4 See RAT report in: /stackable/src/hive/patchable-wor
k/worktree/4.0.0/target/rat.txt
```

The `rat.txt` file contains some information, this is the relevant part:
```
4 Unknown Licenses

*****************************************************

Files with unapproved licenses:

  iceberg/iceberg-handler/pom.xml.versionsBackup
  iceberg/patched-iceberg-api/pom.xml.versionsBackup
  iceberg/patched-iceberg-core/pom.xml.versionsBackup
  iceberg/iceberg-catalog/pom.xml.versionsBackup
```

So I just disabled the creation of the `.versionsBackup`, since they are not needed anyway. Then the build succeeded locally.

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [x] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [x] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
