### PR TITLE
fix: Change GID to 1000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ All notable changes to this project will be documented in this file.
 - ubi-rust-builder: Bump Rust toolchain to 1.87.0, cargo-auditable to 0.7.0 and protoc to 31.1 ([#1197]).
 - stackable-base, stackable-devel, ubi-rust-builder: Update `ubi-minimal` base image ([#1197]).
 - testing-tools: Update `python` 3.12-slim-bullseye base image ([#1197]).
-- Change default user & group IDs to 1000/1000 ([#1193], [#xxxx]).
+- Change default user & group IDs to 1000/1000 ([#1193], [#1202]).
 
 ### Fixed
 
@@ -221,7 +221,7 @@ All notable changes to this project will be documented in this file.
 [#1189]: https://github.com/stackabletech/docker-images/pull/1189
 [#1193]: https://github.com/stackabletech/docker-images/pull/1193
 [#1197]: https://github.com/stackabletech/docker-images/pull/1197
-[#xxxx]: https://github.com/stackabletech/docker-images/pull/xxxx
+[#1202]: https://github.com/stackabletech/docker-images/pull/1202
 
 ## [25.3.0] - 2025-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ All notable changes to this project will be documented in this file.
 - ubi-rust-builder: Bump Rust toolchain to 1.87.0, cargo-auditable to 0.7.0 and protoc to 31.1 ([#1197]).
 - stackable-base, stackable-devel, ubi-rust-builder: Update `ubi-minimal` base image ([#1197]).
 - testing-tools: Update `python` 3.12-slim-bullseye base image ([#1197]).
-- Change default user & group IDs to 1000/0 ([#1193]).
+- Change default user & group IDs to 1000/1000 ([#1193], [#xxxx]).
 
 ### Fixed
 
@@ -221,6 +221,7 @@ All notable changes to this project will be documented in this file.
 [#1189]: https://github.com/stackabletech/docker-images/pull/1189
 [#1193]: https://github.com/stackabletech/docker-images/pull/1193
 [#1197]: https://github.com/stackabletech/docker-images/pull/1197
+[#xxxx]: https://github.com/stackabletech/docker-images/pull/xxxx
 
 ## [25.3.0] - 2025-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,6 @@ All notable changes to this project will be documented in this file.
 - ubi-rust-builder: Bump Rust toolchain to 1.87.0, cargo-auditable to 0.7.0 and protoc to 31.1 ([#1197]).
 - stackable-base, stackable-devel, ubi-rust-builder: Update `ubi-minimal` base image ([#1197]).
 - testing-tools: Update `python` 3.12-slim-bullseye base image ([#1197]).
-- Change default user & group IDs to 1000/1000 ([#1193], [#1202]).
 
 ### Fixed
 
@@ -219,9 +218,7 @@ All notable changes to this project will be documented in this file.
 [#1185]: https://github.com/stackabletech/docker-images/pull/1185
 [#1188]: https://github.com/stackabletech/docker-images/pull/1188
 [#1189]: https://github.com/stackabletech/docker-images/pull/1189
-[#1193]: https://github.com/stackabletech/docker-images/pull/1193
 [#1197]: https://github.com/stackabletech/docker-images/pull/1197
-[#1202]: https://github.com/stackabletech/docker-images/pull/1202
 
 ## [25.3.0] - 2025-03-21
 

--- a/conf.py
+++ b/conf.py
@@ -109,6 +109,6 @@ cache = [
 args = {
     "STACKABLE_USER_NAME": "stackable",
     "STACKABLE_USER_UID": "1000",
-    "STACKABLE_USER_GID": "0",
+    "STACKABLE_USER_GID": "1000",
     "DELETE_CACHES": "true",
 }


### PR DESCRIPTION
#1193 changed the UID to 1000, but the GID was set to 0. This caused issues, because the root group with ID 0 is already present. As such, the `groupadd` command fails which in turn breaks _all_ image builds.

**This PR set the GID to 1000 as well.**

Local test builds succeeded:

- stackable-base@1.0.0
- opa@1.4.2
