### PR TITLE
chore(testing-tools): Update image for 25.11.0

### DIFF
--- a/.scripts/upload_new_keycloak_version.sh
+++ b/.scripts/upload_new_keycloak_version.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+VERSION=${1:?"Missing version number argument (arg 1)"}
+NEXUS_USER=${2:?"Missing Nexus username argument (arg 2)"}
+
+read -r -s -p "Nexus Password: " NEXUS_PASSWORD
+echo ""
+
+# https://stackoverflow.com/questions/4632028/how-to-create-a-temporary-directory
+# Find the directory name of the script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# the temp directory used, within $DIR
+WORK_DIR=$(mktemp -d -p "$DIR")
+
+# check if tmp dir was created
+if [[ ! "$WORK_DIR" || ! -d "$WORK_DIR" ]]; then
+  echo "Could not create temp dir"
+  exit 1
+fi
+
+# deletes the temp directory
+function cleanup {
+  rm -rf "$WORK_DIR"
+}
+
+# register the cleanup function to be called on the EXIT signal
+trap cleanup EXIT
+
+cd "$WORK_DIR" || exit
+
+file=keycloak-$VERSION.tar.gz
+
+echo "Downloading $file from github.com"
+curl --fail -LO --progress-bar "https://github.com/keycloak/keycloak/releases/download/$VERSION/$file"
+
+echo "Uploading $file to Nexus"
+curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" \
+    --upload-file "$file" \
+    'https://repo.stackable.tech/repository/packages/keycloak/'
+
+echo "Successfully uploaded new version $VERSION to Nexus"
+echo "https://repo.stackable.tech/service/rest/repository/browse/packages/keycloak/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - superset: Add `4.1.4`  ([#1284]).
 - spark: Add `4.0.1` ([#1286]).
 - spark-connect-client: Add `4.0.1` ([#1286]).
+- testing-tools: Add `upload_new_keycloak_version.sh` script ([#1289]).
 
 ### Changed
 
@@ -35,6 +36,7 @@ All notable changes to this project will be documented in this file.
 - airflow: Bump uvicorn dependency to `0.37.0` ([#1264]).
 - druid: Deprecate `33.0.0` ([#1263]).
 - opa: Deprecate `1.4.2` ([#1279]).
+- testing-tools: Update keycloak dependency to `26.3.5` and `python:3.12-slim-bullseye` base image ([#1289]).
 
 ### Removed
 
@@ -71,6 +73,7 @@ All notable changes to this project will be documented in this file.
 [#1280]: https://github.com/stackabletech/docker-images/pull/1280
 [#1284]: https://github.com/stackabletech/docker-images/pull/1284
 [#1286]: https://github.com/stackabletech/docker-images/pull/1286
+[#1289]: https://github.com/stackabletech/docker-images/pull/1289
 
 ## [25.7.0] - 2025-07-23
 

--- a/testing-tools/Dockerfile
+++ b/testing-tools/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/_/python/tags
 # In Docker Hub, open up the tag and look for Index Digest. Otherwise do:
 # docker pull python:3.12-slim-bullseye and see the digest that appears in the output.
-FROM python:3.12-slim-bullseye@sha256:f6d639b794b394cbeb7a9327d5af9976f0e8d61353bcf41916984775c9bbed1a
+FROM python:3.12-slim-bullseye@sha256:411fa4dcfdce7e7a3057c45662beba9dcd4fa36b2e50a2bfcd6c9333e59bf0db
 
 ARG PRODUCT_VERSION
 ARG RELEASE_VERSION

--- a/testing-tools/README.md
+++ b/testing-tools/README.md
@@ -1,4 +1,4 @@
 # Stackable testing tools image
 
-* Based on debian/python 3.11 unlike `tools` which is based on UBI9 with python 3.9.
+* Based on debian/python 3.12 unlike `tools` which is based on UBI9 with python 3.9.
 * Comes with Python packages needed by the kuttl tests.

--- a/testing-tools/boil-config.toml
+++ b/testing-tools/boil-config.toml
@@ -1,2 +1,2 @@
 [versions."0.2.0".build-arguments]
-keycloak-version = "23.0.0"
+keycloak-version = "26.3.5"


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/docker-images/issues/1232

### Integrationtests

Ran tests with `hdfs-operator` integrationtests and `opa-operator` integrationtest using `testing-tools`

```
--- PASS: kuttl (3574.94s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.1_zookeeper-3.9.3_zookeeper-latest-3.9.3_number-of-datanodes-2_datanode-pvcs-default_listener-class-external-unstable_openshift-false (267.23s)
        --- PASS: kuttl/harness/topology-provider_hadoop-latest-3.4.1_zookeeper-latest-3.9.3_krb5-1.21.1_kerberos-backend-mit_openshift-false (405.85s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.1_zookeeper-3.9.3_zookeeper-latest-3.9.3_number-of-datanodes-1_datanode-pvcs-default_listener-class-external-unstable_openshift-false (194.53s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.1_zookeeper-3.9.3_zookeeper-latest-3.9.3_number-of-datanodes-2_datanode-pvcs-default_listener-class-cluster-internal_openshift-false (235.83s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.1_zookeeper-3.9.3_zookeeper-latest-3.9.3_number-of-datanodes-2_datanode-pvcs-2hdd-1ssd_listener-class-external-unstable_openshift-false (236.09s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.1_zookeeper-3.9.3_zookeeper-latest-3.9.3_number-of-datanodes-2_datanode-pvcs-2hdd-1ssd_listener-class-cluster-internal_openshift-false (885.37s)
        --- PASS: kuttl/harness/profiling_hadoop-3.4.1_zookeeper-latest-3.9.3_openshift-false (199.33s)
        --- PASS: kuttl/harness/cluster-operation_hadoop-latest-3.4.1_zookeeper-latest-3.9.3_openshift-false (243.21s)
        --- PASS: kuttl/harness/kerberos_hadoop-3.4.1_zookeeper-latest-3.9.3_krb5-1.21.1_opa-1.8.0_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-false (1311.05s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.1_zookeeper-3.9.3_zookeeper-latest-3.9.3_number-of-datanodes-1_datanode-pvcs-2hdd-1ssd_listener-class-external-unstable_openshift-false (169.44s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.1_zookeeper-3.9.3_zookeeper-latest-3.9.3_number-of-datanodes-1_datanode-pvcs-default_listener-class-cluster-internal_openshift-false (150.17s)
        --- PASS: kuttl/harness/logging_hadoop-3.4.1_zookeeper-latest-3.9.3_openshift-false (703.10s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.1_zookeeper-3.9.3_zookeeper-latest-3.9.3_number-of-datanodes-1_datanode-pvcs-2hdd-1ssd_listener-class-cluster-internal_openshift-false (175.27s)
        --- PASS: kuttl/harness/orphaned-resources_hadoop-latest-3.4.1_zookeeper-latest-3.9.3_openshift-false (190.23s)
        --- PASS: kuttl/harness/kerberos_hadoop-3.4.1_zookeeper-latest-3.9.3_krb5-1.21.1_opa-1.8.0_kerberos-realm-CLUSTER.LOCAL_kerberos-backend-mit_openshift-false (1415.85s)
PASS

--- PASS: kuttl (274.77s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/keycloak-user-info_opa-latest-1.8.0_keycloak-23.0.1_openshift-false (274.76s)
PASS
```

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [x] Add an entry to the CHANGELOG.md file
- [x] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
