### PR TITLE
feat(boil): Add support for port in registry host

### DIFF
--- a/rust/boil/src/build/bakefile.rs
+++ b/rust/boil/src/build/bakefile.rs
@@ -14,12 +14,11 @@ use semver::Version;
 use serde::Serialize;
 use snafu::{OptionExt, ResultExt, Snafu};
 use time::format_description::well_known::Rfc3339;
-use url::Host;
 
 use crate::{
     VersionExt,
     build::{
-        cli,
+        cli::{self, HostPort},
         docker::{BuildArgument, BuildArguments, LABEL_BUILD_DATE, ParseBuildArgumentsError},
         image::{Image, ImageConfig, ImageConfigError, ImageOptions, VersionOptionsPair},
         platform::TargetPlatform,
@@ -311,7 +310,7 @@ impl Bakefile {
 
                 // The image registry, eg. `oci.stackable.tech` or `localhost`
                 let image_registry = if args.use_localhost_registry {
-                    &Host::Domain(String::from("localhost"))
+                    &HostPort::localhost()
                 } else {
                     &args.registry
                 };

--- a/rust/boil/src/build/cli.rs
+++ b/rust/boil/src/build/cli.rs
@@ -188,14 +188,14 @@ impl FromStr for HostPort {
 
         let parts: Vec<_> = input.split(':').collect();
 
-        match parts.len() {
-            1 => {
-                let host = Host::parse(parts[0]).context(InvalidHostSnafu)?;
+        match parts[..] {
+            [host] => {
+                let host = Host::parse(host).context(InvalidHostSnafu)?;
                 Ok(Self { host, port: None })
             }
-            2 => {
-                let host = Host::parse(parts[0]).context(InvalidHostSnafu)?;
-                let port = u16::from_str(parts[1]).context(InvalidPortSnafu)?;
+            [host, port] => {
+                let host = Host::parse(host).context(InvalidHostSnafu)?;
+                let port = u16::from_str(port).context(InvalidPortSnafu)?;
 
                 Ok(Self {
                     host,
@@ -238,7 +238,7 @@ mod tests {
 
     #[rstest]
     // We use None here, because ParseIntErrors cannot be constructed outside of std. As such, it is
-    // impossoble to fully qualify the error we expect in cases where port parsing fails.
+    // impossible to fully qualify the error we expect in cases where port parsing fails.
     #[case("localhost:65536", None)]
     #[case("localhost:", None)]
     #[case("with space:", Some(ParseHostPortError::InvalidHost { source: ParseError::IdnaError }))]

--- a/rust/boil/src/utils.rs
+++ b/rust/boil/src/utils.rs
@@ -1,13 +1,12 @@
 use std::process::Command;
 
 use semver::Version;
-use url::Host;
 
-use crate::build::platform::Architecture;
+use crate::build::{cli::HostPort, platform::Architecture};
 
 /// Formats and returns the image repository URI, eg. `oci.stackable.tech/sdp/opa`.
 pub fn format_image_repository_uri(
-    image_registry: &Host,
+    image_registry: &HostPort,
     registry_namespace: &str,
     image_name: &str,
 ) -> String {


### PR DESCRIPTION
@siegfriedweber recently found out that it is currently not possible to specify a port for the registry host. This PR adds support for this.

Tested with

```shell
cargo boil build opa=1.4.2 --registry localhost:8080
# ...
Successfully built 1 image:
localhost:8080/sdp/opa:1.4.2-stackable0.0.0-dev-amd64
```