### PR TITLE
fix: Use STACKABLE_USER_GID arg instead of the hard-coded GID of 0

### DIFF
--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -44,6 +44,7 @@ ARG SHARED_STATSD_EXPORTER
 ARG PYTHON
 ARG TARGETARCH
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 ARG S3FS
 ARG CYCLONEDX_BOM
 ARG UV
@@ -114,7 +115,7 @@ EOF
 
 COPY --from=statsd_exporter-builder /statsd_exporter/statsd_exporter /stackable/statsd_exporter
 COPY --from=statsd_exporter-builder /statsd_exporter/statsd_exporter-${SHARED_STATSD_EXPORTER}.cdx.json /stackable/statsd_exporter-${SHARED_STATSD_EXPORTER}.cdx.json
-COPY --from=gitsync-image --chown=${STACKABLE_USER_UID}:0 /git-sync /stackable/git-sync
+COPY --from=gitsync-image --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /git-sync /stackable/git-sync
 
 RUN <<EOF
 mkdir -pv /stackable/airflow
@@ -132,6 +133,7 @@ ARG RELEASE
 ARG TINI
 ARG TARGETARCH
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 LABEL name="Apache Airflow" \
     maintainer="info@stackable.tech" \
@@ -146,11 +148,11 @@ ENV AIRFLOW_USER_HOME_DIR=/stackable
 ENV PATH=$PATH:/bin:$HOME/app/bin
 ENV AIRFLOW_HOME=$HOME/airflow
 
-COPY --from=airflow-build-image --chown=${STACKABLE_USER_UID}:0 /stackable/ ${HOME}/
-COPY --from=airflow-build-image --chown=${STACKABLE_USER_UID}:0 /stackable/git-sync ${HOME}/git-sync
+COPY --from=airflow-build-image --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/ ${HOME}/
+COPY --from=airflow-build-image --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/git-sync ${HOME}/git-sync
 
-COPY --chown=${STACKABLE_USER_UID}:0 airflow/stackable/utils/entrypoint.sh /entrypoint.sh
-COPY --chown=${STACKABLE_USER_UID}:0 airflow/stackable/utils/run-airflow.sh /run-airflow.sh
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} airflow/stackable/utils/entrypoint.sh /entrypoint.sh
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} airflow/stackable/utils/run-airflow.sh /run-airflow.sh
 
 COPY airflow/licenses /licenses
 

--- a/druid/Dockerfile
+++ b/druid/Dockerfile
@@ -12,6 +12,7 @@ ARG STAX2_API
 ARG WOODSTOX_CORE
 ARG AUTHORIZER
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 ARG HADOOP
 
 # Setting this to anything other than "true" will keep the cache folders around (e.g. for Maven, NPM etc.)
@@ -36,10 +37,10 @@ EOF
 USER ${STACKABLE_USER_UID}
 WORKDIR /stackable
 
-COPY --chown=${STACKABLE_USER_UID}:0 druid/stackable/patches/patchable.toml /stackable/src/druid/stackable/patches/patchable.toml
-COPY --chown=${STACKABLE_USER_UID}:0 druid/stackable/patches/${PRODUCT} /stackable/src/druid/stackable/patches/${PRODUCT}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} druid/stackable/patches/patchable.toml /stackable/src/druid/stackable/patches/patchable.toml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} druid/stackable/patches/${PRODUCT} /stackable/src/druid/stackable/patches/${PRODUCT}
 
-COPY --from=hadoop-builder --chown=${STACKABLE_USER_UID}:0 /stackable/patched-libs /stackable/patched-libs
+COPY --from=hadoop-builder --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/patched-libs /stackable/patched-libs
 # Cache mounts are owned by root by default
 # We need to explicitly give the uid to use.
 # The cache id has to include the product version that we are building because otherwise
@@ -80,7 +81,7 @@ mvn \
   -Dcheckstyle.skip `# Skip checkstyle checks. We dont care if the code is properly formatted, it just wastes time` \
   -Dmaven.javadoc.skip=true `# Dont generate javadoc` \
   -Dmaven.gitcommitid.skip=true `# The gitcommitid plugin cannot work with git workspaces (ie: patchable)` \
-  $(if [[ ${PRODUCT} != 30.* ]]; then echo --projects '!quidem-ut'; fi) `# This is just a maven module for tests. https://github.com/apache/druid/pull/16867 added https://raw.githubusercontent.com/kgyrtkirk/datasets/repo/ as a Maven repository, which fails to pull for us (Failed to execute goal on project druid-quidem-ut: Could not resolve dependencies for project org.apache.druid:druid-quidem-ut:jar:33.0.0: com.github.kgyrtkirk.datasets:kttm-nested:jar:0.1 was not found in https://build-repo.stackable.tech/repository/maven-public/). By disabling the maven module we dont pull in this weird dependency...`
+  $(if [[ ${PRODUCT} != 30.* ]]; then echo --projects '!quidem-ut'; fi) `# This is just a maven module for tests. https://github.com/apache/druid/pull/16867 added https://raw.githubusercontent.com/kgyrtkirk/datasets/repo/ as a Maven repository, which fails to pull for us (Failed to execute goal on project druid-quidem-ut: Could not resolve dependencies for project org.apache.druid:druid-quidem-ut:jar:33.0.0: com.github.kgyrtkirk.datasets:kttm-nested:jar:${STACKABLE_USER_GID}.1 was not found in https://build-repo.stackable.tech/repository/maven-public/). By disabling the maven module we dont pull in this weird dependency...`
 
 mv distribution/target/apache-druid-${NEW_VERSION}-bin/apache-druid-${NEW_VERSION} /stackable/
 sed -i "s/${NEW_VERSION}/${ORIGINAL_VERSION}/g" distribution/target/bom.json
@@ -112,6 +113,7 @@ FROM stackable/image/java-base AS final
 ARG PRODUCT
 ARG RELEASE
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 ARG NAME="Apache Druid"
 ARG DESCRIPTION="This image is deployed by the Stackable Operator for Apache Druid"
@@ -136,26 +138,26 @@ LABEL io.k8s.description="${DESCRIPTION}"
 LABEL io.k8s.display-name="${NAME}"
 
 
-COPY --chown=${STACKABLE_USER_UID}:0 --from=druid-builder /stackable/apache-druid-${PRODUCT}-stackable${RELEASE} /stackable/apache-druid-${PRODUCT}-stackable${RELEASE}
-COPY --chown=${STACKABLE_USER_UID}:0 --from=druid-builder /stackable/druid-${PRODUCT}-stackable${RELEASE}-src.tar.gz /stackable
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=druid-builder /stackable/apache-druid-${PRODUCT}-stackable${RELEASE} /stackable/apache-druid-${PRODUCT}-stackable${RELEASE}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=druid-builder /stackable/druid-${PRODUCT}-stackable${RELEASE}-src.tar.gz /stackable
 
-COPY --chown=${STACKABLE_USER_UID}:0 druid/stackable/bin /stackable/bin
-COPY --chown=${STACKABLE_USER_UID}:0 druid/licenses /licenses
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} druid/stackable/bin /stackable/bin
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} druid/licenses /licenses
 
 RUN <<EOF
 microdnf update
 microdnf clean all
 rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}\n" | sort > /stackable/package_manifest.txt
-chown ${STACKABLE_USER_UID}:0 /stackable/package_manifest.txt
+chown ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/package_manifest.txt
 chmod g=u /stackable/package_manifest.txt
 rm -rf /var/cache/yum
 
 ln -sf /stackable/apache-druid-${PRODUCT}-stackable${RELEASE} /stackable/druid
-chown -h ${STACKABLE_USER_UID}:0 stackable/druid
+chown -h ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} stackable/druid
 
 # Force to overwrite the existing 'run-druid'
 ln -sf /stackable/bin/run-druid /stackable/druid/bin/run-druid
-chown -h ${STACKABLE_USER_UID}:0 /stackable/druid/bin/run-druid
+chown -h ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/druid/bin/run-druid
 
 # fix missing permissions
 chmod -R g=u /stackable/bin

--- a/hadoop/Dockerfile
+++ b/hadoop/Dockerfile
@@ -11,11 +11,12 @@ ARG PROTOBUF
 ARG TARGETARCH
 ARG TARGETOS
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 WORKDIR /stackable
 
-COPY --chown=${STACKABLE_USER_UID}:0 shared/protobuf/stackable/patches/patchable.toml /stackable/src/shared/protobuf/stackable/patches/patchable.toml
-COPY --chown=${STACKABLE_USER_UID}:0 shared/protobuf/stackable/patches/${PROTOBUF} /stackable/src/shared/protobuf/stackable/patches/${PROTOBUF}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} shared/protobuf/stackable/patches/patchable.toml /stackable/src/shared/protobuf/stackable/patches/patchable.toml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} shared/protobuf/stackable/patches/${PROTOBUF} /stackable/src/shared/protobuf/stackable/patches/${PROTOBUF}
 
 RUN <<EOF
 rpm --install --replacepkgs https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
@@ -26,7 +27,7 @@ microdnf install boost1.78-devel automake libtool
 microdnf clean all
 rm -rf /var/cache/yum
 mkdir /opt/protobuf
-chown ${STACKABLE_USER_UID}:0 /opt/protobuf
+chown ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /opt/protobuf
 EOF
 
 USER ${STACKABLE_USER_UID}
@@ -63,10 +64,10 @@ ln -s "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar" /stackable/j
 EOF
 
 WORKDIR /build
-COPY --chown=${STACKABLE_USER_UID}:0 hadoop/stackable/patches/patchable.toml /build/src/hadoop/stackable/patches/patchable.toml
-COPY --chown=${STACKABLE_USER_UID}:0 hadoop/stackable/patches/${PRODUCT} /build/src/hadoop/stackable/patches/${PRODUCT}
-COPY --chown=${STACKABLE_USER_UID}:0 hadoop/stackable/fuse_dfs_wrapper /build
-COPY --chown=${STACKABLE_USER_UID}:0 hadoop/stackable/jmx /stackable/jmx
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} hadoop/stackable/patches/patchable.toml /build/src/hadoop/stackable/patches/patchable.toml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} hadoop/stackable/patches/${PRODUCT} /build/src/hadoop/stackable/patches/${PRODUCT}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} hadoop/stackable/fuse_dfs_wrapper /build
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} hadoop/stackable/jmx /stackable/jmx
 USER ${STACKABLE_USER_UID}
 # Hadoop Pipes requires libtirpc to build, whose headers are not packaged in RedHat UBI, so skip building this module
 # Build from source to enable FUSE module, and to apply custom patches.
@@ -140,6 +141,7 @@ FROM stackable/image/java-devel AS hdfs-utils-builder
 ARG HDFS_UTILS
 ARG PRODUCT
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 # Starting with hdfs-utils 0.4.0 we need to use Java 17 for compilation.
 # We can not simply use java-devel with Java 17, as it is also used to compile Hadoop in this
@@ -158,8 +160,8 @@ ENV JAVA_HOME="/usr/lib/jvm/temurin-17-jdk"
 USER ${STACKABLE_USER_UID}
 WORKDIR /stackable
 
-COPY --chown=${STACKABLE_USER_UID}:0 hadoop/hdfs-utils/stackable/patches/patchable.toml /stackable/src/hadoop/hdfs-utils/stackable/patches/patchable.toml
-COPY --chown=${STACKABLE_USER_UID}:0 hadoop/hdfs-utils/stackable/patches/${HDFS_UTILS} /stackable/src/hadoop/hdfs-utils/stackable/patches/${HDFS_UTILS}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} hadoop/hdfs-utils/stackable/patches/patchable.toml /stackable/src/hadoop/hdfs-utils/stackable/patches/patchable.toml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} hadoop/hdfs-utils/stackable/patches/${HDFS_UTILS} /stackable/src/hadoop/hdfs-utils/stackable/patches/${HDFS_UTILS}
 
 # The Stackable HDFS utils contain an OPA authorizer, group mapper & topology provider.
 # The topology provider provides rack awareness functionality for HDFS by allowing users to specify Kubernetes
@@ -196,6 +198,7 @@ ARG TARGETOS
 ARG HDFS_UTILS
 ARG ASYNC_PROFILER
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 LABEL \
     name="Apache Hadoop" \
@@ -207,16 +210,16 @@ LABEL \
     description="This image is deployed by the Stackable Operator for Apache Hadoop / HDFS."
 
 
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hadoop-builder /stackable/hadoop-${PRODUCT}-stackable${RELEASE} /stackable/hadoop-${PRODUCT}-stackable${RELEASE}
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hadoop-builder /stackable/hadoop-${PRODUCT}-stackable${RELEASE}-src.tar.gz /stackable/
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hadoop-builder /stackable/async-profiler-${ASYNC_PROFILER}-* /stackable/async-profiler-${ASYNC_PROFILER}
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hadoop-builder /stackable/jmx /stackable/jmx
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hadoop-builder /stackable/protobuf-*-src.tar.gz /stackable/
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hadoop-builder /stackable/hadoop-${PRODUCT}-stackable${RELEASE} /stackable/hadoop-${PRODUCT}-stackable${RELEASE}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hadoop-builder /stackable/hadoop-${PRODUCT}-stackable${RELEASE}-src.tar.gz /stackable/
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hadoop-builder /stackable/async-profiler-${ASYNC_PROFILER}-* /stackable/async-profiler-${ASYNC_PROFILER}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hadoop-builder /stackable/jmx /stackable/jmx
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hadoop-builder /stackable/protobuf-*-src.tar.gz /stackable/
 
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hdfs-utils-builder /stackable/hdfs-utils-${HDFS_UTILS}.jar /stackable/hadoop-${PRODUCT}-stackable${RELEASE}/share/hadoop/common/lib/hdfs-utils-${HDFS_UTILS}.jar
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hdfs-utils-builder /stackable/hdfs-utils-${HDFS_UTILS}-src.tar.gz /stackable
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hdfs-utils-builder /stackable/hdfs-utils-${HDFS_UTILS}.jar /stackable/hadoop-${PRODUCT}-stackable${RELEASE}/share/hadoop/common/lib/hdfs-utils-${HDFS_UTILS}.jar
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hdfs-utils-builder /stackable/hdfs-utils-${HDFS_UTILS}-src.tar.gz /stackable
 
-COPY --chown=${STACKABLE_USER_UID}:0 hadoop/licenses /licenses
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} hadoop/licenses /licenses
 
 # fuse is required for fusermount (called by fuse_dfs)
 # fuse-libs is required for fuse_dfs (not included in fuse)
@@ -232,7 +235,7 @@ microdnf install \
   tar
 microdnf clean all
 rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}\n" | sort > /stackable/package_manifest.txt
-chown ${STACKABLE_USER_UID}:0 /stackable/package_manifest.txt
+chown ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/package_manifest.txt
 chmod g=u /stackable/package_manifest.txt
 rm -rf /var/cache/yum
 
@@ -241,7 +244,7 @@ rm -rf /var/cache/yum
 echo "user_allow_other" > /etc/fuse.conf
 
 ln -s "/stackable/hadoop-${PRODUCT}-stackable${RELEASE}" /stackable/hadoop
-chown --no-dereference "${STACKABLE_USER_UID}:0" /stackable/hadoop
+chown --no-dereference "${STACKABLE_USER_UID}:${STACKABLE_USER_GID}" /stackable/hadoop
 chmod g=u "/stackable/hadoop-${PRODUCT}-stackable${RELEASE}"
 chmod g=u /stackable/*-src.tar.gz
 
@@ -249,7 +252,7 @@ ARCH="${TARGETARCH/amd64/x64}"
 mv /stackable/async-profiler-${ASYNC_PROFILER}* "/stackable/async-profiler-${ASYNC_PROFILER-}-${TARGETOS}-${ARCH}"
 chmod g=u "/stackable/async-profiler-${ASYNC_PROFILER-}-${TARGETOS}-${ARCH}"
 ln -s "/stackable/async-profiler-${ASYNC_PROFILER}-${TARGETOS}-${ARCH}" /stackable/async-profiler
-chown --no-dereference "${STACKABLE_USER_UID}:0" /stackable/async-profiler
+chown --no-dereference "${STACKABLE_USER_UID}:${STACKABLE_USER_GID}" /stackable/async-profiler
 
 chmod g=u /stackable/jmx
 
@@ -273,7 +276,7 @@ USER ${STACKABLE_USER_UID}
 
 ENV HOME=/stackable
 ENV LD_LIBRARY_PATH=/stackable/hadoop/lib/native:/usr/lib/jvm/jre/lib/server
-ENV PATH="${PATH}":/stackable/hadoop/bin
+ENV PATH="${PATH}:/stackable/hadoop/bin"
 ENV HADOOP_HOME=/stackable/hadoop
 ENV HADOOP_CONF_DIR=/stackable/config
 ENV ASYNC_PROFILER_HOME=/stackable/async-profiler

--- a/hbase/Dockerfile
+++ b/hbase/Dockerfile
@@ -20,11 +20,12 @@ ARG RELEASE
 ARG HADOOP
 ARG HBASE_HBASE
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 USER ${STACKABLE_USER_UID}
 WORKDIR /stackable
 
-COPY --from=hadoop-builder --chown=${STACKABLE_USER_UID}:0 \
+COPY --from=hadoop-builder --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} \
   # The artifact name of the AWS bundle has changed between Haddop 3.3.6 and 3.4.1
   # from aws-java-sdk-bundle-*.jar to bundle-*.jar.
   # See: https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/aws_sdk_upgrade.html
@@ -34,7 +35,7 @@ COPY --from=hadoop-builder --chown=${STACKABLE_USER_UID}:0 \
   /stackable/hadoop/share/hadoop/tools/lib/hadoop-aws-${HADOOP}-stackable${RELEASE}.jar \
   /stackable/hadoop/share/hadoop/tools/lib/
 
-COPY --chown=${STACKABLE_USER_UID}:0 hbase/hbase/stackable/bin/export-snapshot-to-s3.env /stackable/bin/
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} hbase/hbase/stackable/bin/export-snapshot-to-s3.env /stackable/bin/
 
 RUN <<EOF
 # Resolve paths in bin/export-snapshot-to-s3
@@ -63,6 +64,7 @@ ARG HBASE_HBASE_OPERATOR_TOOLS
 ARG HBASE_HBASE_OPA_AUTHORIZER
 ARG HBASE_PHOENIX
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 ARG NAME="Apache HBase"
 ARG DESCRIPTION="This image is deployed by the Stackable Operator for Apache HBase"
@@ -86,31 +88,31 @@ LABEL io.openshift.tags="ubi9,stackable,hbase,sdp,nosql"
 LABEL io.k8s.description="${DESCRIPTION}"
 LABEL io.k8s.display-name="${NAME}"
 
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hbase-builder /stackable/hbase-${HBASE_HBASE}-stackable${RELEASE} /stackable/hbase-${HBASE_HBASE}-stackable${RELEASE}/
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hbase-builder /stackable/hbase-${HBASE_HBASE}-stackable${RELEASE}-src.tar.gz /stackable
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hbase-builder /stackable/async-profiler /stackable/async-profiler/
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hbase-builder /stackable/hbase-${HBASE_HBASE}-stackable${RELEASE} /stackable/hbase-${HBASE_HBASE}-stackable${RELEASE}/
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hbase-builder /stackable/hbase-${HBASE_HBASE}-stackable${RELEASE}-src.tar.gz /stackable
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hbase-builder /stackable/async-profiler /stackable/async-profiler/
 
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hbase-operator-tools /stackable/hbase-operator-tools-${HBASE_HBASE_OPERATOR_TOOLS}-stackable${RELEASE} /stackable/hbase-operator-tools-${HBASE_HBASE_OPERATOR_TOOLS}-stackable${RELEASE}/
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hbase-operator-tools /stackable/hbase-operator-tools-${HBASE_HBASE_OPERATOR_TOOLS}-stackable${RELEASE}-src.tar.gz /stackable
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hbase-operator-tools /stackable/bin/hbck2 /stackable/bin/hbck2
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hbase-operator-tools /stackable/bin/hbase-entrypoint.sh /stackable/hbase-${HBASE_HBASE}-stackable${RELEASE}/bin/hbase-entrypoint.sh
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hbase-operator-tools /stackable/hbase-operator-tools-${HBASE_HBASE_OPERATOR_TOOLS}-stackable${RELEASE} /stackable/hbase-operator-tools-${HBASE_HBASE_OPERATOR_TOOLS}-stackable${RELEASE}/
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hbase-operator-tools /stackable/hbase-operator-tools-${HBASE_HBASE_OPERATOR_TOOLS}-stackable${RELEASE}-src.tar.gz /stackable
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hbase-operator-tools /stackable/bin/hbck2 /stackable/bin/hbck2
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hbase-operator-tools /stackable/bin/hbase-entrypoint.sh /stackable/hbase-${HBASE_HBASE}-stackable${RELEASE}/bin/hbase-entrypoint.sh
 
-COPY --chown=${STACKABLE_USER_UID}:0 --from=phoenix /stackable/phoenix /stackable/phoenix/
-COPY --chown=${STACKABLE_USER_UID}:0 --from=phoenix /stackable/phoenix-${HBASE_PHOENIX}-stackable${RELEASE}-src.tar.gz /stackable
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=phoenix /stackable/phoenix /stackable/phoenix/
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=phoenix /stackable/phoenix-${HBASE_PHOENIX}-stackable${RELEASE}-src.tar.gz /stackable
 
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hadoop-s3-builder /stackable/bin/export-snapshot-to-s3 /stackable/bin/export-snapshot-to-s3
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hadoop-s3-builder /stackable/hadoop/share/hadoop/tools/lib/ /stackable/hadoop/share/hadoop/tools/lib/
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hadoop-s3-builder /stackable/bin/export-snapshot-to-s3 /stackable/bin/export-snapshot-to-s3
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hadoop-s3-builder /stackable/hadoop/share/hadoop/tools/lib/ /stackable/hadoop/share/hadoop/tools/lib/
 
 # Copy the dependencies from Hadoop which are required for the Azure Data Lake
 # Storage (ADLS) to /stackable/hbase-${HBASE_HBASE}/lib which is on the classpath.
 # hadoop-azure-${HADOOP}.jar contains the AzureBlobFileSystem which is required
 # by hadoop-common-${HADOOP}.jar if the scheme of a file system is "abfs://".
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hadoop-builder \
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hadoop-builder \
   /stackable/hadoop/share/hadoop/tools/lib/hadoop-azure-${HADOOP}-stackable${RELEASE}.jar \
   /stackable/hbase-${HBASE_HBASE}-stackable${RELEASE}/lib/
 
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hbase-opa-authorizer /stackable/hbase-opa-authorizer-${HBASE_HBASE_OPA_AUTHORIZER}-src.tar.gz /stackable
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hbase-opa-authorizer /stackable/hbase-opa-authorizer/target/hbase-opa-authorizer*.jar /stackable/hbase-${HBASE_HBASE}-stackable${RELEASE}/lib
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hbase-opa-authorizer /stackable/hbase-opa-authorizer-${HBASE_HBASE_OPA_AUTHORIZER}-src.tar.gz /stackable
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hbase-opa-authorizer /stackable/hbase-opa-authorizer/target/hbase-opa-authorizer*.jar /stackable/hbase-${HBASE_HBASE}-stackable${RELEASE}/lib
 
 RUN <<EOF
 microdnf update
@@ -126,20 +128,20 @@ microdnf install \
 
 microdnf clean all
 rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}\n" | sort > /stackable/package_manifest.txt
-chown ${STACKABLE_USER_UID}:0 /stackable/package_manifest.txt
+chown ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/package_manifest.txt
 chmod g=u /stackable/package_manifest.txt
 rm -rf /var/cache/yum
 
 ln --symbolic --logical --verbose "/stackable/hbase-${HBASE_HBASE}-stackable${RELEASE}" /stackable/hbase
-chown --no-dereference ${STACKABLE_USER_UID}:0 /stackable/hbase
+chown --no-dereference ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/hbase
 chmod g=u /stackable/hbase
 
 ln --symbolic --logical --verbose "/stackable/hbase-operator-tools-${HBASE_HBASE_OPERATOR_TOOLS}-stackable${RELEASE}" /stackable/hbase-operator-tools
-chown --no-dereference ${STACKABLE_USER_UID}:0 /stackable/hbase-operator-tools
+chown --no-dereference ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/hbase-operator-tools
 chmod g=u /stackable/hbase-operator-tools
 
 ln --symbolic --logical --verbose "/stackable/phoenix/phoenix-server-hbase-${HBASE_PROFILE}.jar" "/stackable/hbase/lib/phoenix-server-hbase-${HBASE_PROFILE}.jar"
-chown --no-dereference ${STACKABLE_USER_UID}:0 "/stackable/hbase/lib/phoenix-server-hbase-${HBASE_PROFILE}.jar"
+chown --no-dereference ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} "/stackable/hbase/lib/phoenix-server-hbase-${HBASE_PROFILE}.jar"
 chmod g=u "/stackable/hbase/lib/phoenix-server-hbase-${HBASE_PROFILE}.jar"
 
 # fix missing permissions

--- a/hbase/hbase-opa-authorizer/Dockerfile
+++ b/hbase/hbase-opa-authorizer/Dockerfile
@@ -3,12 +3,13 @@ FROM stackable/image/java-devel
 ARG PRODUCT
 ARG DELETE_CACHES
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 USER ${STACKABLE_USER_UID}
 WORKDIR /stackable
 
-COPY --chown=${STACKABLE_USER_UID}:0 hbase/hbase-opa-authorizer/stackable/patches/patchable.toml /stackable/src/hbase/hbase-opa-authorizer/stackable/patches/patchable.toml
-COPY --chown=${STACKABLE_USER_UID}:0 hbase/hbase-opa-authorizer/stackable/patches/${PRODUCT} /stackable/src/hbase/hbase-opa-authorizer/stackable/patches/${PRODUCT}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} hbase/hbase-opa-authorizer/stackable/patches/patchable.toml /stackable/src/hbase/hbase-opa-authorizer/stackable/patches/patchable.toml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} hbase/hbase-opa-authorizer/stackable/patches/${PRODUCT} /stackable/src/hbase/hbase-opa-authorizer/stackable/patches/${PRODUCT}
 
 RUN --mount=type=cache,id=maven-opa,uid=${STACKABLE_USER_UID},target=/stackable/.m2/repository <<EOF
 ###

--- a/hbase/hbase-operator-tools/Dockerfile
+++ b/hbase/hbase-operator-tools/Dockerfile
@@ -9,6 +9,7 @@ ARG RELEASE
 ARG HBASE_THIRDPARTY
 ARG HBASE_HBASE
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 ARG HBASE_OPERATOR_TOOLS_VERSION
 
 # Setting this to anything other than "true" will keep the cache folders around (e.g. for Maven, NPM etc.)
@@ -19,13 +20,13 @@ ARG DELETE_CACHES="true"
 # The variable names are intentionally passed to envsubst in single-quotes,
 # so that they are not expanded. Disabling ShellCheck rules in a Dockerfile
 # does not work, so please ignore the according warning (SC2016).
-COPY --chown=${STACKABLE_USER_UID}:0 hbase/hbase/stackable/bin/hbck2.env /stackable/bin/
-COPY --chown=${STACKABLE_USER_UID}:0 hbase/hbase-operator-tools/stackable/patches/patchable.toml /stackable/src/hbase/hbase-operator-tools/stackable/patches/patchable.toml
-COPY --chown=${STACKABLE_USER_UID}:0 hbase/hbase-operator-tools/stackable/patches/${HBASE_OPERATOR_TOOLS_VERSION} /stackable/src/hbase/hbase-operator-tools/stackable/patches/${HBASE_OPERATOR_TOOLS_VERSION}
-COPY --chown=${STACKABLE_USER_UID}:0 hbase/hbase/stackable/bin/hbase-entrypoint.sh /stackable/bin/
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} hbase/hbase/stackable/bin/hbck2.env /stackable/bin/
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} hbase/hbase-operator-tools/stackable/patches/patchable.toml /stackable/src/hbase/hbase-operator-tools/stackable/patches/patchable.toml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} hbase/hbase-operator-tools/stackable/patches/${HBASE_OPERATOR_TOOLS_VERSION} /stackable/src/hbase/hbase-operator-tools/stackable/patches/${HBASE_OPERATOR_TOOLS_VERSION}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} hbase/hbase/stackable/bin/hbase-entrypoint.sh /stackable/bin/
 
-COPY --from=hbase-builder --chown=${STACKABLE_USER_UID}:0 /stackable/patched-libs/maven/org/apache/hbase /stackable/patched-libs/maven/org/apache/hbase
-COPY --from=hadoop-builder --chown=${STACKABLE_USER_UID}:0 /stackable/patched-libs/maven/org/apache/hadoop /stackable/patched-libs/maven/org/apache/hadoop
+COPY --from=hbase-builder --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/patched-libs/maven/org/apache/hbase /stackable/patched-libs/maven/org/apache/hbase
+COPY --from=hadoop-builder --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/patched-libs/maven/org/apache/hadoop /stackable/patched-libs/maven/org/apache/hadoop
 
 USER ${STACKABLE_USER_UID}
 WORKDIR /stackable

--- a/hbase/hbase/Dockerfile
+++ b/hbase/hbase/Dockerfile
@@ -9,6 +9,7 @@ ARG HADOOP
 ARG TARGETARCH
 ARG TARGETOS
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 # Setting this to anything other than "true" will keep the cache folders around (e.g. for Maven, NPM etc.)
 # This can be used to speed up builds when disk space is of no concern.
@@ -19,10 +20,10 @@ COPY hbase/licenses /licenses
 USER ${STACKABLE_USER_UID}
 WORKDIR /stackable
 
-COPY --chown=${STACKABLE_USER_UID}:0 hbase/hbase/stackable/patches/patchable.toml /stackable/src/hbase/hbase/stackable/patches/patchable.toml
-COPY --chown=${STACKABLE_USER_UID}:0 hbase/hbase/stackable/patches/${PRODUCT} /stackable/src/hbase/hbase/stackable/patches/${PRODUCT}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} hbase/hbase/stackable/patches/patchable.toml /stackable/src/hbase/hbase/stackable/patches/patchable.toml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} hbase/hbase/stackable/patches/${PRODUCT} /stackable/src/hbase/hbase/stackable/patches/${PRODUCT}
 
-COPY --from=hadoop-builder --chown=${STACKABLE_USER_UID}:0 /stackable/patched-libs /stackable/patched-libs
+COPY --from=hadoop-builder --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/patched-libs /stackable/patched-libs
 # Cache mounts are owned by root by default
 # We need to explicitly give the uid to use
 # And every cache needs its own id, we can't share them between stages because we might delete the caches

--- a/hbase/phoenix/Dockerfile
+++ b/hbase/phoenix/Dockerfile
@@ -11,16 +11,17 @@ ARG HBASE_HBASE
 ARG HBASE_PROFILE
 ARG HADOOP
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 ARG PHOENIX_VERSION
 
 # Setting this to anything other than "true" will keep the cache folders around (e.g. for Maven, NPM etc.)
 # This can be used to speed up builds when disk space is of no concern.
 ARG DELETE_CACHES="true"
 
-COPY --chown=${STACKABLE_USER_UID}:0 hbase/phoenix/stackable/patches/patchable.toml /stackable/src/phoenix/stackable/patches/patchable.toml
-COPY --chown=${STACKABLE_USER_UID}:0 hbase/phoenix/stackable/patches/${PHOENIX_VERSION} /stackable/src/phoenix/stackable/patches/${PHOENIX_VERSION}
-COPY --from=hbase-builder --chown=${STACKABLE_USER_UID}:0 /stackable/patched-libs/maven/org/apache/hbase /stackable/patched-libs/maven/org/apache/hbase
-COPY --from=hadoop-builder --chown=${STACKABLE_USER_UID}:0 /stackable/patched-libs/maven/org/apache/hadoop /stackable/patched-libs/maven/org/apache/hadoop
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} hbase/phoenix/stackable/patches/patchable.toml /stackable/src/phoenix/stackable/patches/patchable.toml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} hbase/phoenix/stackable/patches/${PHOENIX_VERSION} /stackable/src/phoenix/stackable/patches/${PHOENIX_VERSION}
+COPY --from=hbase-builder --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/patched-libs/maven/org/apache/hbase /stackable/patched-libs/maven/org/apache/hbase
+COPY --from=hadoop-builder --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/patched-libs/maven/org/apache/hadoop /stackable/patched-libs/maven/org/apache/hadoop
 
 USER ${STACKABLE_USER_UID}
 WORKDIR /stackable

--- a/hive/Dockerfile
+++ b/hive/Dockerfile
@@ -19,19 +19,20 @@ ARG AWS_JAVA_SDK_BUNDLE
 ARG AZURE_STORAGE
 ARG AZURE_KEYVAULT_CORE
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 # Setting this to anything other than "true" will keep the cache folders around (e.g. for Maven, NPM etc.)
 # This can be used to speed up builds when disk space is of no concern.
 ARG DELETE_CACHES="true"
 
 # Copy patches into the builder
-COPY --chown=${STACKABLE_USER_UID}:0 hive/stackable/patches/patchable.toml /stackable/src/hive/stackable/patches/patchable.toml
-COPY --chown=${STACKABLE_USER_UID}:0 hive/stackable/patches/${PRODUCT} /stackable/src/hive/stackable/patches/${PRODUCT}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} hive/stackable/patches/patchable.toml /stackable/src/hive/stackable/patches/patchable.toml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} hive/stackable/patches/${PRODUCT} /stackable/src/hive/stackable/patches/${PRODUCT}
 # It is useful to see which version of Hadoop is used at a glance
 # Therefore the use of the full name here
 # TODO: Do we really need all of Hadoop in here?
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hadoop-builder /stackable/hadoop /stackable/hadoop-${HADOOP}-stackable${RELEASE}
-COPY --from=hadoop-builder --chown=${STACKABLE_USER_UID}:0 /stackable/patched-libs /stackable/patched-libs
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hadoop-builder /stackable/hadoop /stackable/hadoop-${HADOOP}-stackable${RELEASE}
+COPY --from=hadoop-builder --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/patched-libs /stackable/patched-libs
 
 USER ${STACKABLE_USER_UID}
 WORKDIR /stackable
@@ -117,6 +118,7 @@ ARG PRODUCT
 ARG HADOOP
 ARG RELEASE
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 
 ARG NAME="Apache Hive metastore"
@@ -143,13 +145,13 @@ LABEL io.k8s.display-name="${NAME}"
 
 WORKDIR /stackable
 
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hive-builder /stackable/apache-hive-metastore-${PRODUCT}-stackable${RELEASE}-bin /stackable/apache-hive-metastore-${PRODUCT}-stackable${RELEASE}-bin
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hive-builder /stackable/hive-${PRODUCT}-stackable${RELEASE}-src.tar.gz /stackable
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hive-builder /stackable/hadoop-${HADOOP}-stackable${RELEASE} /stackable/hadoop-${HADOOP}-stackable${RELEASE}
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hadoop-builder /stackable/hadoop-${HADOOP}-stackable${RELEASE}-src.tar.gz /stackable
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hive-builder /stackable/jmx /stackable/jmx
-COPY --chown=${STACKABLE_USER_UID}:0 hive/stackable/jmx /stackable/jmx
-COPY --chown=${STACKABLE_USER_UID}:0 hive/stackable/bin/start-metastore /stackable/apache-hive-metastore-${PRODUCT}-stackable${RELEASE}-bin/bin
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hive-builder /stackable/apache-hive-metastore-${PRODUCT}-stackable${RELEASE}-bin /stackable/apache-hive-metastore-${PRODUCT}-stackable${RELEASE}-bin
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hive-builder /stackable/hive-${PRODUCT}-stackable${RELEASE}-src.tar.gz /stackable
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hive-builder /stackable/hadoop-${HADOOP}-stackable${RELEASE} /stackable/hadoop-${HADOOP}-stackable${RELEASE}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hadoop-builder /stackable/hadoop-${HADOOP}-stackable${RELEASE}-src.tar.gz /stackable
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hive-builder /stackable/jmx /stackable/jmx
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} hive/stackable/jmx /stackable/jmx
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} hive/stackable/bin/start-metastore /stackable/apache-hive-metastore-${PRODUCT}-stackable${RELEASE}-bin/bin
 
 COPY hive/licenses /licenses
 
@@ -157,17 +159,17 @@ RUN <<EOF
 microdnf update
 microdnf clean all
 rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}\n" | sort > /stackable/package_manifest.txt
-chown ${STACKABLE_USER_UID}:0 /stackable/package_manifest.txt
+chown ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/package_manifest.txt
 chmod g=u /stackable/package_manifest.txt
 rm -rf /var/cache/yum
 
 chmod g=u /stackable/apache-hive-metastore-${PRODUCT}-stackable${RELEASE}-bin/bin/start-metastore
 
 ln -s /stackable/apache-hive-metastore-${PRODUCT}-stackable${RELEASE}-bin /stackable/hive-metastore
-chown -h ${STACKABLE_USER_UID}:0 /stackable/hive-metastore
+chown -h ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/hive-metastore
 chmod g=u /stackable/hive-metastore
 ln -s /stackable/hadoop-${HADOOP}-stackable${RELEASE} /stackable/hadoop
-chown -h ${STACKABLE_USER_UID}:0 /stackable/hadoop
+chown -h ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/hadoop
 chmod g=u /stackable/hadoop
 chmod g=u /stackable/*-src.tar.gz
 

--- a/java-devel/Dockerfile
+++ b/java-devel/Dockerfile
@@ -9,6 +9,7 @@ FROM stackable/image/stackable-devel
 
 ARG PRODUCT
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 # See: https://adoptium.net/en-gb/installation/linux/#_centosrhelfedora_instructions
 RUN cat <<EOF > /etc/yum.repos.d/adoptium.repo
@@ -60,8 +61,8 @@ EOF
 
 ENV JAVA_HOME="/usr/lib/jvm/temurin-${PRODUCT}-jdk"
 
-COPY --chown=${STACKABLE_USER_UID}:0 java-devel/stackable/settings.xml /stackable/.m2/settings.xml
-COPY --chown=${STACKABLE_USER_UID}:0 java-devel/stackable/settings.xml /root/.m2/settings.xml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} java-devel/stackable/settings.xml /stackable/.m2/settings.xml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} java-devel/stackable/settings.xml /root/.m2/settings.xml
 
 # Mitigation for CVE-2021-44228 (Log4Shell)
 # This variable is supported as of Log4j version 2.10 and

--- a/kafka-testing-tools/Dockerfile
+++ b/kafka-testing-tools/Dockerfile
@@ -9,6 +9,7 @@ ARG PRODUCT
 ARG KAFKA_KCAT
 ARG RELEASE
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 LABEL name="Kafka Testing Tools" \
       maintainer="info@stackable.tech" \
@@ -18,7 +19,7 @@ LABEL name="Kafka Testing Tools" \
       summary="The Stackable image for the kcat tool." \
       description="Used for integration testing"
 
- # diffutils (diff) and binutils (cmp) are needed for the kafka integration tests
+# diffutils (diff) and binutils (cmp) are needed for the kafka integration tests
 RUN microdnf install  \
     binutils \
     cyrus-sasl \
@@ -30,11 +31,11 @@ RUN microdnf install  \
     && rm -rf /var/cache/yum
 
 # Store kcat version with binary name and add softlink
-COPY --chown=${STACKABLE_USER_UID}:0 --from=kcat /stackable/kcat /stackable/kcat-${KAFKA_KCAT}
-COPY --chown=${STACKABLE_USER_UID}:0 --from=kcat /stackable/kcat-${KAFKA_KCAT}-src.tar.gz /stackable
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=kcat /stackable/kcat /stackable/kcat-${KAFKA_KCAT}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=kcat /stackable/kcat-${KAFKA_KCAT}-src.tar.gz /stackable
 RUN ln -s /stackable/kcat-${KAFKA_KCAT} /stackable/kcat
-COPY --chown=${STACKABLE_USER_UID}:0 --from=kcat /licenses /licenses
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=kcat /licenses /licenses
 
-COPY --chown=${STACKABLE_USER_UID}:0 kafka-testing-tools/licenses /licenses
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} kafka-testing-tools/licenses /licenses
 
 ENTRYPOINT ["/stackable/kcat"]

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -11,13 +11,14 @@ ARG RELEASE
 ARG SCALA
 ARG JMX_EXPORTER
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 USER ${STACKABLE_USER_UID}
 WORKDIR /stackable
 
-COPY --chown=${STACKABLE_USER_UID}:0 kafka/stackable/jmx/ /stackable/jmx/
-COPY --chown=${STACKABLE_USER_UID}:0 kafka/stackable/patches/patchable.toml /stackable/src/kafka/stackable/patches/patchable.toml
-COPY --chown=${STACKABLE_USER_UID}:0 kafka/stackable/patches/${PRODUCT} /stackable/src/kafka/stackable/patches/${PRODUCT}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} kafka/stackable/jmx/ /stackable/jmx/
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} kafka/stackable/patches/patchable.toml /stackable/src/kafka/stackable/patches/patchable.toml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} kafka/stackable/patches/${PRODUCT} /stackable/src/kafka/stackable/patches/${PRODUCT}
 
 RUN <<EOF
 cd "$(/stackable/patchable --images-repo-root=src checkout kafka ${PRODUCT})"
@@ -58,6 +59,7 @@ ARG SCALA
 ARG KAFKA_KCAT
 ARG KAFKA_KAFKA_OPA_PLUGIN
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 LABEL \
   name="Apache Kafka" \
@@ -68,17 +70,17 @@ LABEL \
   summary="The Stackable image for Apache Kafka." \
   description="This image is deployed by the Stackable Operator for Apache Kafka."
 
-COPY --chown=${STACKABLE_USER_UID}:0 --from=kafka-builder /stackable/kafka_${SCALA}-${PRODUCT}-stackable${RELEASE} /stackable/kafka_${SCALA}-${PRODUCT}-stackable${RELEASE}
-COPY --chown=${STACKABLE_USER_UID}:0 --from=kafka-builder /stackable/kafka_${SCALA}-${PRODUCT}-stackable${RELEASE}.cdx.json /stackable/kafka_${SCALA}-${PRODUCT}-stackable${RELEASE}/kafka_${SCALA}-${PRODUCT}-stackable${RELEASE}.cdx.json
-COPY --chown=${STACKABLE_USER_UID}:0 --from=kafka-builder /stackable/kafka-${PRODUCT}-stackable${RELEASE}-src.tar.gz  /stackable
-COPY --chown=${STACKABLE_USER_UID}:0 --from=kafka-builder /stackable/jmx/ /stackable/jmx/
-COPY --chown=${STACKABLE_USER_UID}:0 --from=kcat /stackable/kcat /stackable/bin/kcat-${KAFKA_KCAT}
-COPY --chown=${STACKABLE_USER_UID}:0 --from=kcat /stackable/kcat-${KAFKA_KCAT}-src.tar.gz /stackable
-COPY --chown=${STACKABLE_USER_UID}:0 --from=kcat /licenses /licenses
-COPY --chown=${STACKABLE_USER_UID}:0 --from=kafka-opa-plugin /stackable/src/kafka/kafka-opa-plugin/patchable-work/worktree/${KAFKA_KAFKA_OPA_PLUGIN}/build/libs/opa-authorizer-${KAFKA_KAFKA_OPA_PLUGIN}-all.jar /stackable/kafka_${SCALA}-${PRODUCT}-stackable${RELEASE}/libs/opa-authorizer-${KAFKA_KAFKA_OPA_PLUGIN}-all.jar
-COPY --chown=${STACKABLE_USER_UID}:0 --from=kafka-opa-plugin /stackable/kafka-opa-plugin-${KAFKA_KAFKA_OPA_PLUGIN}-src.tar.gz /stackable
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=kafka-builder /stackable/kafka_${SCALA}-${PRODUCT}-stackable${RELEASE} /stackable/kafka_${SCALA}-${PRODUCT}-stackable${RELEASE}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=kafka-builder /stackable/kafka_${SCALA}-${PRODUCT}-stackable${RELEASE}.cdx.json /stackable/kafka_${SCALA}-${PRODUCT}-stackable${RELEASE}/kafka_${SCALA}-${PRODUCT}-stackable${RELEASE}.cdx.json
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=kafka-builder /stackable/kafka-${PRODUCT}-stackable${RELEASE}-src.tar.gz  /stackable
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=kafka-builder /stackable/jmx/ /stackable/jmx/
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=kcat /stackable/kcat /stackable/bin/kcat-${KAFKA_KCAT}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=kcat /stackable/kcat-${KAFKA_KCAT}-src.tar.gz /stackable
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=kcat /licenses /licenses
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=kafka-opa-plugin /stackable/src/kafka/kafka-opa-plugin/patchable-work/worktree/${KAFKA_KAFKA_OPA_PLUGIN}/build/libs/opa-authorizer-${KAFKA_KAFKA_OPA_PLUGIN}-all.jar /stackable/kafka_${SCALA}-${PRODUCT}-stackable${RELEASE}/libs/opa-authorizer-${KAFKA_KAFKA_OPA_PLUGIN}-all.jar
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=kafka-opa-plugin /stackable/kafka-opa-plugin-${KAFKA_KAFKA_OPA_PLUGIN}-src.tar.gz /stackable
 
-COPY --chown=${STACKABLE_USER_UID}:0 kafka/licenses /licenses
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} kafka/licenses /licenses
 
 WORKDIR /stackable
 
@@ -90,17 +92,17 @@ microdnf install \
 
 microdnf clean all
 rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}\n" | sort > /stackable/package_manifest.txt
-chown ${STACKABLE_USER_UID}:0 /stackable/package_manifest.txt
+chown ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/package_manifest.txt
 chmod g=u /stackable/package_manifest.txt
 rm -rf /var/cache/yum
 
 ln -s /stackable/bin/kcat-${KAFKA_KCAT} /stackable/bin/kcat
-chown -h ${STACKABLE_USER_UID}:0 /stackable/bin/kcat
+chown -h ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/bin/kcat
 # kcat was located in /stackable/kcat - legacy
 ln -s /stackable/bin/kcat /stackable/kcat
-chown -h ${STACKABLE_USER_UID}:0 /stackable/kcat
+chown -h ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/kcat
 ln -s /stackable/kafka_${SCALA}-${PRODUCT}-stackable${RELEASE} /stackable/kafka
-chown -h ${STACKABLE_USER_UID}:0 /stackable/kafka
+chown -h ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/kafka
 
 # fix missing permissions
 chmod g=u /stackable/bin

--- a/kafka/kafka-opa-plugin/Dockerfile
+++ b/kafka/kafka-opa-plugin/Dockerfile
@@ -5,12 +5,13 @@ FROM stackable/image/java-devel
 
 ARG PRODUCT
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 USER ${STACKABLE_USER_UID}
 WORKDIR /stackable
 
-COPY --chown=${STACKABLE_USER_UID}:0 kafka/kafka-opa-plugin/stackable/patches/patchable.toml /stackable/src/kafka/kafka-opa-plugin/stackable/patches/patchable.toml
-COPY --chown=${STACKABLE_USER_UID}:0 kafka/kafka-opa-plugin/stackable/patches/${PRODUCT} /stackable/src/kafka/kafka-opa-plugin/stackable/patches/${PRODUCT}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} kafka/kafka-opa-plugin/stackable/patches/patchable.toml /stackable/src/kafka/kafka-opa-plugin/stackable/patches/patchable.toml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} kafka/kafka-opa-plugin/stackable/patches/${PRODUCT} /stackable/src/kafka/kafka-opa-plugin/stackable/patches/${PRODUCT}
 
 RUN <<EOF
 cd "$(/stackable/patchable --images-repo-root=src checkout kafka/kafka-opa-plugin ${PRODUCT})"

--- a/kafka/kcat/Dockerfile
+++ b/kafka/kcat/Dockerfile
@@ -8,6 +8,7 @@ FROM stackable/image/java-devel AS builder
 
 ARG PRODUCT
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 RUN <<EOF
 microdnf update
@@ -30,8 +31,8 @@ EOF
 
 WORKDIR /stackable
 
-COPY --chown=${STACKABLE_USER_UID}:0 kafka/kcat/stackable/patches/patchable.toml /stackable/src/kafka/kcat/stackable/patches/patchable.toml
-COPY --chown=${STACKABLE_USER_UID}:0 kafka/kcat/stackable/patches/${PRODUCT} /stackable/src/kafka/kcat/stackable/patches/${PRODUCT}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} kafka/kcat/stackable/patches/patchable.toml /stackable/src/kafka/kcat/stackable/patches/patchable.toml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} kafka/kcat/stackable/patches/${PRODUCT} /stackable/src/kafka/kcat/stackable/patches/${PRODUCT}
 
 RUN <<EOF
 cd "$(/stackable/patchable --images-repo-root=src checkout kafka/kcat ${PRODUCT})"
@@ -46,7 +47,7 @@ chmod --recursive g=u /stackable/kcat
 chmod g=u /stackable/kcat-${PRODUCT}-src.tar.gz
 EOF
 
-COPY --chown=${STACKABLE_USER_UID}:0 kafka/kcat/licenses /licenses
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} kafka/kcat/licenses /licenses
 
 # SNIPPET 1
 # 145.2 gcc  -I/stackable/kcat-1.7.0/tmp-bootstrap/usr/include -I/stackable/kcat-1.7.0/tmp-bootstrap/usr/include -g -O2 -Wall -Wsign-compare -Wfloat-equal -Wpointer-arith -Wcast-align -L/stackable/kcat-1.7.0/tmp-bootstrap/usr/lib -Wl,-rpath-link=/stackable/kcat-1.7.0/tmp-bootstrap/usr/lib -L/stackable/kcat-1.7.0/tmp-bootstrap/usr/lib -Wl,-rpath-link=/stackable/kcat-1.7.0/tmp-bootstrap/usr/lib kcat.o format.o tools.o input.o json.o avro.o -o kcat  -lm -ldl -lpthread -lrt -lpthread -lrt  -L/stackable/kcat-1.7.0/tmp-bootstrap/usr/lib  /stackable/kcat-1.7.0/tmp-bootstrap/usr/lib/libavro.a /stackable/kcat-1.7.0/tmp-bootstrap/usr/lib/libjansson.a -lcurl /stackable/kcat-1.7.0/tmp-bootstrap/usr/lib/libserdes.a -Wl,-Bstatic -lavro -Wl,-Bdynamic /stackable/kcat-1.7.0/tmp-bootstrap/usr/lib/libyajl_s.a -L/stackable/kcat-1.7.0/tmp-bootstrap/usr/lib //stackable/kcat-1.7.0/tmp-bootstrap/usr/lib/librdkafka.a -lm -ldl -lpthread -lrt -lz -lcrypto -lssl -lsasl2   -lm -ldl -lpthread -lrt -lpthread -lrt  -L/stackable/kcat-1.7.0/tmp-bootstrap/usr/lib  /stackable/kcat-1.7.0/tmp-bootstrap/usr/lib/libavro.a /stackable/kcat-1.7.0/tmp-bootstrap/usr/lib/libjansson.a -lcurl

--- a/nifi/Dockerfile
+++ b/nifi/Dockerfile
@@ -11,6 +11,7 @@ ARG PRODUCT
 ARG RELEASE
 ARG MAVEN_VERSION="3.9.8"
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 RUN <<EOF
 microdnf update
@@ -35,9 +36,9 @@ EOF
 USER ${STACKABLE_USER_UID}
 WORKDIR /stackable
 
-COPY --chown=${STACKABLE_USER_UID}:0 nifi/stackable/patches/patchable.toml /stackable/src/nifi/stackable/patches/patchable.toml
-COPY --chown=${STACKABLE_USER_UID}:0 nifi/stackable/patches/${PRODUCT} /stackable/src/nifi/stackable/patches/${PRODUCT}
-COPY --chown=${STACKABLE_USER_UID}:0 --from=git-sync-image /git-sync /stackable/git-sync
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} nifi/stackable/patches/patchable.toml /stackable/src/nifi/stackable/patches/patchable.toml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} nifi/stackable/patches/${PRODUCT} /stackable/src/nifi/stackable/patches/${PRODUCT}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=git-sync-image /git-sync /stackable/git-sync
 
 RUN <<EOF
 # This used to be located in /bin/stackable-bcrypt.jar. We create a softlink for /bin/stackable-bcrypt.jar in the main container for backwards compatibility.
@@ -98,12 +99,13 @@ FROM stackable/image/java-devel AS nifi-iceberg-bundle-builder
 ARG NIFI_ICEBERG_BUNDLE
 ARG PRODUCT
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 USER ${STACKABLE_USER_UID}
 WORKDIR /stackable
 
-COPY --chown=${STACKABLE_USER_UID}:0 nifi/nifi-iceberg-bundle/stackable/patches/patchable.toml /stackable/src/nifi/nifi-iceberg-bundle/stackable/patches/patchable.toml
-COPY --chown=${STACKABLE_USER_UID}:0 nifi/nifi-iceberg-bundle/stackable/patches/${NIFI_ICEBERG_BUNDLE} /stackable/src/nifi/nifi-iceberg-bundle/stackable/patches/${NIFI_ICEBERG_BUNDLE}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} nifi/nifi-iceberg-bundle/stackable/patches/patchable.toml /stackable/src/nifi/nifi-iceberg-bundle/stackable/patches/patchable.toml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} nifi/nifi-iceberg-bundle/stackable/patches/${NIFI_ICEBERG_BUNDLE} /stackable/src/nifi/nifi-iceberg-bundle/stackable/patches/${NIFI_ICEBERG_BUNDLE}
 
 RUN <<EOF
 mkdir -p /stackable
@@ -144,13 +146,14 @@ FROM stackable/image/java-devel AS opa-authorizer-builder
 
 ARG NIFI_OPA_AUTHORIZER_PLUGIN
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 ARG PRODUCT
 
 USER ${STACKABLE_USER_UID}
 WORKDIR /stackable
 
-COPY --chown=${STACKABLE_USER_UID}:0 nifi/opa-plugin/stackable/patches/patchable.toml /stackable/src/nifi/opa-plugin/stackable/patches/patchable.toml
-COPY --chown=${STACKABLE_USER_UID}:0 nifi/opa-plugin/stackable/patches/${NIFI_OPA_AUTHORIZER_PLUGIN} /stackable/src/nifi/opa-plugin/stackable/patches/${NIFI_OPA_AUTHORIZER_PLUGIN}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} nifi/opa-plugin/stackable/patches/patchable.toml /stackable/src/nifi/opa-plugin/stackable/patches/patchable.toml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} nifi/opa-plugin/stackable/patches/${NIFI_OPA_AUTHORIZER_PLUGIN} /stackable/src/nifi/opa-plugin/stackable/patches/${NIFI_OPA_AUTHORIZER_PLUGIN}
 
 RUN <<EOF
 mkdir -p /stackable
@@ -179,6 +182,7 @@ FROM stackable/image/java-base AS final
 ARG PRODUCT
 ARG RELEASE
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 ARG NIFI_OPA_AUTHORIZER_PLUGIN
 
 LABEL name="Apache NiFi" \
@@ -189,20 +193,20 @@ LABEL name="Apache NiFi" \
     summary="The Stackable image for Apache NiFi." \
     description="This image is deployed by the Stackable Operator for Apache NiFi."
 
-COPY --chown=${STACKABLE_USER_UID}:0 --from=nifi-builder /stackable/nifi-${PRODUCT}-stackable${RELEASE} /stackable/nifi-${PRODUCT}-stackable${RELEASE}/
-COPY --chown=${STACKABLE_USER_UID}:0 --from=nifi-builder /stackable/nifi-${PRODUCT}-stackable${RELEASE}-src.tar.gz /stackable
-COPY --chown=${STACKABLE_USER_UID}:0 --from=nifi-builder /stackable/stackable-bcrypt.jar /stackable/stackable-bcrypt.jar
-COPY --chown=${STACKABLE_USER_UID}:0 --from=nifi-iceberg-bundle-builder /stackable/*.nar /stackable/nifi-${PRODUCT}-stackable${RELEASE}/lib/
-COPY --chown=${STACKABLE_USER_UID}:0 --from=nifi-iceberg-bundle-builder /stackable/*.cdx.json /stackable/nifi-${PRODUCT}-stackable${RELEASE}/lib/
-COPY --chown=${STACKABLE_USER_UID}:0 --from=nifi-iceberg-bundle-builder /stackable/*-src.tar.gz /stackable
-COPY --chown=${STACKABLE_USER_UID}:0 --from=nifi-builder /stackable/git-sync /stackable/git-sync
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=nifi-builder /stackable/nifi-${PRODUCT}-stackable${RELEASE} /stackable/nifi-${PRODUCT}-stackable${RELEASE}/
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=nifi-builder /stackable/nifi-${PRODUCT}-stackable${RELEASE}-src.tar.gz /stackable
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=nifi-builder /stackable/stackable-bcrypt.jar /stackable/stackable-bcrypt.jar
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=nifi-iceberg-bundle-builder /stackable/*.nar /stackable/nifi-${PRODUCT}-stackable${RELEASE}/lib/
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=nifi-iceberg-bundle-builder /stackable/*.cdx.json /stackable/nifi-${PRODUCT}-stackable${RELEASE}/lib/
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=nifi-iceberg-bundle-builder /stackable/*-src.tar.gz /stackable
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=nifi-builder /stackable/git-sync /stackable/git-sync
 
-COPY --chown=${STACKABLE_USER_UID}:0 --from=opa-authorizer-builder /stackable/opa-authorizer.nar /stackable/nifi-${PRODUCT}-stackable${RELEASE}/extensions/opa-authorizer.nar
-COPY --chown=${STACKABLE_USER_UID}:0 --from=opa-authorizer-builder /stackable/nifi-opa-plugin-${NIFI_OPA_AUTHORIZER_PLUGIN}-src.tar.gz  /stackable
-COPY --chown=${STACKABLE_USER_UID}:0 --from=opa-authorizer-builder /stackable/LICENSE /licenses/NIFI_OPA_PLUGIN_LICENSE
-COPY --chown=${STACKABLE_USER_UID}:0 nifi/stackable/bin /stackable/bin
-COPY --chown=${STACKABLE_USER_UID}:0 nifi/licenses /licenses
-COPY --chown=${STACKABLE_USER_UID}:0 nifi/python /stackable/python
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=opa-authorizer-builder /stackable/opa-authorizer.nar /stackable/nifi-${PRODUCT}-stackable${RELEASE}/extensions/opa-authorizer.nar
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=opa-authorizer-builder /stackable/nifi-opa-plugin-${NIFI_OPA_AUTHORIZER_PLUGIN}-src.tar.gz  /stackable
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=opa-authorizer-builder /stackable/LICENSE /licenses/NIFI_OPA_PLUGIN_LICENSE
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} nifi/stackable/bin /stackable/bin
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} nifi/licenses /licenses
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} nifi/python /stackable/python
 
 RUN <<EOF
 microdnf update
@@ -229,7 +233,7 @@ ln -s /stackable/stackable-bcrypt.jar /bin/stackable-bcrypt.jar
 ln -s /stackable/nifi-${PRODUCT}-stackable${RELEASE} /stackable/nifi
 
 # fix missing permissions / ownership
-chown --no-dereference ${STACKABLE_USER_UID}:0 /stackable/nifi
+chown --no-dereference ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/nifi
 chmod --recursive g=u /stackable/python
 chmod --recursive g=u /stackable/bin
 chmod g=u /stackable/nifi-${PRODUCT}-stackable${RELEASE}

--- a/omid/Dockerfile
+++ b/omid/Dockerfile
@@ -7,6 +7,7 @@ ARG PRODUCT
 ARG RELEASE
 ARG DELETE_CACHES="true"
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 RUN <<EOF
 microdnf update
@@ -22,8 +23,8 @@ EOF
 USER ${STACKABLE_USER_UID}
 WORKDIR /stackable
 
-COPY --chown=${STACKABLE_USER_UID}:0 omid/stackable/patches/patchable.toml /stackable/src/omid/stackable/patches/patchable.toml
-COPY --chown=${STACKABLE_USER_UID}:0 omid/stackable/patches/${PRODUCT} /stackable/src/omid/stackable/patches/${PRODUCT}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} omid/stackable/patches/patchable.toml /stackable/src/omid/stackable/patches/patchable.toml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} omid/stackable/patches/${PRODUCT} /stackable/src/omid/stackable/patches/${PRODUCT}
 
 RUN --mount=type=cache,id=maven-omid-${PRODUCT},uid=${STACKABLE_USER_UID},target=/stackable/.m2/repository <<EOF
   set -x
@@ -55,6 +56,7 @@ ARG PRODUCT
 ARG RELEASE
 ARG JMX_EXPORTER
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 LABEL name="Apache Phoenix Omid" \
       maintainer="info@stackable.tech" \
@@ -66,10 +68,10 @@ LABEL name="Apache Phoenix Omid" \
 
 COPY omid/licenses /licenses
 
-COPY --chown=${STACKABLE_USER_UID}:0 omid/stackable /stackable
-COPY --chown=${STACKABLE_USER_UID}:0 --from=builder /stackable/omid-tso-server-${PRODUCT}-stackable${RELEASE} /stackable/omid-tso-server-${PRODUCT}-stackable${RELEASE}
-COPY --chown=${STACKABLE_USER_UID}:0 --from=builder /stackable/omid-examples-${PRODUCT}-stackable${RELEASE} /stackable/omid-examples-${PRODUCT}-stackable${RELEASE}
-COPY --chown=${STACKABLE_USER_UID}:0 --from=builder /stackable/omid-${PRODUCT}-stackable${RELEASE}-src.tar.gz /stackable
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} omid/stackable /stackable
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=builder /stackable/omid-tso-server-${PRODUCT}-stackable${RELEASE} /stackable/omid-tso-server-${PRODUCT}-stackable${RELEASE}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=builder /stackable/omid-examples-${PRODUCT}-stackable${RELEASE} /stackable/omid-examples-${PRODUCT}-stackable${RELEASE}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=builder /stackable/omid-${PRODUCT}-stackable${RELEASE}-src.tar.gz /stackable
 
 RUN <<EOF
 microdnf update
@@ -89,7 +91,7 @@ mkdir /stackable/logs
 
 # All files and folders owned by root group to support running as arbitrary users.
 # This is best practice as all container users will belong to the root group (0).
-chown -R ${STACKABLE_USER_UID}:0 /stackable
+chown -R ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable
 chmod -R g=u /stackable
 EOF
 
@@ -97,7 +99,7 @@ EOF
 # Attention: We are changing the group of all files in /stackable directly above
 # If you do any file based actions (copying / creating etc.) below this comment you
 # absolutely need to make sure that the correct permissions are applied!
-# chown ${STACKABLE_USER_UID}:0
+# chown ${STACKABLE_USER_UID}:${STACKABLE_USER_GID}
 # ----------------------------------------
 
 USER ${STACKABLE_USER_UID}

--- a/opa/Dockerfile
+++ b/opa/Dockerfile
@@ -43,6 +43,7 @@ FROM stackable/image/stackable-devel AS opa-builder
 ARG PRODUCT
 ARG RELEASE
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 ARG TARGETARCH
 ARG TARGETOS
 
@@ -60,14 +61,14 @@ microdnf install \
 microdnf clean all
 EOF
 
-COPY --chown=${STACKABLE_USER_UID}:0 opa/stackable/bin /stackable/opa/bin
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} opa/stackable/bin /stackable/opa/bin
 
 # Manually install Go since the dnf package is sometimes not recent enough
 COPY --from=golang-image /usr/local/go/ /usr/local/go/
 ENV PATH="/usr/local/go/bin:${PATH}"
 
-COPY --chown=${STACKABLE_USER_UID}:0 opa/stackable/patches/patchable.toml /stackable/src/opa/stackable/patches/patchable.toml
-COPY --chown=${STACKABLE_USER_UID}:0 opa/stackable/patches/${PRODUCT} /stackable/src/opa/stackable/patches/${PRODUCT}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} opa/stackable/patches/patchable.toml /stackable/src/opa/stackable/patches/patchable.toml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} opa/stackable/patches/${PRODUCT} /stackable/src/opa/stackable/patches/${PRODUCT}
 
 WORKDIR /stackable
 
@@ -107,6 +108,7 @@ FROM stackable/image/vector
 ARG PRODUCT
 ARG RELEASE
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 LABEL name="Open Policy Agent" \
   maintainer="info@stackable.tech" \
@@ -116,11 +118,11 @@ LABEL name="Open Policy Agent" \
   summary="The Stackable image for Open Policy Agent (OPA)." \
   description="This image is deployed by the Stackable Operator for OPA."
 
-COPY --chown=${STACKABLE_USER_UID}:0 opa/licenses /licenses
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} opa/licenses /licenses
 
-COPY --from=opa-builder --chown=${STACKABLE_USER_UID}:0 /stackable/opa /stackable/opa
-COPY --from=opa-builder --chown=${STACKABLE_USER_UID}:0 /stackable/opa-${PRODUCT}-stackable${RELEASE}-src.tar.gz /stackable/opa-${PRODUCT}-stackable${RELEASE}-src.tar.gz
-COPY --from=multilog-builder --chown=${STACKABLE_USER_UID}:0 /daemontools/admin/daemontools/command/multilog /stackable/multilog
+COPY --from=opa-builder --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/opa /stackable/opa
+COPY --from=opa-builder --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/opa-${PRODUCT}-stackable${RELEASE}-src.tar.gz /stackable/opa-${PRODUCT}-stackable${RELEASE}-src.tar.gz
+COPY --from=multilog-builder --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /daemontools/admin/daemontools/command/multilog /stackable/multilog
 
 RUN <<EOF
 microdnf update

--- a/shared/statsd-exporter/Dockerfile
+++ b/shared/statsd-exporter/Dockerfile
@@ -4,6 +4,7 @@
 FROM stackable/image/stackable-base
 ARG PRODUCT
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 WORKDIR /statsd_exporter
 

--- a/spark-connect-client/Dockerfile
+++ b/spark-connect-client/Dockerfile
@@ -7,6 +7,7 @@ ARG PRODUCT
 ARG PYTHON
 ARG RELEASE
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 LABEL name="Stackable Spark Connect Examples" \
     maintainer="info@stackable.tech" \
@@ -19,8 +20,8 @@ LABEL name="Stackable Spark Connect Examples" \
 # Need root to install setuptools
 USER root
 
-COPY --chown=${STACKABLE_USER_UID}:0 spark-connect-client/stackable/spark-connect-examples /stackable/spark-connect-examples
-COPY --chown=${STACKABLE_USER_UID}:0 spark-connect-client/stackable/.jupyter /stackable/.jupyter
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} spark-connect-client/stackable/spark-connect-examples /stackable/spark-connect-examples
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} spark-connect-client/stackable/.jupyter /stackable/.jupyter
 
 RUN <<EOF
 microdnf update
@@ -32,7 +33,7 @@ rm -rf /var/cache/yum
 
 # All files and folders owned by root group to support running as arbitrary users.
 # This is best practice as all container users will belong to the root group (0).
-chown -R ${STACKABLE_USER_UID}:0 /stackable
+chown -R ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable
 chmod -R g=u /stackable
 EOF
 

--- a/spark-k8s/Dockerfile
+++ b/spark-k8s/Dockerfile
@@ -13,11 +13,12 @@ FROM stackable/image/java-devel AS spark-source-builder
 ARG PRODUCT
 ARG RELEASE
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 WORKDIR /stackable
 
-COPY --chown=${STACKABLE_USER_UID}:0 spark-k8s/stackable/patches/patchable.toml /stackable/src/spark-k8s/stackable/patches/patchable.toml
-COPY --chown=${STACKABLE_USER_UID}:0 spark-k8s/stackable/patches/${PRODUCT} /stackable/src/spark-k8s/stackable/patches/${PRODUCT}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} spark-k8s/stackable/patches/patchable.toml /stackable/src/spark-k8s/stackable/patches/patchable.toml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} spark-k8s/stackable/patches/${PRODUCT} /stackable/src/spark-k8s/stackable/patches/${PRODUCT}
 
 RUN <<EOF
 cd "$(/stackable/patchable --images-repo-root=src checkout spark-k8s ${PRODUCT})"
@@ -41,6 +42,7 @@ ARG HADOOP
 ARG HBASE
 ARG HBASE_CONNECTOR
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 WORKDIR /stackable
 
@@ -48,15 +50,15 @@ WORKDIR /stackable
 # versions used by Spark. The pom.xml defines child modules which are
 # not required and not copied, therefore mvn must be called with the
 # parameter --non-recursive.
-COPY --chown=${STACKABLE_USER_UID}:0 --from=spark-source-builder \
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=spark-source-builder \
     /stackable/src/spark-k8s/patchable-work/worktree/${PRODUCT}/pom.xml \
     spark/
 
 # Patch the hbase-connectors source code
 WORKDIR /stackable
 
-COPY --chown=${STACKABLE_USER_UID}:0 spark-k8s/hbase-connectors/stackable/patches/patchable.toml /stackable/src/spark-k8s/hbase-connectors/stackable/patches/patchable.toml
-COPY --chown=${STACKABLE_USER_UID}:0 spark-k8s/hbase-connectors/stackable/patches/${HBASE_CONNECTOR} /stackable/src/spark-k8s/hbase-connectors/stackable/patches/${HBASE_CONNECTOR}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} spark-k8s/hbase-connectors/stackable/patches/patchable.toml /stackable/src/spark-k8s/hbase-connectors/stackable/patches/patchable.toml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} spark-k8s/hbase-connectors/stackable/patches/${HBASE_CONNECTOR} /stackable/src/spark-k8s/hbase-connectors/stackable/patches/${HBASE_CONNECTOR}
 
 RUN <<EOF
 cd "$(/stackable/patchable --images-repo-root=src checkout spark-k8s/hbase-connectors ${HBASE_CONNECTOR})/spark"
@@ -146,16 +148,17 @@ ARG TARGETARCH
 ARG TINI
 ARG RELEASE
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 # Find the latest version here: https://github.com/apache/maven
 # renovate: datasource=github-tags packageName=apache/maven
 ARG MAVEN_VERSION="3.9.10"
 
 WORKDIR /stackable/spark-${PRODUCT}-stackable${RELEASE}
 
-COPY --chown=${STACKABLE_USER_UID}:0 --from=spark-source-builder \
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=spark-source-builder \
     /stackable/src/spark-k8s/patchable-work/worktree/${PRODUCT} \
     ./
-COPY --from=hadoop-builder --chown=${STACKABLE_USER_UID}:0 /stackable/patched-libs /stackable/patched-libs
+COPY --from=hadoop-builder --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/patched-libs /stackable/patched-libs
 
 # >>> Build spark
 # Compiling the tests takes a lot of time, so we skip them
@@ -217,35 +220,35 @@ EOF
 WORKDIR /stackable/spark-${PRODUCT}-stackable${RELEASE}/dist/jars
 
 # Copy modules required for s3a://
-COPY --from=hadoop-builder --chown=${STACKABLE_USER_UID}:0 \
+COPY --from=hadoop-builder --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} \
     /stackable/hadoop/share/hadoop/tools/lib/hadoop-aws-${HADOOP}-stackable${RELEASE}.jar \
     /stackable/hadoop/share/hadoop/tools/lib/bundle-${AWS_JAVA_SDK_BUNDLE}.jar \
     ./
 
 # Copy modules required for abfs://
-COPY --from=hadoop-builder --chown=${STACKABLE_USER_UID}:0 \
+COPY --from=hadoop-builder --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} \
     /stackable/hadoop/share/hadoop/tools/lib/hadoop-azure-${HADOOP}-stackable${RELEASE}.jar \
     /stackable/hadoop/share/hadoop/tools/lib/azure-storage-${AZURE_STORAGE}.jar \
     /stackable/hadoop/share/hadoop/tools/lib/azure-keyvault-core-${AZURE_KEYVAULT_CORE}.jar \
     ./
 
 # Copy the HBase connector including required modules
-COPY --from=hbase-connectors-builder --chown=${STACKABLE_USER_UID}:0 \
+COPY --from=hbase-connectors-builder --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} \
     /stackable/spark/jars/* \
     ./
 
 # Copy modules required to access HBase
-COPY --from=hbase-builder --chown=${STACKABLE_USER_UID}:0 \
+COPY --from=hbase-builder --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} \
     /stackable/hbase/lib/shaded-clients/hbase-shaded-client-byo-hadoop-${HBASE}-stackable${RELEASE}.jar \
     /stackable/hbase/lib/shaded-clients/hbase-shaded-mapreduce-${HBASE}-stackable${RELEASE}.jar \
     ./
 # Copy modules required to access HBase if $HBASE == 2.4.x
-COPY --from=hbase-builder --chown=${STACKABLE_USER_UID}:0 \
+COPY --from=hbase-builder --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} \
     /stackable/hbase/lib/client-facing-thirdparty/htrace-core4-*-incubating.jar \
     /stackable/hbase/lib/client-facing-thirdparty/slf4j-reload4j-*.jar \
     ./
 # Copy modules required to access HBase if $HBASE == 2.6.x
-COPY --from=hbase-builder --chown=${STACKABLE_USER_UID}:0 \
+COPY --from=hbase-builder --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} \
     /stackable/hbase/lib/client-facing-thirdparty/opentelemetry-api-*.jar \
     /stackable/hbase/lib/client-facing-thirdparty/opentelemetry-context-*.jar \
     /stackable/hbase/lib/client-facing-thirdparty/opentelemetry-semconv-*-alpha.jar \
@@ -289,6 +292,7 @@ ARG RELEASE
 ARG JMX_EXPORTER
 ARG HBASE_CONNECTOR
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 LABEL name="Apache Spark" \
     maintainer="info@stackable.tech" \
@@ -308,15 +312,15 @@ ENV PYSPARK_PYTHON=/usr/bin/python
 ENV PYTHONPATH=$SPARK_HOME/python
 
 
-COPY --chown=${STACKABLE_USER_UID}:0 --from=spark-builder /stackable/spark-${PRODUCT}-stackable${RELEASE}/dist /stackable/spark
-COPY --chown=${STACKABLE_USER_UID}:0 --from=spark-source-builder /stackable/spark-${PRODUCT}-stackable${RELEASE}-src.tar.gz /stackable
-COPY --chown=${STACKABLE_USER_UID}:0 --from=hbase-connectors-builder /stackable/hbase-connector-${HBASE_CONNECTOR}-stackable${RELEASE}-src.tar.gz /stackable
-COPY --chown=${STACKABLE_USER_UID}:0 --from=spark-builder /stackable/spark-${PRODUCT}-stackable${RELEASE}/assembly/target/bom.json /stackable/spark/spark-${PRODUCT}-stackable${RELEASE}.cdx.json
-COPY --chown=${STACKABLE_USER_UID}:0 --from=spark-builder /stackable/jmx /stackable/jmx
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=spark-builder /stackable/spark-${PRODUCT}-stackable${RELEASE}/dist /stackable/spark
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=spark-source-builder /stackable/spark-${PRODUCT}-stackable${RELEASE}-src.tar.gz /stackable
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=hbase-connectors-builder /stackable/hbase-connector-${HBASE_CONNECTOR}-stackable${RELEASE}-src.tar.gz /stackable
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=spark-builder /stackable/spark-${PRODUCT}-stackable${RELEASE}/assembly/target/bom.json /stackable/spark/spark-${PRODUCT}-stackable${RELEASE}.cdx.json
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=spark-builder /stackable/jmx /stackable/jmx
 COPY --from=spark-builder /usr/bin/tini /usr/bin/tini
 
-COPY --chown=${STACKABLE_USER_UID}:0 spark-k8s/stackable/run-spark.sh /stackable/run-spark.sh
-COPY --chown=${STACKABLE_USER_UID}:0 spark-k8s/licenses /licenses
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} spark-k8s/stackable/run-spark.sh /stackable/run-spark.sh
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} spark-k8s/licenses /licenses
 
 RUN <<EOF
 microdnf update
@@ -342,7 +346,7 @@ ln -s /usr/bin/pip-${PYTHON} /usr/bin/pip
 
 # Symlink example jar, so that we can easily use it in tests
 ln -s /stackable/spark/examples/jars/spark-examples_*.jar /stackable/spark/examples/jars/spark-examples.jar
-chown -h ${STACKABLE_USER_UID}:0 /stackable/spark/examples/jars/spark-examples.jar
+chown -h ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/spark/examples/jars/spark-examples.jar
 
 # fix permissions
 chmod g=u /stackable/spark

--- a/stackable-base/Dockerfile
+++ b/stackable-base/Dockerfile
@@ -42,6 +42,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:383329bf9c4f968e87e85d30
 ARG PRODUCT
 ARG STACKABLE_USER_UID
 ARG STACKABLE_USER_GID
+ARG STACKABLE_USER_GID
 ARG STACKABLE_USER_NAME
 
 # Sets the default shell to Bash with strict error handling and robust pipeline processing.
@@ -144,11 +145,11 @@ microdnf clean all
 
 echo -e "if [ -f ~/.bashrc ]; then\n\tsource ~/.bashrc\nfi" >> /stackable/.profile
 
-chown ${STACKABLE_USER_UID}:0 /stackable/.bashrc
-chown ${STACKABLE_USER_UID}:0 /stackable/.profile
+chown ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/.bashrc
+chown ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/.profile
 
 cp /root/.curlrc /stackable/.curlrc
-chown ${STACKABLE_USER_UID}:0 /stackable/.curlrc
+chown ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/.curlrc
 
 # CVE-2023-37920: Remove "e-Tugra" root certificates
 # e-Tugra's root certificates were subject to an investigation prompted by reporting of security issues in their systems
@@ -174,16 +175,16 @@ if [ "$(trust list --filter=ca-anchors | grep -c 'E-Tugra')" != "0" ]; then
 fi
 EOF
 
-COPY --from=config-utils --chown=${STACKABLE_USER_UID}:0 /config-utils/target/release/config-utils /stackable/config-utils
-COPY --from=config-utils --chown=${STACKABLE_USER_UID}:0 /config-utils/config-utils_bin.cdx.xml /stackable/config-utils.cdx.xml
+COPY --from=config-utils --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /config-utils/target/release/config-utils /stackable/config-utils
+COPY --from=config-utils --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /config-utils/config-utils_bin.cdx.xml /stackable/config-utils.cdx.xml
 
 # **containerdebug**
 # Debug tool that logs generic system information.
-COPY --from=containerdebug --chown=${STACKABLE_USER_UID}:0 /containerdebug/target/release/containerdebug /stackable/containerdebug
+COPY --from=containerdebug --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /containerdebug/target/release/containerdebug /stackable/containerdebug
 
 # **check-permissions-ownership.sh**
 # Bash script to check proper permissions and ownership requirements in the final Stackable images
-COPY --chown=${STACKABLE_USER_UID}:0 shared/checks/check-permissions-ownership.sh /bin/check-permissions-ownership.sh
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} shared/checks/check-permissions-ownership.sh /bin/check-permissions-ownership.sh
 
 ENV PATH="${PATH}:/stackable"
 

--- a/stackable-devel/Dockerfile
+++ b/stackable-devel/Dockerfile
@@ -17,6 +17,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:383329bf9c4f968e87e85d30
 ARG PRODUCT
 ARG STACKABLE_USER_UID
 ARG STACKABLE_USER_GID
+ARG STACKABLE_USER_GID
 ARG STACKABLE_USER_NAME
 
 # Sets the default shell to Bash with strict error handling and robust pipeline processing.
@@ -89,7 +90,7 @@ microdnf clean all
 rm -rf /var/cache/yum
 
 cp /root/.curlrc /stackable/.curlrc
-chown ${STACKABLE_USER_UID}:0 /stackable/.curlrc
+chown ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/.curlrc
 
 # WARNING (@NickLarsenNZ): We should pin the rustup version
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain "$RUST_DEFAULT_TOOLCHAIN_VERSION"
@@ -112,6 +113,6 @@ cd /patchable
 cargo auditable --quiet build --release && cargo cyclonedx --all --spec-version 1.5 --describe binaries
 mv /patchable/target/release/patchable /stackable/patchable
 microdnf clean all
-chown ${STACKABLE_USER_UID}:0 /stackable/patchable
+chown ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/patchable
 rm -rf /patchable
 EOF

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -137,6 +137,7 @@ ARG PRODUCT
 ARG PYTHON
 ARG RELEASE
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 LABEL name="Apache Superset" \
     maintainer="info@stackable.tech" \
@@ -155,7 +156,7 @@ ENV PATH="${HOME}/app/bin:${PATH}" \
 
 COPY superset/licenses /licenses
 
-COPY --from=builder --chown=${STACKABLE_USER_UID}:0 /stackable/ ${HOME}/
+COPY --from=builder --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/ ${HOME}/
 
 RUN <<EOF
 microdnf update

--- a/testing-tools/Dockerfile
+++ b/testing-tools/Dockerfile
@@ -12,6 +12,7 @@ ARG RELEASE
 ARG KEYCLOAK_VERSION
 ARG STACKABLE_USER_UID
 ARG STACKABLE_USER_GID
+ARG STACKABLE_USER_GID
 ARG STACKABLE_USER_NAME
 
 LABEL name="Stackable Testing Tools" \
@@ -80,7 +81,7 @@ useradd \
   --home-dir /stackable \
    ${STACKABLE_USER_NAME}
 
-chown -R ${STACKABLE_USER_UID}:0 /stackable
+chown -R ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable
 EOF
 
 ENV PATH=/stackable/keycloak/bin:$PATH

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -10,6 +10,7 @@ ARG JQ_VERSION
 ARG YQ_VERSION
 ARG TARGETARCH
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 LABEL name="Stackable Tools" \
     maintainer="info@stackable.tech" \
@@ -59,7 +60,7 @@ chmod +x /stackable/bin/yq
 
 # All files and folders owned by root group to support running as arbitrary users.
 # This is best practice as all container users will belong to the root group (0).
-chown -R ${STACKABLE_USER_UID}:0 /stackable
+chown -R ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable
 chmod -R g=u /stackable
 EOF
 
@@ -67,7 +68,7 @@ EOF
 # Attention: We are changing the group of all files in /stackable directly above
 # If you do any file based actions (copying / creating etc.) below this comment you
 # absolutely need to make sure that the correct permissions are applied!
-# chown ${STACKABLE_USER_UID}:0
+# chown ${STACKABLE_USER_UID}:${STACKABLE_USER_GID}
 # ----------------------------------------
 
 USER ${STACKABLE_USER_UID}

--- a/trino-cli/Dockerfile
+++ b/trino-cli/Dockerfile
@@ -6,6 +6,7 @@ FROM stackable/image/java-base
 ARG PRODUCT
 ARG RELEASE
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 LABEL name="Trino CLI" \
       maintainer="info@stackable.tech" \
@@ -24,7 +25,7 @@ RUN microdnf update && \
     rm -rf /var/cache/yum
 
 
-COPY --chown=${STACKABLE_USER_UID}:0 trino-cli/licenses /licenses
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} trino-cli/licenses /licenses
 
 WORKDIR /stackable/trino-cli
 
@@ -34,7 +35,7 @@ ln -s "trino-cli-${PRODUCT}-executable.jar" trino-cli-executable.jar
 
 # All files and folders owned by root group to support running as arbitrary users.
 # This is best practice as all container users will belong to the root group (0).
-chown -R ${STACKABLE_USER_UID}:0 /stackable
+chown -R ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable
 chmod -R g=u /stackable
 EOF
 
@@ -42,7 +43,7 @@ EOF
 # Attention: We are changing the group of all files in /stackable directly above
 # If you do any file based actions (copying / creating etc.) below this comment you
 # absolutely need to make sure that the correct permissions are applied!
-# chown ${STACKABLE_USER_UID}:0
+# chown ${STACKABLE_USER_UID}:${STACKABLE_USER_GID}
 # ----------------------------------------
 
 USER ${STACKABLE_USER_UID}

--- a/trino/Dockerfile
+++ b/trino/Dockerfile
@@ -10,6 +10,7 @@ FROM stackable/image/java-base
 ARG PRODUCT
 ARG RELEASE
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 ARG JMX_EXPORTER
 
 LABEL \
@@ -35,14 +36,14 @@ microdnf clean all
 rm -rf /var/cache/yum
 EOF
 
-COPY --from=trino-builder --chown=${STACKABLE_USER_UID}:0 /stackable/trino-server /stackable/trino-server-${PRODUCT}-stackable${RELEASE}
-COPY --chown=${STACKABLE_USER_UID}:0 trino/licenses /licenses
+COPY --from=trino-builder --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/trino-server /stackable/trino-server-${PRODUCT}-stackable${RELEASE}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} trino/licenses /licenses
 
-COPY --from=trino-storage-connector-image --chown=${STACKABLE_USER_UID}:0 /stackable/src/trino-storage-connector/patchable-work/worktree/${PRODUCT}/target/trino-storage-${PRODUCT}-stackable${RELEASE} /stackable/trino-server-${PRODUCT}-stackable${RELEASE}/plugin/trino-storage-${PRODUCT}-stackable${RELEASE}
-COPY --from=trino-storage-connector-image --chown=${STACKABLE_USER_UID}:0 /stackable/src/trino-storage-connector/patchable-work/worktree/${PRODUCT}/target/bom.json /stackable/trino-server-${PRODUCT}-stackable${RELEASE}/plugin/trino-storage-${PRODUCT}-stackable${RELEASE}/trino-storage-${PRODUCT}-stackable${RELEASE}.cdx.json
-COPY --from=trino-storage-connector-image --chown=${STACKABLE_USER_UID}:0 /stackable/trino-storage-connector-${PRODUCT}-stackable${RELEASE}-src.tar.gz /stackable
+COPY --from=trino-storage-connector-image --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/src/trino-storage-connector/patchable-work/worktree/${PRODUCT}/target/trino-storage-${PRODUCT}-stackable${RELEASE} /stackable/trino-server-${PRODUCT}-stackable${RELEASE}/plugin/trino-storage-${PRODUCT}-stackable${RELEASE}
+COPY --from=trino-storage-connector-image --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/src/trino-storage-connector/patchable-work/worktree/${PRODUCT}/target/bom.json /stackable/trino-server-${PRODUCT}-stackable${RELEASE}/plugin/trino-storage-${PRODUCT}-stackable${RELEASE}/trino-storage-${PRODUCT}-stackable${RELEASE}.cdx.json
+COPY --from=trino-storage-connector-image --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/trino-storage-connector-${PRODUCT}-stackable${RELEASE}-src.tar.gz /stackable
 
-COPY --chown=${STACKABLE_USER_UID}:0 trino/stackable/jmx /stackable/jmx
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} trino/stackable/jmx /stackable/jmx
 
 RUN <<EOF
 # JMX Exporter
@@ -52,7 +53,7 @@ ln -s /stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER}.jar /stackable/jmx
 ln -s /stackable/trino-server-${PRODUCT}-stackable${RELEASE} /stackable/trino-server
 
 # Set correct permissions
-chown -R ${STACKABLE_USER_UID}:0 /stackable/jmx /stackable/trino-server
+chown -R ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/jmx /stackable/trino-server
 chmod --recursive g=u /stackable
 EOF
 

--- a/trino/storage-connector/Dockerfile
+++ b/trino/storage-connector/Dockerfile
@@ -8,12 +8,13 @@ FROM stackable/image/java-devel AS storage-connector-builder
 ARG PRODUCT
 ARG RELEASE
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 WORKDIR /stackable
 
-COPY --chown=${STACKABLE_USER_UID}:0 trino/storage-connector/stackable/patches/patchable.toml /stackable/src/trino-storage-connector/stackable/patches/patchable.toml
-COPY --chown=${STACKABLE_USER_UID}:0 trino/storage-connector/stackable/patches/${PRODUCT} /stackable/src/trino-storage-connector/stackable/patches/${PRODUCT}
-COPY --chown=${STACKABLE_USER_UID}:0 --from=trino-builder /stackable/patched-libs /stackable/patched-libs
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} trino/storage-connector/stackable/patches/patchable.toml /stackable/src/trino-storage-connector/stackable/patches/patchable.toml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} trino/storage-connector/stackable/patches/${PRODUCT} /stackable/src/trino-storage-connector/stackable/patches/${PRODUCT}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=trino-builder /stackable/patched-libs /stackable/patched-libs
 USER ${STACKABLE_USER_UID}
 
 # adding a hadolint ignore for SC2215, due to https://github.com/hadolint/hadolint/issues/980

--- a/trino/trino/Dockerfile
+++ b/trino/trino/Dockerfile
@@ -5,11 +5,12 @@ FROM stackable/image/java-devel AS trino-builder
 ARG PRODUCT
 ARG RELEASE
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 WORKDIR /stackable
 
-COPY --chown=${STACKABLE_USER_UID}:0 trino/trino/stackable/patches/patchable.toml /stackable/src/trino/trino/stackable/patches/patchable.toml
-COPY --chown=${STACKABLE_USER_UID}:0 trino/trino/stackable/patches/${PRODUCT} /stackable/src/trino/trino/stackable/patches/${PRODUCT}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} trino/trino/stackable/patches/patchable.toml /stackable/src/trino/trino/stackable/patches/patchable.toml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} trino/trino/stackable/patches/${PRODUCT} /stackable/src/trino/trino/stackable/patches/${PRODUCT}
 
 # adding a hadolint ignore for SC2215, due to https://github.com/hadolint/hadolint/issues/980
 # hadolint ignore=SC2215

--- a/vector/Dockerfile
+++ b/vector/Dockerfile
@@ -8,6 +8,7 @@ ARG RPM_RELEASE
 ARG INOTIFY_TOOLS
 ARG TARGETARCH
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 # Init Jobs/Pods often start a Vector Sidecar Container which collects the logs.
 # As soon as an Init Container is done it'll need to tell the Vector sidecar that it can now also stop
@@ -29,7 +30,7 @@ cp /usr/share/licenses/vector-${PRODUCT}/LICENSE /licenses/VECTOR_LICENSE
 # Vector state, such as on-disk buffers, file checkpoints, and more.
 # Vector needs write permissions.
 mkdir --parents /stackable/vector/var
-chown --recursive ${STACKABLE_USER_UID}:0 /stackable/
+chown --recursive ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/
 # Set correct permissions
 chmod -R g=u /stackable
 EOF

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -9,13 +9,14 @@ FROM stackable/image/java-devel AS builder
 ARG PRODUCT
 ARG JMX_EXPORTER
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 ARG RELEASE
 
 # Copy patches into the builder
-COPY --chown=${STACKABLE_USER_UID}:0 zookeeper/stackable/patches/patchable.toml /stackable/src/zookeeper/stackable/patches/patchable.toml
-COPY --chown=${STACKABLE_USER_UID}:0 zookeeper/stackable/patches/${PRODUCT} /stackable/src/zookeeper/stackable/patches/${PRODUCT}
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} zookeeper/stackable/patches/patchable.toml /stackable/src/zookeeper/stackable/patches/patchable.toml
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} zookeeper/stackable/patches/${PRODUCT} /stackable/src/zookeeper/stackable/patches/${PRODUCT}
 # Copy JMX config into the builder
-COPY --chown=${STACKABLE_USER_UID}:0 zookeeper/stackable/jmx /stackable/jmx
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} zookeeper/stackable/jmx /stackable/jmx
 
 USER ${STACKABLE_USER_UID}
 WORKDIR /stackable
@@ -66,6 +67,7 @@ FROM stackable/image/java-base
 ARG PRODUCT
 ARG RELEASE
 ARG STACKABLE_USER_UID
+ARG STACKABLE_USER_GID
 
 LABEL  \
   name="Apache ZooKeeper" \
@@ -77,23 +79,23 @@ LABEL  \
   description="This image is deployed by the Stackable Operator for Apache ZooKeeper."
 
 # Copy over the ZooKeeper binary folder
-COPY --chown=${STACKABLE_USER_UID}:0 --from=builder /stackable/apache-zookeeper-${PRODUCT}-stackable${RELEASE}-bin /stackable/apache-zookeeper-${PRODUCT}-stackable${RELEASE}-bin/
-COPY --chown=${STACKABLE_USER_UID}:0 --from=builder /stackable/zookeeper-${PRODUCT}-stackable${RELEASE}-src.tar.gz /stackable
-COPY --chown=${STACKABLE_USER_UID}:0 --from=builder /stackable/jmx /stackable/jmx/
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=builder /stackable/apache-zookeeper-${PRODUCT}-stackable${RELEASE}-bin /stackable/apache-zookeeper-${PRODUCT}-stackable${RELEASE}-bin/
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=builder /stackable/zookeeper-${PRODUCT}-stackable${RELEASE}-src.tar.gz /stackable
+COPY --chown=${STACKABLE_USER_UID}:${STACKABLE_USER_GID} --from=builder /stackable/jmx /stackable/jmx/
 COPY zookeeper/licenses /licenses
 
 RUN <<EOF
 microdnf update
 microdnf clean all
 rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}\n" | sort > /stackable/package_manifest.txt
-chown ${STACKABLE_USER_UID}:0 /stackable/package_manifest.txt
+chown ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/package_manifest.txt
 chmod g=u /stackable/package_manifest.txt
 rm -rf /var/cache/yum
 
 # Add link pointing from /stackable/zookeeper to /stackable/apache-zookeeper-${PRODUCT}-stackable${RELEASE}-bin/
 # to preserve the folder name with the version.
 ln -s /stackable/apache-zookeeper-${PRODUCT}-stackable${RELEASE}-bin/ /stackable/zookeeper
-chown -h ${STACKABLE_USER_UID}:0 /stackable/zookeeper
+chown -h ${STACKABLE_USER_UID}:${STACKABLE_USER_GID} /stackable/zookeeper
 
 # fix missing permissions
 chmod g=u /stackable/jmx


### PR DESCRIPTION
Images were failing to build, and we think it is due to the GID being `1000`, but permissions being set to GID `0`.

Error:

```
failed to solve: failed to compute cache key: failed to calculate checksum of ref sx27n0fucs3yx7dk9rffa305j::0l8bk4seqdjwhzu4loqedvxlm: "/stackable/patched-libs": not found
```

Maybe because of:

```sh
COPY --from=hadoop-builder --chown=${STACKABLE_USER_UID}:0 /stackable/patched-libs /stackable/patched-libs
```

[Slack thread](https://stackable-workspace.slack.com/archives/C07UG6JH44F/p1752243729159399)