### PR TITLE
ci(boil): Improve and split workflows

### DIFF
--- a/.github/workflows/boil_pr.yaml
+++ b/.github/workflows/boil_pr.yaml
@@ -1,0 +1,65 @@
+---
+name: Build boil
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/boil_pr.yaml"
+      - "rust-toolchain.toml"
+      - "rust/boil/**.rs"
+      - "Cargo.*"
+
+env:
+  RUST_VERSION: 1.87.0
+
+jobs:
+  # This job is always run to ensure we don't miss any new upstream advisories
+  cargo-deny:
+    name: Run cargo-deny
+    runs-on: ubuntu-latest
+    # Prevent sudden announcement of a new advisory from failing CI
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Run cargo-deny
+        uses: EmbarkStudios/cargo-deny-action@f2ba7abc2abebaf185c833c3961145a3c275caad # v2.0.13
+        with:
+          command: check ${{ matrix.checks }}
+
+  build:
+    name: Build boil
+    needs:
+      - cargo-deny
+    strategy:
+      fail-fast: false
+      matrix:
+        targets:
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-24.04-arm }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
+          - { target: aarch64-apple-darwin, os: macos-latest }
+    runs-on: ${{ matrix.targets.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          targets: ${{ matrix.targets.target }}
+
+      - name: Build Binary
+        env:
+          TARGET: ${{ matrix.targets.target }}
+        run: cargo build --target "$TARGET" --package boil

--- a/.github/workflows/boil_release.yaml
+++ b/.github/workflows/boil_release.yaml
@@ -1,13 +1,7 @@
 ---
-name: Build/Release boil
+name: Release boil
 
 on:
-  pull_request:
-    paths:
-      - '.github/workflows/boil_build_release.yaml'
-      - 'rust-toolchain.toml'
-      - 'Cargo.*'
-      - '**.rs'
   push:
     tags:
       - "boil-[0-9]+.[0-9]+.[0-9]+**"
@@ -16,34 +10,8 @@ env:
   RUST_VERSION: 1.87.0
 
 jobs:
-  # This job is always run to ensure we don't miss any new upstream advisories
-  cargo-deny:
-    name: Run cargo-deny
-    runs-on: ubuntu-latest
-    # Prevent sudden announcement of a new advisory from failing CI
-    continue-on-error: ${{ matrix.checks == 'advisories' }}
-    strategy:
-      matrix:
-        checks:
-          - advisories
-          - bans licenses sources
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          persist-credentials: false
-          submodules: recursive
-
-      - name: Run cargo-deny
-        uses: EmbarkStudios/cargo-deny-action@f2ba7abc2abebaf185c833c3961145a3c275caad # v2.0.13
-        with:
-          command: check ${{ matrix.checks }}
-
   create-release:
     name: Create Draft Release
-    if: github.event_name == 'push'
-    needs:
-      - cargo-deny
     runs-on: ubuntu-latest
     steps:
       - name: Create Draft Release
@@ -54,14 +22,14 @@ jobs:
   build:
     name: Build boil
     needs:
-      - cargo-deny
+      - create-release
     strategy:
       fail-fast: false
       matrix:
         targets:
-          - {target: aarch64-unknown-linux-gnu, os: ubuntu-24.04-arm}
-          - {target: x86_64-unknown-linux-gnu, os: ubuntu-latest}
-          - {target: aarch64-apple-darwin, os: macos-latest}
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-24.04-arm }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
+          - { target: aarch64-apple-darwin, os: macos-latest }
     runs-on: ${{ matrix.targets.os }}
     steps:
       - name: Checkout
@@ -85,7 +53,6 @@ jobs:
         run: mv "target/$TARGET/release/boil" "boil-$TARGET"
 
       - name: Upload Artifact to Release
-        if: github.event_name == 'push'
         uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
         with:
           draft: false

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -11,3 +11,6 @@ rules:
   comments:
     min-spaces-from-content: 1  # Needed due to https://github.com/adrienverge/yamllint/issues/443
   indentation: disable
+  braces:
+    max-spaces-inside: 1
+    max-spaces-inside-empty: 0


### PR DESCRIPTION
This PR clearly separates the PR and release workflows for `boil`. This is done because previously, the cargo-deny checks could have failed the release workflow (which is triggered by a Git tag). This would result in the need to move Git tags, which should be avoided in all circumstances.