### PR TITLE
Use our build-repo to cache NPM dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- all: Use our build-repo to cache NPM dependencies ([#1219])
+
+[#1219]: https://github.com/stackabletech/docker-images/pull/1219
+
 ## [25.7.0] - 2025-07-23
 
 ## [25.7.0-rc1] - 2025-07-18

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -31,6 +31,7 @@ find . -type f -print0 | xargs -0 sed -i "s/\-stackable0\.0\.0\-dev/-stackable${
 tar -czf /stackable/kafka-${NEW_VERSION}-src.tar.gz .
 
 # TODO: Try to install gradle via package manager (if possible) instead of fetching it from the internet
+# We patch Kafka to use our Nexus build repo instead
 # We don't specify "-x test" to skip the tests, as we might bump some Kafka internal dependencies in the future and
 # it's a good idea to run the tests in this case.
 ./gradlew clean releaseTarGz

--- a/stackable-devel/Dockerfile
+++ b/stackable-devel/Dockerfile
@@ -115,3 +115,16 @@ microdnf clean all
 chown ${STACKABLE_USER_UID}:0 /stackable/patchable
 rm -rf /patchable
 EOF
+
+# Make sure NPM and YARN use our build mirror
+# In theory YARN should (I believe) fall back to the npmrc file but we want to make sure...
+COPY --chown=${STACKABLE_USER_UID}:0 stackable-devel/stackable/.npmrc /stackable/.npmrc
+COPY --chown=${STACKABLE_USER_UID}:0 stackable-devel/stackable/.npmrc /root/.npmrc
+
+# YARN v1
+COPY --chown=${STACKABLE_USER_UID}:0 stackable-devel/stackable/.yarnrc /stackable/.yarnrc
+COPY --chown=${STACKABLE_USER_UID}:0 stackable-devel/stackable/.yarnrc /root/.yarnrc
+
+# YARN v2++
+COPY --chown=${STACKABLE_USER_UID}:0 stackable-devel/stackable/.yarnrc.yml /stackable/.yarnrc.yml
+COPY --chown=${STACKABLE_USER_UID}:0 stackable-devel/stackable/.yarnrc.yml /root/.yarnrc.yml

--- a/stackable-devel/stackable/.npmrc
+++ b/stackable-devel/stackable/.npmrc
@@ -1,0 +1,1 @@
+registry=https://build-repo.stackable.tech/repository/npm-public/

--- a/stackable-devel/stackable/.yarnrc
+++ b/stackable-devel/stackable/.yarnrc
@@ -1,0 +1,1 @@
+registry "https://build-repo.stackable.tech/repository/npm-public/"

--- a/stackable-devel/stackable/.yarnrc.yml
+++ b/stackable-devel/stackable/.yarnrc.yml
@@ -1,0 +1,1 @@
+npmRegistryServer: "https://build-repo.stackable.tech/repository/npm-public/"


### PR DESCRIPTION
# Description

We're already using our mirror to cache Maven dependencies.
This uses the same mirror for NPM dependencies.

I tried building all of these and they worked:

- [x] Airflow
- [x] Druid
- [x] HBase
- [x] Hadoop HDFS
- [x] Hive
- [x] Kafka
- [x] NiFi
- [x] Spark
- [x] Superset
- [x] Trino
- [x] ZooKeeper
- [x] OPA

## Definition of Done Checklist


- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] Add an entry to the CHANGELOG.md file

## How I tested this
I did apply the patch and built all images in all versions. They all succeeded so I'm sure that things have not gotten worse. At the same time I tailed the logs for our build-repo server and saw accesses to the NPM mirror. As we're not using that mirror anywhere else I'm fairly certain that these requests must be coming from me.

As a side-effect I also built a spike which introduces a proxy in our build process which can intercept these calls. The branch is available here https://github.com/stackabletech/docker-images/tree/feat/proxy but I did not test it with this yet. That's for the future. This is purely informational and this branch is NOT READY for use.

After these tests I'm convinced that the mirroring will work for at least some projects and it does not break any of them.