### PR TITLE
Backport NIFI-14858 to NiFi 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - ubi9-rust-builder: Include `.tar.gz` snapshots of the operator source code in container images ([#1207])
 - opensearch: Add Opensearch as new product with version `3.1.0` ([#1215]).
 - opensearch: Use build-repo.stackable.tech instead of Maven Central ([#1222]).
+- nifi: Backport NIFI-14848 to NiFi ([#1225])
 
 ### Changed
 
@@ -20,6 +21,7 @@ All notable changes to this project will be documented in this file.
 [#1219]: https://github.com/stackabletech/docker-images/pull/1219
 [#1220]: https://github.com/stackabletech/docker-images/pull/1220
 [#1222]: https://github.com/stackabletech/docker-images/pull/1222
+[#1225]: https://github.com/stackabletech/docker-images/pull/1225
 
 ## [25.7.0] - 2025-07-23
 

--- a/nifi/stackable/patches/2.4.0/0004-NIFI-14858-Make-SNI-checking-configurable.patch
+++ b/nifi/stackable/patches/2.4.0/0004-NIFI-14858-Make-SNI-checking-configurable.patch
@@ -1,0 +1,106 @@
+From 6f36be44f82a759fe7f4604839b5e528e5037fea Mon Sep 17 00:00:00 2001
+From: Lars Francke <git@lars-francke.de>
+Date: Wed, 13 Aug 2025 14:16:55 +0200
+Subject: NIFI-14858: Make SNI checking configurable
+
+Introduces two new properties:
+- nifi.web.https.sni.required
+- nifi.web.https.sni.host.check
+---
+ .../StandardServerConnectorFactory.java       | 24 +++++++++++++++++++
+ .../org/apache/nifi/util/NiFiProperties.java  | 10 ++++++++
+ .../FrameworkServerConnectorFactory.java      |  4 ++++
+ 3 files changed, 38 insertions(+)
+
+diff --git a/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/StandardServerConnectorFactory.java b/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/StandardServerConnectorFactory.java
+index 26d09706a1..37fda0929d 100644
+--- a/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/StandardServerConnectorFactory.java
++++ b/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/StandardServerConnectorFactory.java
+@@ -70,6 +70,10 @@ public class StandardServerConnectorFactory implements ServerConnectorFactory {
+ 
+     private int requestHeaderSize = 8192;
+ 
++    private boolean sniRequired = true;
++
++    private boolean sniHostCheck = true;
++
+     /**
+      * Standard Server Connector Factory Constructor with required properties
+      *
+@@ -181,6 +185,24 @@ public class StandardServerConnectorFactory implements ServerConnectorFactory {
+         this.requestHeaderSize = requestHeaderSize;
+     }
+ 
++    /**
++     * Set SNI Required controls whether SNI is required for TLS connections
++     *
++     * @param sniRequired SNI Required status
++     */
++    public void setSniRequired(final boolean sniRequired) {
++        this.sniRequired = sniRequired;
++    }
++
++    /**
++     * Set SNI Host Check controls whether SNI host checking is enabled for TLS connections
++     *
++     * @param sniHostCheck SNI Host Check status
++     */
++    public void setSniHostCheck(final boolean sniHostCheck) {
++        this.sniHostCheck = sniHostCheck;
++    }
++
+     protected Server getServer() {
+         return server;
+     }
+@@ -195,6 +217,8 @@ public class StandardServerConnectorFactory implements ServerConnectorFactory {
+             httpConfiguration.setSendServerVersion(SEND_SERVER_VERSION);
+ 
+             final SecureRequestCustomizer secureRequestCustomizer = new SecureRequestCustomizer();
++            secureRequestCustomizer.setSniRequired(sniRequired);
++            secureRequestCustomizer.setSniHostCheck(sniHostCheck);
+             httpConfiguration.addCustomizer(secureRequestCustomizer);
+         }
+ 
+diff --git a/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java b/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
+index cd3cd0b27e..0e07d5a141 100644
+--- a/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
++++ b/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
+@@ -206,6 +206,8 @@ public class NiFiProperties extends ApplicationProperties {
+     public static final String WEB_HTTPS_CIPHERSUITES_INCLUDE = "nifi.web.https.ciphersuites.include";
+     public static final String WEB_HTTPS_CIPHERSUITES_EXCLUDE = "nifi.web.https.ciphersuites.exclude";
+     public static final String WEB_HTTPS_NETWORK_INTERFACE_PREFIX = "nifi.web.https.network.interface.";
++    public static final String WEB_HTTPS_SNI_REQUIRED = "nifi.web.https.sni.required";
++    public static final String WEB_HTTPS_SNI_HOST_CHECK = "nifi.web.https.sni.host.check";
+     public static final String WEB_WORKING_DIR = "nifi.web.jetty.working.directory";
+     public static final String WEB_THREADS = "nifi.web.jetty.threads";
+     public static final String WEB_MAX_HEADER_SIZE = "nifi.web.max.header.size";
+@@ -710,6 +712,14 @@ public class NiFiProperties extends ApplicationProperties {
+         return Arrays.stream(protocols.split("\\s+")).collect(Collectors.toSet());
+     }
+ 
++    public boolean isWebHttpsSniRequired() {
++        return Boolean.parseBoolean(getProperty(WEB_HTTPS_SNI_REQUIRED, "true"));
++    }
++
++    public boolean isWebHttpsSniHostCheck() {
++        return Boolean.parseBoolean(getProperty(WEB_HTTPS_SNI_HOST_CHECK, "true"));
++    }
++
+     public String getWebMaxHeaderSize() {
+         return getProperty(WEB_MAX_HEADER_SIZE, DEFAULT_WEB_MAX_HEADER_SIZE);
+     }
+diff --git a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/connector/FrameworkServerConnectorFactory.java b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/connector/FrameworkServerConnectorFactory.java
+index b58c886f4f..55a28b1c3c 100644
+--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/connector/FrameworkServerConnectorFactory.java
++++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/connector/FrameworkServerConnectorFactory.java
+@@ -90,6 +90,10 @@ public class FrameworkServerConnectorFactory extends StandardServerConnectorFact
+ 
+             // Set Transport Layer Security Protocols based on platform configuration
+             setIncludeSecurityProtocols(TlsPlatform.getPreferredProtocols().toArray(new String[0]));
++
++            // Set SNI configuration from properties
++            setSniRequired(properties.isWebHttpsSniRequired());
++            setSniHostCheck(properties.isWebHttpsSniHostCheck());
+         }
+     }
+ 


### PR DESCRIPTION
# Description

This allows to manually work around https://github.com/stackabletech/nifi-operator/issues/812 by applying [NIFI-14848](https://issues.apache.org/jira/browse/NIFI-14858) to NiFi 2.4.0.

It allows disabling of SNI checks for NiFi 2.x

## How this was tested

I did run the image build and we tested it manually on a cluster with an Ingress.
Without config overrides we'd get an error accessing NiFi.
With the config overrides it works:

```
nodes:
  configOverrides:
    nifi.properties:
      nifi.web.https.sni.required: "false"
      nifi.web.https.sni.host.check: "false"
```


## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [x] Add an entry to the CHANGELOG.md file

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
