### PR TITLE
chore: Update issue templates pre 25.11.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/early-pre-release.md
+++ b/.github/ISSUE_TEMPLATE/early-pre-release.md
@@ -1,7 +1,7 @@
 ---
 name: Early Pre-Release Container Image Updates
 about: This template can be used to track the container image updates leading up to the next Stackable release
-title: "chore: Update Container Images for Stackable Release YY.M.X"
+title: "chore(tracking): Update major/minor|patch versions for YY.M.X"
 labels: ['epic']
 assignees: ''
 ---
@@ -12,7 +12,7 @@ assignees: ''
 -->
 
 <!-- Update this with the parent tracking issue for the release -->
-Part of stackabletech/issues#xxx.
+Part of <https://github.com/stackabletech/issues/issues/xxx>.
 
 > [!NOTE]
 > Update the product versions based on what has been decided upon in the _Product Spreadsheet[^1]_.

--- a/.github/ISSUE_TEMPLATE/update-base-java.md
+++ b/.github/ISSUE_TEMPLATE/update-base-java.md
@@ -4,14 +4,14 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(java-bases): Update container images ahead of Stackable Release YY.M.X
+  chore(java-bases): Update image for YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of #xxx.
+Part of <https://github.com/stackabletech/issues/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.
@@ -21,7 +21,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - Remove: `y.y.y`
 
 > [!TIP]
-> Please add the `scheduled-for/20XX-XX` label, and add to the [Stackable Engineering][1] project.
+> Please add the `scheduled-for/YY.M.X` label, and add to the [Stackable Engineering][1] project.
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 

--- a/.github/ISSUE_TEMPLATE/update-base-stackable.md
+++ b/.github/ISSUE_TEMPLATE/update-base-stackable.md
@@ -4,17 +4,17 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(stackable-base): Update container images ahead of Stackable Release YY.M.X
+  chore(stackable-base): Update image for YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of #xxx.
+Part of <https://github.com/stackabletech/issues/issues/xxx>.
 
 > [!TIP]
-> Please add the `scheduled-for/20XX-XX` label, and add to the [Stackable Engineering][1] project.
+> Please add the `scheduled-for/YY.M.X` label, and add to the [Stackable Engineering][1] project.
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 

--- a/.github/ISSUE_TEMPLATE/update-base-ubi-rust-builders.md
+++ b/.github/ISSUE_TEMPLATE/update-base-ubi-rust-builders.md
@@ -4,7 +4,7 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(ubi-rust-builders): Update container images ahead of Stackable Release YY.M.X
+  chore(ubi-rust-builders): Update image for YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']
@@ -17,7 +17,7 @@ developers need newer versions , which could be multiple times in a release.
 If there are no bumps in a release, we can still rely on SecObserve and Renovate
 to alert us to security vulnerabilities.
 -->
-Part of #xxx.
+Part of <https://github.com/stackabletech/issues/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.
@@ -27,7 +27,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - Remove: `y.y.y`
 
 > [!TIP]
-> Please add the `scheduled-for/20XX-XX` label, and add to the [Stackable Engineering][1] project.
+> Please add the `scheduled-for/YY.M.X` label, and add to the [Stackable Engineering][1] project.
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 

--- a/.github/ISSUE_TEMPLATE/update-base-vector.md
+++ b/.github/ISSUE_TEMPLATE/update-base-vector.md
@@ -4,14 +4,14 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(vector): Update container images ahead of Stackable Release YY.M.X
+  chore(vector): Update major/minor|patch versions for YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of #xxx.
+Part of <https://github.com/stackabletech/issues/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.
@@ -21,7 +21,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - Remove: `y.y.y`
 
 > [!TIP]
-> Please add the `scheduled-for/20XX-XX` label, and add to the [Stackable Engineering][1] project.
+> Please add the `scheduled-for/YY.M.X` label, and add to the [Stackable Engineering][1] project.
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 

--- a/.github/ISSUE_TEMPLATE/update-product-airflow.md
+++ b/.github/ISSUE_TEMPLATE/update-product-airflow.md
@@ -4,14 +4,14 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(airflow): Update container images ahead of Stackable Release YY.M.X
+  chore(airflow): Update major/minor|patch versions for YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of #xxx.
+Part of <https://github.com/stackabletech/issues/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.
@@ -21,7 +21,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - Remove: `y.y.y`
 
 > [!TIP]
-> Please add the `scheduled-for/20XX-XX` label, add to the [Stackable Engineering][1] project.
+> Please add the `scheduled-for/YY.M.X` label, add to the [Stackable Engineering][1] project.
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 

--- a/.github/ISSUE_TEMPLATE/update-product-druid.md
+++ b/.github/ISSUE_TEMPLATE/update-product-druid.md
@@ -4,14 +4,14 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(druid): Update container images ahead of Stackable Release YY.M.X
+  chore(druid): Update major/minor|patch versions for YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of #xxx.
+Part of <https://github.com/stackabletech/issues/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.
@@ -21,7 +21,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - Remove: `y.y.y`
 
 > [!TIP]
-> Please add the `scheduled-for/20XX-XX` label, and add to the [Stackable Engineering][1] project.
+> Please add the `scheduled-for/YY.M.X` label, and add to the [Stackable Engineering][1] project.
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 

--- a/.github/ISSUE_TEMPLATE/update-product-hbase-phoenix-omid.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hbase-phoenix-omid.md
@@ -4,14 +4,14 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(hbase-phoenix-omid): Update container images ahead of Stackable Release YY.M.X
+  chore(hbase-phoenix-omid): Update major/minor|patch versions for YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of #xxx.
+Part of <https://github.com/stackabletech/issues/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.
@@ -21,7 +21,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - Remove: `y.y.y`
 
 > [!TIP]
-> Please add the `scheduled-for/20XX-XX` label, and add to the [Stackable Engineering][1] project.
+> Please add the `scheduled-for/YY.M.X` label, and add to the [Stackable Engineering][1] project.
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 

--- a/.github/ISSUE_TEMPLATE/update-product-hdfs.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hdfs.md
@@ -4,14 +4,14 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(hdfs): Update container images ahead of Stackable Release YY.M.X
+  chore(hdfs): Update major/minor|patch versions for YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of #xxx.
+Part of <https://github.com/stackabletech/issues/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.
@@ -21,7 +21,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - Remove: `y.y.y`
 
 > [!TIP]
-> Please add the `scheduled-for/20XX-XX` label, and add to the [Stackable Engineering][1] project.
+> Please add the `scheduled-for/YY.M.X` label, and add to the [Stackable Engineering][1] project.
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 

--- a/.github/ISSUE_TEMPLATE/update-product-hive.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hive.md
@@ -4,14 +4,14 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(hive): Update container images ahead of Stackable Release YY.M.X
+  chore(hive): Update major/minor|patch versions for YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of #xxx.
+Part of <https://github.com/stackabletech/issues/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.
@@ -21,7 +21,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - Remove: `y.y.y`
 
 > [!TIP]
-> Please add the `scheduled-for/20XX-XX` label, and add to the [Stackable Engineering][1] project.
+> Please add the `scheduled-for/YY.M.X` label, and add to the [Stackable Engineering][1] project.
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 

--- a/.github/ISSUE_TEMPLATE/update-product-kafka.md
+++ b/.github/ISSUE_TEMPLATE/update-product-kafka.md
@@ -4,14 +4,14 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(kafka): Update container images ahead of Stackable Release YY.M.X
+  chore(kafka): Update major/minor|patch versions for YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of #xxx.
+Part of <https://github.com/stackabletech/issues/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.
@@ -21,7 +21,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - Remove: `y.y.y`
 
 > [!TIP]
-> Please add the `scheduled-for/20XX-XX` label, and add to the [Stackable Engineering][1] project.
+> Please add the `scheduled-for/YY.M.X` label, and add to the [Stackable Engineering][1] project.
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 

--- a/.github/ISSUE_TEMPLATE/update-product-nifi.md
+++ b/.github/ISSUE_TEMPLATE/update-product-nifi.md
@@ -4,14 +4,14 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(nifi): Update container images ahead of Stackable Release YY.M.X
+  chore(nifi): Update major/minor|patch versions for YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of #xxx.
+Part of <https://github.com/stackabletech/issues/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.
@@ -21,7 +21,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - Remove: `y.y.y`
 
 > [!TIP]
-> Please add the `scheduled-for/20XX-XX` label, and add to the [Stackable Engineering][1] project.
+> Please add the `scheduled-for/YY.M.X` label, and add to the [Stackable Engineering][1] project.
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 

--- a/.github/ISSUE_TEMPLATE/update-product-opa.md
+++ b/.github/ISSUE_TEMPLATE/update-product-opa.md
@@ -4,14 +4,14 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(opa): Update container images ahead of Stackable Release YY.M.X
+  chore(opa): Update major/minor|patch versions for YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of #xxx.
+Part of <https://github.com/stackabletech/issues/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.
@@ -21,7 +21,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - Remove: `y.y.y`
 
 > [!TIP]
-> Please add the `scheduled-for/20XX-XX` label, and add to the [Stackable Engineering][1] project.
+> Please add the `scheduled-for/YY.M.X` label, and add to the [Stackable Engineering][1] project.
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 

--- a/.github/ISSUE_TEMPLATE/update-product-opensearch.md
+++ b/.github/ISSUE_TEMPLATE/update-product-opensearch.md
@@ -4,14 +4,14 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(opensearch): Update container images ahead of Stackable Release YY.M.X
+  chore(opensearch): Update major/minor|patch versions for YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of #xxx.
+Part of <https://github.com/stackabletech/issues/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.
@@ -21,7 +21,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - Remove: `y.y.y`
 
 > [!TIP]
-> Please add the `scheduled-for/20XX-XX` label, and add to the [Stackable Engineering][1] project.
+> Please add the `scheduled-for/YY.M.X` label, and add to the [Stackable Engineering][1] project.
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 

--- a/.github/ISSUE_TEMPLATE/update-product-spark.md
+++ b/.github/ISSUE_TEMPLATE/update-product-spark.md
@@ -4,14 +4,14 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(spark): Update container images ahead of Stackable Release YY.M.X
+  chore(spark): Update major/minor|patch versions for YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of #xxx.
+Part of <https://github.com/stackabletech/issues/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.
@@ -21,7 +21,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - Remove: `y.y.y`
 
 > [!TIP]
-> Please add the `scheduled-for/20XX-XX` label, and add to the [Stackable Engineering][1] project.
+> Please add the `scheduled-for/YY.M.X` label, and add to the [Stackable Engineering][1] project.
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 

--- a/.github/ISSUE_TEMPLATE/update-product-superset.md
+++ b/.github/ISSUE_TEMPLATE/update-product-superset.md
@@ -4,14 +4,14 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(superset): Update container images ahead of Stackable Release YY.M.X
+  chore(superset): Update major/minor|patch versions for YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of #xxx.
+Part of <https://github.com/stackabletech/issues/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.
@@ -21,7 +21,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - Remove: `y.y.y`
 
 > [!TIP]
-> Please add the `scheduled-for/20XX-XX` label, and add to the [Stackable Engineering][1] project.
+> Please add the `scheduled-for/YY.M.X` label, and add to the [Stackable Engineering][1] project.
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 

--- a/.github/ISSUE_TEMPLATE/update-product-trino.md
+++ b/.github/ISSUE_TEMPLATE/update-product-trino.md
@@ -4,14 +4,14 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(trino): Update container images ahead of Stackable Release YY.M.X
+  chore(trino): Update major/minor|patch versions for YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of #xxx.
+Part of <https://github.com/stackabletech/issues/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.
@@ -21,7 +21,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - Remove: `y.y.y`
 
 > [!TIP]
-> Please add the `scheduled-for/20XX-XX` label, and add to the [Stackable Engineering][1] project.
+> Please add the `scheduled-for/YY.M.X` label, and add to the [Stackable Engineering][1] project.
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 

--- a/.github/ISSUE_TEMPLATE/update-product-zookeeper.md
+++ b/.github/ISSUE_TEMPLATE/update-product-zookeeper.md
@@ -4,14 +4,14 @@ about: >-
   This template contains instructions specific to updating this product and/or
   container image(s).
 title: >-
-  chore(zookeeper): Update container images ahead of Stackable Release YY.M.X
+  chore(zookeeper): Update major/minor|patch versions for YY.M.X
 labels: []
 # Currently, projects cannot be assigned via front-matter.
 projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of #xxx.
+Part of <https://github.com/stackabletech/issues/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.
@@ -21,7 +21,7 @@ Add/Change/Remove anything that isn't applicable anymore
 - Remove: `y.y.y`
 
 > [!TIP]
-> Please add the `scheduled-for/20XX-XX` label, and add to the [Stackable Engineering][1] project.
+> Please add the `scheduled-for/YY.M.X` label, and add to the [Stackable Engineering][1] project.
 >
 > [1]: https://github.com/orgs/stackabletech/projects/10
 


### PR DESCRIPTION
This PR slightly tweaks the issue templates while using them for the upcoming SDP 25.11.0 release.