### PR TITLE
build Hive 2

### DIFF
--- a/hive/stackable/patches/2.3.9/0001-Revert-HIVE-24608-Switch-back-to-get_table-in-HMS-cl.patch
+++ b/hive/stackable/patches/2.3.9/0001-Revert-HIVE-24608-Switch-back-to-get_table-in-HMS-cl.patch
@@ -1,0 +1,79 @@
+From b02129c9d83aab93915a59beea68a72f0e5937a1 Mon Sep 17 00:00:00 2001
+From: Razvan-Daniel Mihai <84674+razvan@users.noreply.github.com>
+Date: Fri, 29 Aug 2025 15:35:12 +0200
+Subject: Revert "HIVE-24608: Switch back to get_table in HMS client for Hive
+ 2.3.x (#2080)"
+
+This reverts commit c78ff81915ff3f54d3b1e7c3ce1f11a6fdf749b2.
+---
+ .../org/apache/hadoop/hive/conf/HiveConf.java     |  2 +-
+ .../hive/metastore/HiveMetaStoreClient.java       | 15 ++++++++++++---
+ 2 files changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+index 46a74305ee..412e7d0273 100644
+--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
++++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+@@ -601,7 +601,7 @@ public static enum ConfVars {
+     METASTOREURIS("hive.metastore.uris", "",
+         "Thrift URI for the remote metastore. Used by metastore client to connect to remote metastore."),
+ 
+-    METASTORE_CAPABILITY_CHECK("hive.metastore.client.capability.check", false,
++    METASTORE_CAPABILITY_CHECK("hive.metastore.client.capability.check", true,
+         "Whether to check client capabilities for potentially breaking API usage."),
+     METASTORE_FASTPATH("hive.metastore.fastpath", false,
+         "Used to avoid all of the proxies and object copies in the metastore.  Note, if this is " +
+diff --git a/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java b/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+index 53d97ff073..971a8a45df 100644
+--- a/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
++++ b/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+@@ -121,6 +121,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient {
+   // for thrift connects
+   private int retries = 5;
+   private long retryDelaySeconds = 0;
++  private final ClientCapabilities version;
+ 
+   static final protected Logger LOG = LoggerFactory.getLogger("hive.metastore");
+ 
+@@ -142,6 +143,7 @@ public HiveMetaStoreClient(HiveConf conf, HiveMetaHookLoader hookLoader, Boolean
+     } else {
+       this.conf = new HiveConf(conf);
+     }
++    version = HiveConf.getBoolVar(conf, ConfVars.HIVE_IN_TEST) ? TEST_VERSION : VERSION;
+     filterHook = loadFilterHooks();
+     fileMetadataBatchSize = HiveConf.getIntVar(
+         conf, HiveConf.ConfVars.METASTORE_BATCH_RETRIEVE_OBJECTS_MAX);
+@@ -1343,7 +1345,9 @@ public Partition getPartitionWithAuthInfo(String db_name, String tbl_name,
+   @Override
+   public Table getTable(String dbname, String name) throws MetaException,
+       TException, NoSuchObjectException {
+-    Table t = client.get_table(dbname, name);
++    GetTableRequest req = new GetTableRequest(dbname, name);
++    req.setCapabilities(version);
++    Table t = client.get_table_req(req).getTable();
+     return fastpath ? t : deepCopy(filterHook.filterTable(t));
+   }
+ 
+@@ -1360,7 +1364,10 @@ public Table getTable(String tableName) throws MetaException, TException,
+   @Override
+   public List<Table> getTableObjectsByName(String dbName, List<String> tableNames)
+       throws MetaException, InvalidOperationException, UnknownDBException, TException {
+-    List<Table> tabs = client.get_table_objects_by_name(dbName, tableNames);
++    GetTablesRequest req = new GetTablesRequest(dbName);
++    req.setTblNames(tableNames);
++    req.setCapabilities(version);
++    List<Table> tabs = client.get_table_objects_by_name_req(req).getTables();
+     return fastpath ? tabs : deepCopyTables(filterHook.filterTables(tabs));
+   }
+ 
+@@ -1452,7 +1459,9 @@ public List<String> getAllTables(String dbname) throws MetaException {
+   public boolean tableExists(String databaseName, String tableName) throws MetaException,
+       TException, UnknownDBException {
+     try {
+-      return filterHook.filterTable(client.get_table(databaseName, tableName)) != null;
++      GetTableRequest req = new GetTableRequest(databaseName, tableName);
++      req.setCapabilities(version);
++      return filterHook.filterTable(client.get_table_req(req).getTable()) != null;
+     } catch (NoSuchObjectException e) {
+       return false;
+     }

--- a/hive/stackable/patches/2.3.9/0002-remove-pentaho-dep.patch
+++ b/hive/stackable/patches/2.3.9/0002-remove-pentaho-dep.patch
@@ -1,0 +1,67 @@
+From 8691f45a499a40c82397f9afd27e06eda98f2ad5 Mon Sep 17 00:00:00 2001
+From: Razvan-Daniel Mihai <84674+razvan@users.noreply.github.com>
+Date: Mon, 1 Sep 2025 09:47:13 +0200
+Subject: remove pentaho dep
+
+---
+ pom.xml    | 10 +++++-----
+ ql/pom.xml |  4 ++--
+ 2 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/pom.xml b/pom.xml
+index 97443e73b9..414047bfd9 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -181,7 +181,7 @@
+     <mina.version>2.0.0-M5</mina.version>
+     <netty.version>4.0.52.Final</netty.version>
+     <parquet.version>1.8.1</parquet.version>
+-    <pentaho-aggdesigner.version>5.1.5-jhyde</pentaho-aggdesigner.version>
++    <!-- pentaho-aggdesigner.version>5.1.5-jhyde</pentaho-aggdesigner.version -->
+     <pig.version>0.16.0</pig.version>
+     <protobuf.version>2.5.0</protobuf.version>
+     <stax.version>1.0.1</stax.version>
+@@ -751,12 +751,12 @@
+         <artifactId>hadoop-minicluster</artifactId>
+         <version>${hadoop.version}</version>
+       </dependency>
+-      <dependency>
++<!--      <dependency>
+         <groupId>org.pentaho</groupId>
+         <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+         <version>${pentaho-aggdesigner.version}</version>
+       </dependency>
+-      <dependency>
++ -->     <dependency>
+         <groupId>org.scala-lang</groupId>
+         <artifactId>scala-library</artifactId>
+         <version>${scala.version}</version>
+@@ -809,8 +809,8 @@
+           <artifactId>maven-compiler-plugin</artifactId>
+           <version>${maven.compiler.plugin.version}</version>
+           <configuration>
+-            <source>1.7</source>
+-            <target>1.7</target>
++            <source>1.8</source>
++            <target>1.8</target>
+           </configuration>
+         </plugin>
+         <plugin>
+diff --git a/ql/pom.xml b/ql/pom.xml
+index 460cc225e1..2bb05e1411 100644
+--- a/ql/pom.xml
++++ b/ql/pom.xml
+@@ -708,11 +708,11 @@
+       <groupId>org.codehaus.janino</groupId>
+       <artifactId>janino</artifactId>
+     </dependency>
+-    <dependency>
++<!--    <dependency>
+       <groupId>org.pentaho</groupId>
+       <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+     </dependency>
+-  </dependencies>
++ --> </dependencies>
+ 
+   <profiles>
+     <profile>

--- a/hive/stackable/patches/2.3.9/patchable.toml
+++ b/hive/stackable/patches/2.3.9/patchable.toml
@@ -1,0 +1,2 @@
+base = "92dd0159f440ca7863be3232f3a683a510a62b9d"
+mirror = "https://github.com/stackabletech/hive.git"


### PR DESCRIPTION
# Description

Requires JDK 8.

```
$ mvn clean package -DskipTests -Dmaven.test.skip
...
[ERROR] Failed to execute goal on project hive-exec: Could not collect dependencies for project org.apache.hive:hive-exec:jar:2.3.9
[ERROR] Failed to read artifact descriptor for org.pentaho:pentaho-aggdesigner-algorithm:jar:5.1.5-jhyde
[ERROR]         Caused by: The following artifacts could not be resolved: org.pentaho:pentaho-aggdesigner-algorithm:pom:5.1.5-jhyde (absent): Could not transfer artifact org.pentaho:pentaho-aggdesigner-algorithm:pom:5.1.5-jhyde from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [conjars (http://conjars.org/repo, default, releases+snapshots), apache.snapshots (http://repository.apache.org/snapshots, default, snapshots), central (http://repo.maven.apache.org/maven2, default, releases)]
```
## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
