### PR TITLE
fix: Update nipyapi to 0.22.0 to work with custom nifi versions

### DIFF
--- a/nifi/Dockerfile
+++ b/nifi/Dockerfile
@@ -204,6 +204,13 @@ COPY --chown=${STACKABLE_USER_UID}:0 nifi/stackable/bin /stackable/bin
 COPY --chown=${STACKABLE_USER_UID}:0 nifi/licenses /licenses
 COPY --chown=${STACKABLE_USER_UID}:0 nifi/python /stackable/python
 
+# The nipyapi is required until NiFi 2.0.x for the ReportingTaskJob
+# This can be removed once the 1.x.x line is removed
+# Note: Keep this in sync with the version installed in testing-tools! (See the requirements.txt file)
+# Find the latest version here: https://pypi.org/project/nipyapi/
+# renovate: datasource=pypi packageName=nipyapi
+ENV NIPYAPI_VERSION=0.22.0
+
 RUN <<EOF
 microdnf update
 
@@ -217,10 +224,8 @@ microdnf install \
 microdnf clean all
 rm -rf /var/cache/yum
 
-# The nipyapi is required until NiFi 2.0.x for the ReportingTaskJob
-# This can be removed once the 1.x.x line is removed
 pip install --no-cache-dir \
-    nipyapi==0.19.1
+    nipyapi==${NIPYAPI_VERSION}
 
 # For backwards compatibility we create a softlink in /bin where the jar used to be as long as we are root
 # This can be removed once older versions / operators using this are no longer supported

--- a/testing-tools/python/requirements.txt
+++ b/testing-tools/python/requirements.txt
@@ -6,6 +6,7 @@ hive-metastore-client==1.0.9
 kafka-python3==3.0.0
 
 # Used in the NiFi integration tests
+# Should match the version in nifi/Dockerfile
 nipyapi==0.22.0
 
 pandas==2.2.3

--- a/testing-tools/python/requirements.txt
+++ b/testing-tools/python/requirements.txt
@@ -4,12 +4,17 @@ requests==2.32.3
 charset-normalizer==3.3.2 #
 hive-metastore-client==1.0.9
 kafka-python3==3.0.0
-nipyapi==0.20.0
+
+# Used in the NiFi integration tests
+nipyapi==0.22.0
+
 pandas==2.2.3
 trino==0.329.0
+
 # gssapi/kerberos/pure-sasl are needed for using the python metastore client with kerberos.
 gssapi==1.8.3
 kerberos==1.3.1
 pure-sasl==0.6.2
+
 pytest==8.3.3 # Needed to execute Python unit-tests
 #thrift==0.13.0 # Installed as deb package because it fails to build from source with pip. Needs to match the version from hive-metastore-client


### PR DESCRIPTION
# Description

fix: Update nipyapi to 0.22.0 to work with custom nifi versions

The test still fails for me but for now unrelated reasons I'd say: https://github.com/stackabletech/nifi-operator/issues/814#issuecomment-3064125417

