### PR TITLE
fix: automatically determine NiFi version create reporting task script

### DIFF
--- a/nifi/python/create_nifi_reporting_task.py
+++ b/nifi/python/create_nifi_reporting_task.py
@@ -47,8 +47,11 @@ def find_reporting_task(name: str, port: str):
     return None
 
 
-def create_reporting_task(name: str, port: str, version: str):
+def create_reporting_task(name: str, port: str):
     """Create a ReportingTask"""
+    nifi_version = (
+        nipyapi.system.get_system_diagnostics().system_diagnostics.aggregate_snapshot.version_info.ni_fi_version
+    )
     task = nipyapi.nifi.models.reporting_task_entity.ReportingTaskEntity(
         revision=nipyapi.nifi.models.revision_dto.RevisionDTO(version=0),
         disconnected_node_acknowledged=False,
@@ -56,7 +59,9 @@ def create_reporting_task(name: str, port: str, version: str):
             name=name,
             type="org.apache.nifi.reporting.prometheus.PrometheusReportingTask",
             bundle=nipyapi.nifi.models.bundle_dto.BundleDTO(
-                group="org.apache.nifi", artifact="nifi-prometheus-nar", version=version
+                group="org.apache.nifi",
+                artifact="nifi-prometheus-nar",
+                version=nifi_version,
             ),
             properties={
                 "prometheus-reporting-task-metrics-endpoint-port": port,
@@ -159,7 +164,7 @@ def main():
 
     if reporting_task is None:
         reporting_task = create_reporting_task(
-            name=task_name, port=port, version=args["nifi_version"]
+            name=task_name, port=port
         )
         print(
             get_reporting_task_name(task=reporting_task)


### PR DESCRIPTION
# Description

Since we use custom versions now, the wrong NiFi version was passed to the script (`1.28.1` instead of `1.28.1-stackable0.0.0-dev` for example). Since it's a bit hard to determine the actual SDP version of the NiFi image in the operator and this is just needed for NiFi 1 which will eventually be deprecated, I decided to just let the script determine the NiFi version on the go. It still has the `-v` parameter, we could remove it but that would require the operator to not pass it as well. I decided to go the easy non-breaking way and just leave it in, even though it's not used anymore.

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [x] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] All packages should have (if available) signatures/hashes verified
- [x] Add an entry to the CHANGELOG.md file
- [x] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
