### PR TITLE
fix(trino): Disable checking of trino-web-ui

### DIFF
--- a/trino/trino/stackable/patches/470/0001-Add-CycloneDX-plugin.patch
+++ b/trino/trino/stackable/patches/470/0001-Add-CycloneDX-plugin.patch
@@ -8,7 +8,7 @@ Subject: Add CycloneDX plugin
  1 file changed, 18 insertions(+)
 
 diff --git a/pom.xml b/pom.xml
-index a1604d5ebec..3f9f7945046 100644
+index a1604d5ebe..3f9f794504 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -2814,6 +2814,24 @@

--- a/trino/trino/stackable/patches/470/0002-Disable-web-ui-code-checking-because-flow-v0.241.0-f.patch
+++ b/trino/trino/stackable/patches/470/0002-Disable-web-ui-code-checking-because-flow-v0.241.0-f.patch
@@ -1,0 +1,44 @@
+From 1ec0bcdafe9f74f37b6e791e3df6b552ba748538 Mon Sep 17 00:00:00 2001
+From: dervoeti <lukas.krug@stackable.tech>
+Date: Wed, 18 Jun 2025 15:22:49 +0200
+Subject: Disable web-ui code checking, because flow v0.241.0 for non-x86
+ systems requires glibc 2.35, as of 2025-06-18 our UBI image comes with glibc
+ 2.34. This patch can likely be removed once we ship a newer version of glibc.
+
+---
+ core/trino-web-ui/pom.xml | 22 ----------------------
+ 1 file changed, 22 deletions(-)
+
+diff --git a/core/trino-web-ui/pom.xml b/core/trino-web-ui/pom.xml
+index d097a1e22f..98c7516af1 100644
+--- a/core/trino-web-ui/pom.xml
++++ b/core/trino-web-ui/pom.xml
+@@ -103,28 +103,6 @@
+                             <workingDirectory>src/main/resources/webapp/src</workingDirectory>
+                         </configuration>
+                     </execution>
+-                    <execution>
+-                        <id>check (webapp)</id>
+-                        <goals>
+-                            <goal>npm</goal>
+-                        </goals>
+-                        <phase>verify</phase>
+-                        <configuration>
+-                            <arguments>run ${frontend.check.goal}</arguments>
+-                            <workingDirectory>src/main/resources/webapp/src</workingDirectory>
+-                        </configuration>
+-                    </execution>
+-                    <execution>
+-                        <id>check (webapp-preview)</id>
+-                        <goals>
+-                            <goal>npm</goal>
+-                        </goals>
+-                        <phase>verify</phase>
+-                        <configuration>
+-                            <arguments>run ${frontend.check.goal}</arguments>
+-                            <workingDirectory>src/main/resources/webapp-preview</workingDirectory>
+-                        </configuration>
+-                    </execution>
+                     <execution>
+                         <id>package (webapp-preview)</id>
+                         <goals>

--- a/trino/trino/stackable/patches/476/0002-Disable-web-ui-code-checking-because-flow-v0.241.0-f.patch
+++ b/trino/trino/stackable/patches/476/0002-Disable-web-ui-code-checking-because-flow-v0.241.0-f.patch
@@ -1,0 +1,44 @@
+From c69033a355820753a49772be984b9c735ce8b92d Mon Sep 17 00:00:00 2001
+From: dervoeti <lukas.krug@stackable.tech>
+Date: Wed, 18 Jun 2025 14:05:10 +0200
+Subject: Disable web-ui code checking, because flow v0.241.0 for non-x86
+ systems requires glibc 2.35, as of 2025-06-18 our UBI image comes with glibc
+ 2.34. This patch can likely be removed once we ship a newer version of glibc.
+
+---
+ core/trino-web-ui/pom.xml | 22 ----------------------
+ 1 file changed, 22 deletions(-)
+
+diff --git a/core/trino-web-ui/pom.xml b/core/trino-web-ui/pom.xml
+index a783c8f989..bea233cfb9 100644
+--- a/core/trino-web-ui/pom.xml
++++ b/core/trino-web-ui/pom.xml
+@@ -103,28 +103,6 @@
+                             <workingDirectory>src/main/resources/webapp/src</workingDirectory>
+                         </configuration>
+                     </execution>
+-                    <execution>
+-                        <id>check (webapp)</id>
+-                        <goals>
+-                            <goal>npm</goal>
+-                        </goals>
+-                        <phase>verify</phase>
+-                        <configuration>
+-                            <arguments>run ${frontend.check.goal}</arguments>
+-                            <workingDirectory>src/main/resources/webapp/src</workingDirectory>
+-                        </configuration>
+-                    </execution>
+-                    <execution>
+-                        <id>check (webapp-preview)</id>
+-                        <goals>
+-                            <goal>npm</goal>
+-                        </goals>
+-                        <phase>verify</phase>
+-                        <configuration>
+-                            <arguments>run ${frontend.check.goal}</arguments>
+-                            <workingDirectory>src/main/resources/webapp-preview</workingDirectory>
+-                        </configuration>
+-                    </execution>
+                     <execution>
+                         <id>package (webapp-preview)</id>
+                         <goals>


### PR DESCRIPTION
# Description

The builds for Trino 470 and 476 [currently fail on ARM](https://github.com/stackabletech/docker-images/actions/runs/15720684576).

The reason is:
https://github.com/stackabletech/docker-images/pull/1168 switched the build command from `mvnw package` to `mvnw install`, so that `trino-storage-connector` can use our patched Trino libs. That causes the `verify` stage of Maven to execute as well, which for the affected Trino versions invokes [flow](https://github.com/facebook/flow) to check the Typescript code of the Web UI. This fails on ARM, because the non x86 binaries of flow 0.241.0 require glibc 2.35 (see https://github.com/facebook/flow/releases/tag/v0.238.3). UBI comes with glibc 2.34. As we can't bump glibc and I didn't want to use an older version of flow and flow wasn't even part of the build process up until recently, I just removed the frontend checks alltogether.

These patches can likely be removed once we switch to UBI 10 (I left a comment in the patch files).

Tested a local build of Trino 476 on ARM, worked (it also failed locally before this patch).

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [x] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [x] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
