### PR TITLE
feat: update publish-image action to fix RELEASE arg

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -57,7 +57,7 @@ jobs:
           echo "IMAGE_REPOSITORY=$(.scripts/get_repo_name.sh)" | tee -a "$GITHUB_ENV"
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9aae2d1c14239021bfa33c041010f6fb7adec815 # 0.8.2
+        uses: stackabletech/actions/publish-image@497f3e3cbfe9b89b1e570351b97d050eebcad5d0 # 0.8.3
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -84,7 +84,7 @@ jobs:
           echo "IMAGE_REPOSITORY=$(.scripts/get_repo_name.sh)" | tee -a "$GITHUB_ENV"
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9aae2d1c14239021bfa33c041010f6fb7adec815 # 0.8.2
+        uses: stackabletech/actions/publish-index-manifest@497f3e3cbfe9b89b1e570351b97d050eebcad5d0 # 0.8.3
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/pr_pre-commit.yaml
+++ b/.github/workflows/pr_pre-commit.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-      - uses: stackabletech/actions/run-pre-commit@9aae2d1c14239021bfa33c041010f6fb7adec815 # 0.8.2
+      - uses: stackabletech/actions/run-pre-commit@497f3e3cbfe9b89b1e570351b97d050eebcad5d0 # 0.8.3
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           hadolint: ${{ env.HADOLINT_VERSION }}

--- a/.github/workflows/reusable_build_image.yaml
+++ b/.github/workflows/reusable_build_image.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           persist-credentials: false
       - id: shard
-        uses: stackabletech/actions/shard@9aae2d1c14239021bfa33c041010f6fb7adec815 # 0.8.2
+        uses: stackabletech/actions/shard@497f3e3cbfe9b89b1e570351b97d050eebcad5d0 # 0.8.3
         with:
           product-name: ${{ inputs.product-name }}
     outputs:
@@ -53,18 +53,18 @@ jobs:
           persist-credentials: false
 
       - name: Free Disk Space
-        uses: stackabletech/actions/free-disk-space@9aae2d1c14239021bfa33c041010f6fb7adec815 # 0.8.2
+        uses: stackabletech/actions/free-disk-space@497f3e3cbfe9b89b1e570351b97d050eebcad5d0 # 0.8.3
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@9aae2d1c14239021bfa33c041010f6fb7adec815 # 0.8.2
+        uses: stackabletech/actions/build-product-image@497f3e3cbfe9b89b1e570351b97d050eebcad5d0 # 0.8.3
         with:
           product-name: ${{ inputs.product-name }}
           product-version: ${{ matrix.versions }}
           sdp-version: ${{ inputs.sdp-version }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@9aae2d1c14239021bfa33c041010f6fb7adec815 # 0.8.2
+        uses: stackabletech/actions/publish-image@497f3e3cbfe9b89b1e570351b97d050eebcad5d0 # 0.8.3
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$${{ inputs.registry-namespace }}+github-action-build
@@ -90,7 +90,7 @@ jobs:
           persist-credentials: false
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@9aae2d1c14239021bfa33c041010f6fb7adec815 # 0.8.2
+        uses: stackabletech/actions/publish-index-manifest@497f3e3cbfe9b89b1e570351b97d050eebcad5d0 # 0.8.3
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$${{ inputs.registry-namespace }}+github-action-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ All notable changes to this project will be documented in this file.
 - ubi9-rust-builder: Use pinned `rustup` version ([#1121]).
 - hive: Patch for postgres CVE-2024-1597 ([#1100]).
 - bump image-tools (for `bake`) and nixpkgs (for `nodejs_20`, used by pre-commit) ([#1100]).
+- bump image-tools (for `bake`) to fix `RELEASE` arg ([#1188]).
 
 ### Removed
 
@@ -209,6 +210,7 @@ All notable changes to this project will be documented in this file.
 [#1180]: https://github.com/stackabletech/docker-images/pull/1180
 [#1184]: https://github.com/stackabletech/docker-images/pull/1184
 [#1185]: https://github.com/stackabletech/docker-images/pull/1185
+[#1188]: https://github.com/stackabletech/docker-images/pull/1188
 
 ## [25.3.0] - 2025-03-21
 


### PR DESCRIPTION
# Description

With `image-tools` 0.0.17 we now have a separate argument to provide the SDP version. This is needed because we want to include the architecture in the image tag (`0.0.0-dev-amd64`) but not in the `RELEASE` argument (that one should just be `0.0.0-dev` or `25.7.0`).
Before 0.0.17 the `--image-version` argument was used for both the image tag and the `RELEASE` arg.

This PR bumps the Github actions to use the new version of `image-tools` and provide the SDP version as a separate `--release` argument so `RELEASE` does not contain the architecture anymore.

See https://github.com/stackabletech/actions/pull/47 and https://github.com/stackabletech/image-tools/pull/55

Successful build with the new action: https://github.com/stackabletech/docker-images/actions/runs/15897788169/job/44833458187

I also checked the release label for the new image:
```
# Old
docker inspect oci.stackable.tech/sdp/zookeeper:3.9.2-stackable0.0.0-dev-arm64 | rg release
"release": "0.0.0-dev-arm64",

# New
docker inspect oci.stackable.tech/sdp/zookeeper:3.9.3-stackable0.0.0-dev-arm64 | rg release
"release": "0.0.0-dev",
```

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [x] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
