### PR TITLE
Fix NIFI-14858 patch

### DIFF
--- a/nifi/stackable/patches/2.4.0/0004-NIFI-14858-Make-SNI-checking-configurable.patch
+++ b/nifi/stackable/patches/2.4.0/0004-NIFI-14858-Make-SNI-checking-configurable.patch
@@ -1,11 +1,13 @@
-From 6f36be44f82a759fe7f4604839b5e528e5037fea Mon Sep 17 00:00:00 2001
+From d91597ab5d3410cb3955b1bad5a750a3b99f7126 Mon Sep 17 00:00:00 2001
 From: Lars Francke <git@lars-francke.de>
 Date: Wed, 13 Aug 2025 14:16:55 +0200
 Subject: NIFI-14858: Make SNI checking configurable
 
 Introduces two new properties:
-- nifi.web.https.sni.required
-- nifi.web.https.sni.host.check
+- nifi.web.https.sni.required (default: false)
+- nifi.web.https.sni.host.check (default: true)
+
+These defaults mean that SNI is not required (this is the current behavior already) but if SNI is provided then the host has to match.
 ---
  .../StandardServerConnectorFactory.java       | 24 +++++++++++++++++++
  .../org/apache/nifi/util/NiFiProperties.java  | 10 ++++++++
@@ -13,14 +15,14 @@ Introduces two new properties:
  3 files changed, 38 insertions(+)
 
 diff --git a/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/StandardServerConnectorFactory.java b/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/StandardServerConnectorFactory.java
-index 26d09706a1..37fda0929d 100644
+index 26d09706a1..132973cad5 100644
 --- a/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/StandardServerConnectorFactory.java
 +++ b/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/StandardServerConnectorFactory.java
 @@ -70,6 +70,10 @@ public class StandardServerConnectorFactory implements ServerConnectorFactory {
  
      private int requestHeaderSize = 8192;
  
-+    private boolean sniRequired = true;
++    private boolean sniRequired = false;
 +
 +    private boolean sniHostCheck = true;
 +
@@ -32,7 +34,7 @@ index 26d09706a1..37fda0929d 100644
      }
  
 +    /**
-+     * Set SNI Required controls whether SNI is required for TLS connections
++     * Set to true if a SNI certificate is required, else requests will be rejected with 400 response.
 +     *
 +     * @param sniRequired SNI Required status
 +     */
@@ -41,7 +43,7 @@ index 26d09706a1..37fda0929d 100644
 +    }
 +
 +    /**
-+     * Set SNI Host Check controls whether SNI host checking is enabled for TLS connections
++     * Set to true if the SNI Host name must match when there is an SNI certificate.
 +     *
 +     * @param sniHostCheck SNI Host Check status
 +     */


### PR DESCRIPTION
# Description

During my recent [PR](https://github.com/stackabletech/docker-images/pull/1225) to introduce overrides for SNI checking in NiFi I made a mistake with the defaults.

I mistakenly set `nifi.web.https.sni.required` to `true` but the current behavior in NiFi 2.4 is to set this to false.
This patch for the patch fixes this default behavior.