### PR TITLE
fix(hadoop): Upgrade nimbus-jose-jwt in Hadoop 3.4.1 to fix CVE-2025-53864

### DIFF
--- a/hadoop/hadoop/stackable/patches/3.4.1/0011-HADOOP-18583.-Fix-loading-of-OpenSSL-3.x-symbols-525.patch
+++ b/hadoop/hadoop/stackable/patches/3.4.1/0011-HADOOP-18583.-Fix-loading-of-OpenSSL-3.x-symbols-525.patch
@@ -1,7 +1,7 @@
-From cd1c23ea5bddd2796caf2590fef467e488c3bcbf Mon Sep 17 00:00:00 2001
+From 932464d9fbf23f9042fee2f8b4be6029174d2ca4 Mon Sep 17 00:00:00 2001
 From: Sebastian Klemke <3669903+packet23@users.noreply.github.com>
 Date: Thu, 7 Nov 2024 19:14:13 +0100
-Subject: HADOOP-18583. Fix loading of OpenSSL 3.x symbols  (#5256) (#7149)
+Subject: HADOOP-18583. Fix loading of OpenSSL 3.x symbols (#5256) (#7149)
 
 Contributed by Sebastian Klemke
 ---

--- a/hadoop/hadoop/stackable/patches/3.4.1/0012-Upgrade-nimbus-jose-jwt-to-9.37.4-to-fix-CVE-2025-53.patch
+++ b/hadoop/hadoop/stackable/patches/3.4.1/0012-Upgrade-nimbus-jose-jwt-to-9.37.4-to-fix-CVE-2025-53.patch
@@ -1,0 +1,36 @@
+From d2e87ede0e3a4c6fa600de7d7f51fb4134fa0438 Mon Sep 17 00:00:00 2001
+From: xeniape <xenia.fischer@stackable.tech>
+Date: Wed, 10 Sep 2025 12:51:47 +0200
+Subject: Upgrade nimbus-jose-jwt to 9.37.4 to fix CVE-2025-53864
+
+---
+ LICENSE-binary         | 2 +-
+ hadoop-project/pom.xml | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/LICENSE-binary b/LICENSE-binary
+index 90da3d032b..fdcb5c0a1f 100644
+--- a/LICENSE-binary
++++ b/LICENSE-binary
+@@ -240,7 +240,7 @@ com.google.guava:guava:20.0
+ com.google.guava:guava:32.0.1-jre
+ com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+ com.microsoft.azure:azure-storage:7.0.0
+-com.nimbusds:nimbus-jose-jwt:9.37.2
++com.nimbusds:nimbus-jose-jwt:9.37.4
+ com.zaxxer:HikariCP:4.0.3
+ commons-beanutils:commons-beanutils:1.9.4
+ commons-cli:commons-cli:1.5.0
+diff --git a/hadoop-project/pom.xml b/hadoop-project/pom.xml
+index 155cdf9841..e23f524224 100644
+--- a/hadoop-project/pom.xml
++++ b/hadoop-project/pom.xml
+@@ -216,7 +216,7 @@
+     <openssl-wildfly.version>1.1.3.Final</openssl-wildfly.version>
+     <jsonschema2pojo.version>1.0.2</jsonschema2pojo.version>
+     <woodstox.version>5.4.0</woodstox.version>
+-    <nimbus-jose-jwt.version>9.37.2</nimbus-jose-jwt.version>
++    <nimbus-jose-jwt.version>9.37.4</nimbus-jose-jwt.version>
+     <nodejs.version>v14.17.0</nodejs.version>
+     <yarnpkg.version>v1.22.5</yarnpkg.version>
+     <apache-ant.version>1.10.13</apache-ant.version>


### PR DESCRIPTION
# Description

This PR upgrades the `nimbus-jose-jwt` dependency to 9.37.4 in Hadoop to fix CVE-2025-53864.
Similar to https://www.github.com/apache/hadoop/pull/7870

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
bake --product <product> --image-version <stackable-image-version>
kind load docker-image <image-tagged-with-the-major-version> --name=<name-of-your-test-cluster>
```

See the output of `bake` to retrieve the image tag for `<image-tagged-with-the-major-version>`.
</details>
