### PR TITLE
chore(opa): Update image for 25.11.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/update-product-opa.md
+++ b/.github/ISSUE_TEMPLATE/update-product-opa.md
@@ -28,8 +28,8 @@ Add/Change/Remove anything that isn't applicable anymore
 ## Update tasks
 
 - [ ] Update `boil-config.toml` to reflect the agreed upon versions in the spreadsheet (including the removal of old versions).
-- [ ] Upload new version (see `opa/upload_new_opa_version.sh`).
-- [ ] Update other dependencies if applicable (eg: opa_bundle_builder, etc).
+- [ ] Update other dependencies if applicable (eg: golang-version, etc).
+- [ ] Check the corresponding operator (getting_started / kuttl / supported-versions) for usage of the versions.
 - [ ] Check other operators (getting_started / kuttl / supported-versions) for usage of the versions. Add the PR(s) to the list below.
 - [ ] Update the version in demos. Add the PR(s) to the list below.
 

--- a/opa/boil-config.toml
+++ b/opa/boil-config.toml
@@ -1,15 +1,15 @@
+# Version 1.8.0
+[versions."1.8.0".local-images]
+stackable-devel = "1.0.0"
+vector = "0.49.0"
+
+[versions."1.8.0".build-arguments]
+golang-version = "1.24.6"
+
 # Version 1.4.2
 [versions."1.4.2".local-images]
 stackable-devel = "1.0.0"
 vector = "0.49.0"
 
 [versions."1.4.2".build-arguments]
-golang-version = "1.23.9"
-
-# Version 1.0.1
-[versions."1.0.1".local-images]
-stackable-devel = "1.0.0"
-vector = "0.49.0"
-
-[versions."1.0.1".build-arguments]
 golang-version = "1.23.9"

--- a/opa/stackable/patches/1.8.0/patchable.toml
+++ b/opa/stackable/patches/1.8.0/patchable.toml
@@ -1,2 +1,2 @@
 mirror = "https://github.com/stackabletech/opa.git"
-base = "a5afc5ab5074ae6b17fd0b167ff3d5053303a58c"
+base = "78328267fb3fa8aef7d73894ccce05302723daa0"


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/docker-images/issues/1238

```
--- PASS: kuttl (63.04s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_opa-1.8.0_openshift-false (63.02s)
PASS
```

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
