### PR TITLE
fix: spark 3 add bouncy castle as compile time dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,7 +232,7 @@ All notable changes to this project will be documented in this file.
 
 - omid: Added 1.1.3-SNAPSHOT to allow for easier scanning pre-release
 - airflow: Add OPA support to Airflow ([#978]).
-- nifi: Activate `include-hadoop` profile for NiFi version 2.\* ([#958]).
+- nifi: Activate `include-hadoop` profile for NiFi version 2 ([#958]).
 - nifi: Add NiFi hadoop Azure and GCP libraries ([#943]).
 - superset: Add role mapping from OPA ([#979]).
 - base: Add containerdebug tool ([#928], [#959]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ All notable changes to this project will be documented in this file.
 - zookeeper: bump netty version for CVE-2025-24970 in 3.9.3 ([#1180])
 - hadoop: backport HADOOP-19352, HADOOP-19335, HADOOP-19465, HADOOP-19456 and HADOOP-19225 to fix vulnerabilities in Hadoop `3.4.1` ([#1184])
 - hadoop: Backport HADOOP-18583 to make OpenSSL 3.x work with the native hadoop libraries ([#1209]).
+- spark: backport [SPARK-51311] Promote bcprov-jdk18on to compile scope ([#1212]).
 
 ### Changed
 
@@ -223,6 +224,7 @@ All notable changes to this project will be documented in this file.
 [#1189]: https://github.com/stackabletech/docker-images/pull/1189
 [#1197]: https://github.com/stackabletech/docker-images/pull/1197
 [#1209]: https://github.com/stackabletech/docker-images/pull/1209
+[#1212]: https://github.com/stackabletech/docker-images/pull/1212
 
 ## [25.3.0] - 2025-03-21
 
@@ -230,7 +232,7 @@ All notable changes to this project will be documented in this file.
 
 - omid: Added 1.1.3-SNAPSHOT to allow for easier scanning pre-release
 - airflow: Add OPA support to Airflow ([#978]).
-- nifi: Activate `include-hadoop` profile for NiFi version 2.* ([#958]).
+- nifi: Activate `include-hadoop` profile for NiFi version 2.\* ([#958]).
 - nifi: Add NiFi hadoop Azure and GCP libraries ([#943]).
 - superset: Add role mapping from OPA ([#979]).
 - base: Add containerdebug tool ([#928], [#959]).
@@ -763,7 +765,7 @@ All notable changes to this project will be documented in this file.
 - BREAKING: Use RPM instead of tar.gz for Vector. Because of that, the
   location of the Vector executable changed, and the operator-rs version
   0.45.0 or newer is required ([#429]).
-- spark-k8s: Rework spark images to build on top of java-base image.  This fixes the missing tzdata-java package in 0.0.0-dev versions ([#434]).
+- spark-k8s: Rework spark images to build on top of java-base image. This fixes the missing tzdata-java package in 0.0.0-dev versions ([#434]).
 
 - airflow: Updated git-sync to 3.6.8 ([#431]).
 - airflow: Updated statsd-exporter to 0.24, this was accidentally moved to a very old version previously (0.3.0) ([#431]).

--- a/spark-k8s/stackable/patches/3.5.5/0002-Backport-SPARK-51311-BUILD-Promote-bcprov-jdk18on-to.patch
+++ b/spark-k8s/stackable/patches/3.5.5/0002-Backport-SPARK-51311-BUILD-Promote-bcprov-jdk18on-to.patch
@@ -1,0 +1,83 @@
+From c4a23f0060f34a2e1c3b826b9698ad56a5ce7176 Mon Sep 17 00:00:00 2001
+From: Razvan-Daniel Mihai <84674+razvan@users.noreply.github.com>
+Date: Tue, 22 Jul 2025 18:51:28 +0200
+Subject: Backport [SPARK-51311][BUILD] Promote bcprov-jdk18on to compile scope
+
+---
+ LICENSE-binary                           |  1 +
+ assembly/pom.xml                         | 14 ++++++++++++++
+ dev/deps/spark-deps-hadoop-3-hive-2.3    |  1 +
+ licenses-binary/LICENSE-bouncycastle.txt | 13 +++++++++++++
+ 4 files changed, 29 insertions(+)
+ create mode 100644 licenses-binary/LICENSE-bouncycastle.txt
+
+diff --git a/LICENSE-binary b/LICENSE-binary
+index 05645977a0..9834cf333f 100644
+--- a/LICENSE-binary
++++ b/LICENSE-binary
+@@ -480,6 +480,7 @@ org.typelevel:algebra_2.12:jar
+ org.typelevel:cats-kernel_2.12
+ org.typelevel:machinist_2.12
+ net.razorvine:pickle
++org.bouncycastle:bcprov-jdk18on
+ org.slf4j:jcl-over-slf4j
+ org.slf4j:jul-to-slf4j
+ org.slf4j:slf4j-api
+diff --git a/assembly/pom.xml b/assembly/pom.xml
+index 2066bbeb7e..05edd80958 100644
+--- a/assembly/pom.xml
++++ b/assembly/pom.xml
+@@ -85,8 +85,22 @@
+       <artifactId>guava</artifactId>
+       <scope>${hadoop.deps.scope}</scope>
+     </dependency>
++
++    <!--
++      Adapted from https://github.com/apache/spark/pull/50077
++
++      SPARK-51311: HDFS-15098 (3.4.0) adds hard dependency on bcprov-jdk18on, Spark fails to submit
++      to Kerberized cluster without this dependency, until HADOOP-19152 (3.5.0, unreleased)
++      -->
++    <dependency>
++      <groupId>org.bouncycastle</groupId>
++      <artifactId>bcprov-jdk18on</artifactId>
++      <scope>${hadoop.deps.scope}</scope>
++    </dependency>
++
+   </dependencies>
+ 
++
+   <build>
+     <plugins>
+       <plugin>
+diff --git a/dev/deps/spark-deps-hadoop-3-hive-2.3 b/dev/deps/spark-deps-hadoop-3-hive-2.3
+index 4feea62dfe..df85dcb6f5 100644
+--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
++++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
+@@ -28,6 +28,7 @@ aws-java-sdk-bundle/1.12.262//aws-java-sdk-bundle-1.12.262.jar
+ azure-data-lake-store-sdk/2.3.9//azure-data-lake-store-sdk-2.3.9.jar
+ azure-keyvault-core/1.0.0//azure-keyvault-core-1.0.0.jar
+ azure-storage/7.0.1//azure-storage-7.0.1.jar
++bcprov-jdk18on/1.77//bcprov-jdk18on-1.77.jar
+ blas/3.0.3//blas-3.0.3.jar
+ bonecp/0.8.0.RELEASE//bonecp-0.8.0.RELEASE.jar
+ breeze-macros_2.12/2.1.0//breeze-macros_2.12-2.1.0.jar
+diff --git a/licenses-binary/LICENSE-bouncycastle.txt b/licenses-binary/LICENSE-bouncycastle.txt
+new file mode 100644
+index 0000000000..277dcd1ebb
+--- /dev/null
++++ b/licenses-binary/LICENSE-bouncycastle.txt
+@@ -0,0 +1,13 @@
++Copyright (c) 2000-2024 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org).
++Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
++associated documentation files (the "Software"), to deal in the Software without restriction,
++including without limitation the rights to use, copy, modify, merge, publish, distribute,
++sub license, and/or sell copies of the Software, and to permit persons to whom the Software is
++furnished to do so, subject to the following conditions: The above copyright notice and this
++permission notice shall be included in all copies or substantial portions of the Software.
++
++**THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
++NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
++DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
++OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.**

--- a/spark-k8s/stackable/patches/3.5.6/0002-Backport-SPARK-51311-BUILD-Promote-bcprov-jdk18on-to.patch
+++ b/spark-k8s/stackable/patches/3.5.6/0002-Backport-SPARK-51311-BUILD-Promote-bcprov-jdk18on-to.patch
@@ -1,14 +1,14 @@
-From 078f639ddc0f7b108345dc5491c9a8ebe55e35bf Mon Sep 17 00:00:00 2001
+From 37d866706d952702effd640babf891fef349da7d Mon Sep 17 00:00:00 2001
 From: Razvan-Daniel Mihai <84674+razvan@users.noreply.github.com>
 Date: Tue, 22 Jul 2025 17:34:03 +0200
 Subject: Backport [SPARK-51311][BUILD] Promote bcprov-jdk18on to compile scope
 
 ---
  LICENSE-binary                           |  1 +
- assembly/pom.xml                         | 13 +++++++++++++
+ assembly/pom.xml                         | 14 ++++++++++++++
  dev/deps/spark-deps-hadoop-3-hive-2.3    |  1 +
  licenses-binary/LICENSE-bouncycastle.txt | 13 +++++++++++++
- 4 files changed, 28 insertions(+)
+ 4 files changed, 29 insertions(+)
  create mode 100644 licenses-binary/LICENSE-bouncycastle.txt
 
 diff --git a/LICENSE-binary b/LICENSE-binary
@@ -24,13 +24,14 @@ index 05645977a0..9834cf333f 100644
  org.slf4j:jul-to-slf4j
  org.slf4j:slf4j-api
 diff --git a/assembly/pom.xml b/assembly/pom.xml
-index dcc46b0b82..fc3c11d385 100644
+index dcc46b0b82..def40ad52e 100644
 --- a/assembly/pom.xml
 +++ b/assembly/pom.xml
-@@ -87,6 +87,19 @@
+@@ -85,8 +85,22 @@
+       <artifactId>guava</artifactId>
+       <scope>${hadoop.deps.scope}</scope>
      </dependency>
-   </dependencies>
- 
++
 +    <!--
 +      Adapted from https://github.com/apache/spark/pull/50077
 +
@@ -42,7 +43,9 @@ index dcc46b0b82..fc3c11d385 100644
 +      <artifactId>bcprov-jdk18on</artifactId>
 +      <scope>${hadoop.deps.scope}</scope>
 +    </dependency>
-+  </dependencies>
++
+   </dependencies>
+ 
 +
    <build>
      <plugins>

--- a/spark-k8s/stackable/patches/3.5.6/0002-Backport-SPARK-51311-BUILD-Promote-bcprov-jdk18on-to.patch
+++ b/spark-k8s/stackable/patches/3.5.6/0002-Backport-SPARK-51311-BUILD-Promote-bcprov-jdk18on-to.patch
@@ -1,0 +1,80 @@
+From 078f639ddc0f7b108345dc5491c9a8ebe55e35bf Mon Sep 17 00:00:00 2001
+From: Razvan-Daniel Mihai <84674+razvan@users.noreply.github.com>
+Date: Tue, 22 Jul 2025 17:34:03 +0200
+Subject: Backport [SPARK-51311][BUILD] Promote bcprov-jdk18on to compile scope
+
+---
+ LICENSE-binary                           |  1 +
+ assembly/pom.xml                         | 13 +++++++++++++
+ dev/deps/spark-deps-hadoop-3-hive-2.3    |  1 +
+ licenses-binary/LICENSE-bouncycastle.txt | 13 +++++++++++++
+ 4 files changed, 28 insertions(+)
+ create mode 100644 licenses-binary/LICENSE-bouncycastle.txt
+
+diff --git a/LICENSE-binary b/LICENSE-binary
+index 05645977a0..9834cf333f 100644
+--- a/LICENSE-binary
++++ b/LICENSE-binary
+@@ -480,6 +480,7 @@ org.typelevel:algebra_2.12:jar
+ org.typelevel:cats-kernel_2.12
+ org.typelevel:machinist_2.12
+ net.razorvine:pickle
++org.bouncycastle:bcprov-jdk18on
+ org.slf4j:jcl-over-slf4j
+ org.slf4j:jul-to-slf4j
+ org.slf4j:slf4j-api
+diff --git a/assembly/pom.xml b/assembly/pom.xml
+index dcc46b0b82..fc3c11d385 100644
+--- a/assembly/pom.xml
++++ b/assembly/pom.xml
+@@ -87,6 +87,19 @@
+     </dependency>
+   </dependencies>
+ 
++    <!--
++      Adapted from https://github.com/apache/spark/pull/50077
++
++      SPARK-51311: HDFS-15098 (3.4.0) adds hard dependency on bcprov-jdk18on, Spark fails to submit
++      to Kerberized cluster without this dependency, until HADOOP-19152 (3.5.0, unreleased)
++      -->
++    <dependency>
++      <groupId>org.bouncycastle</groupId>
++      <artifactId>bcprov-jdk18on</artifactId>
++      <scope>${hadoop.deps.scope}</scope>
++    </dependency>
++  </dependencies>
++
+   <build>
+     <plugins>
+       <plugin>
+diff --git a/dev/deps/spark-deps-hadoop-3-hive-2.3 b/dev/deps/spark-deps-hadoop-3-hive-2.3
+index dbf0cb34c5..689f50612b 100644
+--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
++++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
+@@ -28,6 +28,7 @@ aws-java-sdk-bundle/1.12.262//aws-java-sdk-bundle-1.12.262.jar
+ azure-data-lake-store-sdk/2.3.9//azure-data-lake-store-sdk-2.3.9.jar
+ azure-keyvault-core/1.0.0//azure-keyvault-core-1.0.0.jar
+ azure-storage/7.0.1//azure-storage-7.0.1.jar
++bcprov-jdk18on/1.77//bcprov-jdk18on-1.77.jar
+ blas/3.0.3//blas-3.0.3.jar
+ bonecp/0.8.0.RELEASE//bonecp-0.8.0.RELEASE.jar
+ breeze-macros_2.12/2.1.0//breeze-macros_2.12-2.1.0.jar
+diff --git a/licenses-binary/LICENSE-bouncycastle.txt b/licenses-binary/LICENSE-bouncycastle.txt
+new file mode 100644
+index 0000000000..277dcd1ebb
+--- /dev/null
++++ b/licenses-binary/LICENSE-bouncycastle.txt
+@@ -0,0 +1,13 @@
++Copyright (c) 2000-2024 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org).
++Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
++associated documentation files (the "Software"), to deal in the Software without restriction,
++including without limitation the rights to use, copy, modify, merge, publish, distribute,
++sub license, and/or sell copies of the Software, and to permit persons to whom the Software is
++furnished to do so, subject to the following conditions: The above copyright notice and this
++permission notice shall be included in all copies or substantial portions of the Software.
++
++**THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
++NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
++DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
++OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.**


### PR DESCRIPTION
# Description

Hadoop has stopped exporting the bouncy castle dependency which leads to ClassNotFoundExceptions in kerberized environments.

Spark 4 has already fixed this issue in [SPARK-51311 ](https://github.com/apache/spark/pull/50077).

This PR backports the above to Spark 3.

The image contains the required jar file:

```
❯ docker run --rm oci.stackable.tech/sdp/spark-k8s:3.5.6-stackable0.0.0-dev find ./ -iname 'bcprov*'
...
./jars/bcprov-jdk18on-1.77.jar
```
## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
