### PR TITLE
chore(issue_templates): Improve issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/early-pre-release.md
+++ b/.github/ISSUE_TEMPLATE/early-pre-release.md
@@ -16,11 +16,21 @@ Part of <https://github.com/stackabletech/issues/issues/xxx>.
 
 > [!NOTE]
 > Update the product versions based on what has been decided upon in the _Product Spreadsheet[^1]_.
+> Follow these rules when creating the tracking for individual images:
+>
+> - Major/minor changes:
+>   - Removal and deprecation of entire major or minor version branches
+>   - Adding a new major/minor version (optionally marking it as LTS)
+> - Patch-level changes:
+>   - Removal and deprecation if individual patch-level versions
+>   - Marking a (new) patch-level version as LTS
+>   - Adding a new patch-level version
 
 [^1]: Currently this is a private spreadsheet
 
 > [!IMPORTANT]
 > Replace the items in the task lists below with the subsequent tracking issue.
+> Remove this and the above admonitions afterwards to de-clutter the tracking issue.
 
 ## Product Container Images
 

--- a/.github/ISSUE_TEMPLATE/update-base-java.md
+++ b/.github/ISSUE_TEMPLATE/update-base-java.md
@@ -11,7 +11,7 @@ projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of <https://github.com/stackabletech/issues/issues/xxx>.
+Part of <https://github.com/stackabletech/docker-images/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.

--- a/.github/ISSUE_TEMPLATE/update-base-stackable.md
+++ b/.github/ISSUE_TEMPLATE/update-base-stackable.md
@@ -11,7 +11,7 @@ projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of <https://github.com/stackabletech/issues/issues/xxx>.
+Part of <https://github.com/stackabletech/docker-images/issues/xxx>.
 
 > [!TIP]
 > Please add the `scheduled-for/YY.M.X` label, and add to the [Stackable Engineering][1] project.

--- a/.github/ISSUE_TEMPLATE/update-base-ubi-rust-builders.md
+++ b/.github/ISSUE_TEMPLATE/update-base-ubi-rust-builders.md
@@ -17,7 +17,7 @@ developers need newer versions , which could be multiple times in a release.
 If there are no bumps in a release, we can still rely on SecObserve and Renovate
 to alert us to security vulnerabilities.
 -->
-Part of <https://github.com/stackabletech/issues/issues/xxx>.
+Part of <https://github.com/stackabletech/docker-images/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.

--- a/.github/ISSUE_TEMPLATE/update-base-vector.md
+++ b/.github/ISSUE_TEMPLATE/update-base-vector.md
@@ -11,7 +11,7 @@ projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of <https://github.com/stackabletech/issues/issues/xxx>.
+Part of <https://github.com/stackabletech/docker-images/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.

--- a/.github/ISSUE_TEMPLATE/update-product-airflow.md
+++ b/.github/ISSUE_TEMPLATE/update-product-airflow.md
@@ -11,7 +11,7 @@ projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of <https://github.com/stackabletech/issues/issues/xxx>.
+Part of <https://github.com/stackabletech/docker-images/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.

--- a/.github/ISSUE_TEMPLATE/update-product-druid.md
+++ b/.github/ISSUE_TEMPLATE/update-product-druid.md
@@ -11,7 +11,7 @@ projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of <https://github.com/stackabletech/issues/issues/xxx>.
+Part of <https://github.com/stackabletech/docker-images/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.

--- a/.github/ISSUE_TEMPLATE/update-product-hbase-phoenix-omid.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hbase-phoenix-omid.md
@@ -11,7 +11,7 @@ projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of <https://github.com/stackabletech/issues/issues/xxx>.
+Part of <https://github.com/stackabletech/docker-images/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.

--- a/.github/ISSUE_TEMPLATE/update-product-hdfs.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hdfs.md
@@ -11,7 +11,7 @@ projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of <https://github.com/stackabletech/issues/issues/xxx>.
+Part of <https://github.com/stackabletech/docker-images/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.

--- a/.github/ISSUE_TEMPLATE/update-product-hive.md
+++ b/.github/ISSUE_TEMPLATE/update-product-hive.md
@@ -11,7 +11,7 @@ projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of <https://github.com/stackabletech/issues/issues/xxx>.
+Part of <https://github.com/stackabletech/docker-images/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.

--- a/.github/ISSUE_TEMPLATE/update-product-kafka.md
+++ b/.github/ISSUE_TEMPLATE/update-product-kafka.md
@@ -11,7 +11,7 @@ projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of <https://github.com/stackabletech/issues/issues/xxx>.
+Part of <https://github.com/stackabletech/docker-images/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.

--- a/.github/ISSUE_TEMPLATE/update-product-nifi.md
+++ b/.github/ISSUE_TEMPLATE/update-product-nifi.md
@@ -11,7 +11,7 @@ projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of <https://github.com/stackabletech/issues/issues/xxx>.
+Part of <https://github.com/stackabletech/docker-images/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.

--- a/.github/ISSUE_TEMPLATE/update-product-opa.md
+++ b/.github/ISSUE_TEMPLATE/update-product-opa.md
@@ -11,7 +11,7 @@ projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of <https://github.com/stackabletech/issues/issues/xxx>.
+Part of <https://github.com/stackabletech/docker-images/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.

--- a/.github/ISSUE_TEMPLATE/update-product-opensearch.md
+++ b/.github/ISSUE_TEMPLATE/update-product-opensearch.md
@@ -11,7 +11,7 @@ projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of <https://github.com/stackabletech/issues/issues/xxx>.
+Part of <https://github.com/stackabletech/docker-images/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.

--- a/.github/ISSUE_TEMPLATE/update-product-spark.md
+++ b/.github/ISSUE_TEMPLATE/update-product-spark.md
@@ -11,7 +11,7 @@ projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of <https://github.com/stackabletech/issues/issues/xxx>.
+Part of <https://github.com/stackabletech/docker-images/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.

--- a/.github/ISSUE_TEMPLATE/update-product-superset.md
+++ b/.github/ISSUE_TEMPLATE/update-product-superset.md
@@ -11,7 +11,7 @@ projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of <https://github.com/stackabletech/issues/issues/xxx>.
+Part of <https://github.com/stackabletech/docker-images/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.

--- a/.github/ISSUE_TEMPLATE/update-product-trino.md
+++ b/.github/ISSUE_TEMPLATE/update-product-trino.md
@@ -11,7 +11,7 @@ projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of <https://github.com/stackabletech/issues/issues/xxx>.
+Part of <https://github.com/stackabletech/docker-images/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.

--- a/.github/ISSUE_TEMPLATE/update-product-zookeeper.md
+++ b/.github/ISSUE_TEMPLATE/update-product-zookeeper.md
@@ -11,7 +11,7 @@ projects: ['stackabletech/10']
 assignees: ''
 ---
 
-Part of <https://github.com/stackabletech/issues/issues/xxx>.
+Part of <https://github.com/stackabletech/docker-images/issues/xxx>.
 
 <!--
 This gives hints to the person doing the work.


### PR DESCRIPTION
This PR:

- Clarifies how the major/minor vs patch tracking issues are created.
- Updates the link in image tracking issues to point to the `docker-images` repo.