### PR TITLE
feat: SBOMs for OpenSearch and opensearch-security-plugin

### DIFF
--- a/opensearch/Dockerfile
+++ b/opensearch/Dockerfile
@@ -11,7 +11,6 @@ WORKDIR /stackable
 
 COPY --chown=${STACKABLE_USER_UID}:0 opensearch/stackable/patches/patchable.toml /stackable/src/opensearch/stackable/patches/patchable.toml
 COPY --chown=${STACKABLE_USER_UID}:0 opensearch/stackable/patches/${PRODUCT} /stackable/src/opensearch/stackable/patches/${PRODUCT}
-COPY --chown=${STACKABLE_USER_UID}:0 --from=opensearch-security-plugin /stackable/src/opensearch/security-plugin/patchable-work/worktree/${OPENSEARCH_SECURITY_PLUGIN}/build/distributions/opensearch-security-${OPENSEARCH_SECURITY_PLUGIN}-SNAPSHOT.zip /stackable/opensearch-security-plugin/opensearch-security-${OPENSEARCH_SECURITY_PLUGIN}-SNAPSHOT.zip
 
 RUN <<EOF
 microdnf update
@@ -29,11 +28,15 @@ NEW_VERSION="${PRODUCT}-stackable${RELEASE}"
 # Create snapshot of the source code including custom patches
 tar -czf /stackable/opensearch-${NEW_VERSION}-src.tar.gz .
 ./gradlew localDistro
+./gradlew cyclonedxBom --warning-mode=summary
 cp -r ./distribution/archives/linux-tar/build/install/opensearch-${PRODUCT}-SNAPSHOT /stackable/opensearch
 cp ./distribution/docker/src/docker/bin/docker-entrypoint.sh /stackable/opensearch/opensearch-docker-entrypoint.sh
+cp build/reports/bom.json /stackable/opensearch/opensearch-${PRODUCT}-SNAPSHOT.cdx.json
 EOF
 
 WORKDIR /stackable/opensearch-security-plugin
+COPY --chown=${STACKABLE_USER_UID}:0 --from=opensearch-security-plugin /stackable/src/opensearch/security-plugin/patchable-work/worktree/${OPENSEARCH_SECURITY_PLUGIN}/build/distributions/opensearch-security-${OPENSEARCH_SECURITY_PLUGIN}-SNAPSHOT.zip /stackable/opensearch-security-plugin/opensearch-security-${OPENSEARCH_SECURITY_PLUGIN}-SNAPSHOT.zip
+COPY --chown=${STACKABLE_USER_UID}:0 --from=opensearch-security-plugin /stackable/src/opensearch/security-plugin/patchable-work/worktree/${OPENSEARCH_SECURITY_PLUGIN}/build/reports/bom.json /stackable/opensearch-security-plugin/opensearch-security-${OPENSEARCH_SECURITY_PLUGIN}-SNAPSHOT.cdx.json
 
 RUN <<EOF
 unzip opensearch-security-${OPENSEARCH_SECURITY_PLUGIN}-SNAPSHOT.zip

--- a/opensearch/security-plugin/Dockerfile
+++ b/opensearch/security-plugin/Dockerfile
@@ -16,6 +16,7 @@ cd "$(/stackable/patchable --images-repo-root=src checkout opensearch/security-p
 # Create snapshot of the source code including custom patches
 tar -czf /stackable/opensearch-security-plugin-${PRODUCT}-src.tar.gz .
 ./gradlew clean assemble
+./gradlew cyclonedxBom --warning-mode=summary
 EOF
 
 RUN <<EOF

--- a/opensearch/security-plugin/stackable/patches/3.1.0.0/0001-Add-CycloneDX-plugin.patch
+++ b/opensearch/security-plugin/stackable/patches/3.1.0.0/0001-Add-CycloneDX-plugin.patch
@@ -1,0 +1,38 @@
+From eb596aa60cc21369d742b8d73604a2aac2a70f59 Mon Sep 17 00:00:00 2001
+From: dervoeti <lukas.krug@stackable.tech>
+Date: Tue, 22 Jul 2025 09:52:55 +0200
+Subject: Add CycloneDX plugin
+
+---
+ build.gradle | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/build.gradle b/build.gradle
+index bb2e65ab..314bb7be 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -71,6 +71,7 @@ plugins {
+     id 'eclipse'
+     id "com.github.spotbugs" version "6.2.0"
+     id "com.google.osdetector" version "1.7.3"
++    id "org.cyclonedx.bom" version "2.3.1"
+ }
+ 
+ allprojects {
+@@ -87,6 +88,16 @@ apply from: 'gradle/formatting.gradle'
+ licenseFile = rootProject.file('LICENSE.txt')
+ noticeFile = rootProject.file('NOTICE.txt')
+ 
++cyclonedxBom {
++    includeConfigs = ["runtimeClasspath"]
++    includeLicenseText = false
++    skipConfigs = ["compileClasspath", "testCompileClasspath"]
++    projectType = "application"
++    schemaVersion = "1.6"
++    outputFormat = "json"
++    componentVersion = opensearch_build
++}
++
+ spotbugs {
+     includeFilter = file('spotbugs-include.xml')
+ }

--- a/opensearch/stackable/patches/3.1.0/0002-Add-CycloneDX-plugin.patch
+++ b/opensearch/stackable/patches/3.1.0/0002-Add-CycloneDX-plugin.patch
@@ -1,0 +1,38 @@
+From b216d37795bbf81a5ebad73101d8081a8f93068c Mon Sep 17 00:00:00 2001
+From: dervoeti <lukas.krug@stackable.tech>
+Date: Mon, 21 Jul 2025 12:45:43 +0200
+Subject: Add CycloneDX plugin
+
+---
+ build.gradle | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/build.gradle b/build.gradle
+index e7988cb852f..4c2f2374a99 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -58,6 +58,7 @@ plugins {
+   id "org.gradle.test-retry" version "1.6.2" apply false
+   id "test-report-aggregation"
+   id 'jacoco-report-aggregation'
++  id 'org.cyclonedx.bom' version '1.8.2'
+ }
+ 
+ apply from: 'gradle/build-complete.gradle'
+@@ -77,6 +78,16 @@ allprojects {
+   description = "OpenSearch subproject ${project.path}"
+ }
+ 
++cyclonedxBom {
++    includeConfigs = ["runtimeClasspath"]
++    includeLicenseText = false
++    skipConfigs = ["compileClasspath", "testCompileClasspath"]
++    projectType = "application"
++    schemaVersion = "1.6"
++    outputFormat = "json"
++    componentVersion = VersionProperties.getOpenSearch()
++}
++
+ configure(allprojects - project(':distribution:archives:integ-test-zip')) {
+   project.pluginManager.withPlugin('nebula.maven-base-publish') {
+     if (project.pluginManager.hasPlugin('opensearch.build') == false) {


### PR DESCRIPTION
# Description

I had to use an older version of the [cyclonedx-gradle-plugin](https://github.com/CycloneDX/cyclonedx-gradle-plugin) for OpenSearch itself, since newer versions caused issues with the version of the `com.networknt:json-schema-validator` component used by the OpenSearch build process. Updating `com.networknt:json-schema-validator` to the latest version is also possible (then the most recent version of cyclonedx-gradle-plugin works), but I decided against it to prevent side effect on the OpenSearch build process.

`--warning-mode=summary` is passed to the `cyclonedxBom` subcommand to prevent it from failing because of deprecated features. The SBOM is generated correctly, it will probably not work with Gradle 9 but by then newer versions of OpenSearch and the cyclonedx-gradle-plugin might be ready that fix these warnings.

I also moved the `COPY` line of the security plugin further down to avoid rebuilding OpenSearch when changing something in the plugin.

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
