### PR TITLE
feat: remove version flag from NiFi 1 reporting task

### DIFF
--- a/nifi/python/create_nifi_reporting_task.py
+++ b/nifi/python/create_nifi_reporting_task.py
@@ -129,9 +129,6 @@ def main():
         "-p", "--password", required=True, help="Password for the user."
     )
     all_args.add_argument(
-        "-v", "--nifi_version", required=True, help="The NiFi product version."
-    )
-    all_args.add_argument(
         "-c",
         "--cert",
         required=True,


### PR DESCRIPTION
# Description

Follow up for https://github.com/stackabletech/docker-images/pull/1189.
Removed version flag, needs adjustment in nifi-operator.

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
