### PR TITLE
ci: Adjust send-slack-notification action inputs

### DIFF
--- a/.github/workflows/reusable_build_image.yaml
+++ b/.github/workflows/reusable_build_image.yaml
@@ -111,3 +111,5 @@ jobs:
           publish-manifests-result: ${{ needs.publish_manifests.result }}
           build-result: ${{ needs.build.result }}
           slack-token: ${{ secrets.slack-token }}
+          channel-id: C07UG6JH44F # notifications-container-images
+          type: container-image-build


### PR DESCRIPTION
The send-slack-notification now requires both the `type` and `channel-id` inputs.