### PR TITLE
feat(boil): Add support for Nushell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "clap_complete",
+ "clap_complete_nushell",
  "git2",
  "glob",
  "oci-spec",
@@ -182,6 +183,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5abde44486daf70c5be8b8f8f1b66c49f86236edf6fa2abadb4d961c4c6229a"
 dependencies = [
  "clap",
+]
+
+[[package]]
+name = "clap_complete_nushell"
+version = "4.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a0c951694691e65bf9d421d597d68416c22de9632e884c28412cb8cd8b73dce"
+dependencies = [
+ "clap",
+ "clap_complete",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 [workspace.dependencies]
 clap = { version = "4.5.41", features = ["derive"] }
 clap_complete = "4.5.55"
+clap_complete_nushell = "4.5.8"
 git2 = "0.20.1"
 glob = "0.3.2"
 oci-spec = "0.8.2"

--- a/rust/boil/Cargo.toml
+++ b/rust/boil/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 [dependencies]
 clap.workspace = true
 clap_complete.workspace = true
+clap_complete_nushell.workspace = true
 git2.workspace = true
 glob.workspace = true
 oci-spec.workspace = true

--- a/rust/boil/src/completions/mod.rs
+++ b/rust/boil/src/completions/mod.rs
@@ -1,12 +1,35 @@
-use clap::{Args, CommandFactory};
-use clap_complete::Shell;
+use clap::{Args, Command, CommandFactory, ValueEnum};
+use clap_complete::{
+    Generator,
+    Shell::{Bash, Elvish, Fish, Zsh},
+};
+use clap_complete_nushell::Nushell;
 
 use crate::cli::Cli;
 
 #[derive(Debug, Args)]
 pub struct CompletionsArguments {
     /// Shell to generate completions for.
+    #[arg(value_enum)]
     pub shell: Shell,
+}
+
+#[derive(Clone, Debug, ValueEnum)]
+pub enum Shell {
+    /// Bourne Again SHell
+    Bash,
+
+    /// Elvish shell
+    Elvish,
+
+    /// Friendly Interactive SHell
+    Fish,
+
+    /// Z SHell
+    Zsh,
+
+    /// Nushell
+    Nushell,
 }
 
 /// This is the `boil completions` command handler function.
@@ -14,5 +37,15 @@ pub fn run_command(arguments: CompletionsArguments) {
     let mut cli = Cli::command();
     let bin_name = cli.get_bin_name().unwrap_or("boil").to_owned();
 
-    clap_complete::generate(arguments.shell, &mut cli, bin_name, &mut std::io::stdout());
+    match arguments.shell {
+        Shell::Bash => generate(Bash, &mut cli, bin_name),
+        Shell::Elvish => generate(Elvish, &mut cli, bin_name),
+        Shell::Fish => generate(Fish, &mut cli, bin_name),
+        Shell::Zsh => generate(Zsh, &mut cli, bin_name),
+        Shell::Nushell => generate(Nushell, &mut cli, bin_name),
+    }
+}
+
+fn generate(generator: impl Generator, cli: &mut Command, bin_name: String) {
+    clap_complete::generate(generator, cli, bin_name, &mut std::io::stdout());
 }


### PR DESCRIPTION
This PR adds support for Nushell completions to `boil` because they were also available in `bake`.