### PR TITLE
chore(zookeeper): Update image for 25.11.0

### DIFF
--- a/zookeeper/boil-config.toml
+++ b/zookeeper/boil-config.toml
@@ -3,4 +3,11 @@ java-base = "17"
 java-devel = "11"
 
 [versions."3.9.3".build-arguments]
-jmx-exporter-version = "1.3.0"
+jmx-exporter-version = "1.4.0"
+
+[versions."3.9.4".local-images]
+java-base = "17"
+java-devel = "11"
+
+[versions."3.9.4".build-arguments]
+jmx-exporter-version = "1.4.0"

--- a/zookeeper/stackable/patches/3.9.4/0001-Add-CycloneDX-plugin.patch
+++ b/zookeeper/stackable/patches/3.9.4/0001-Add-CycloneDX-plugin.patch
@@ -1,0 +1,34 @@
+From 24644dd2f8463f972965d14021a7b071d8feaf81 Mon Sep 17 00:00:00 2001
+From: xeniape <xenia.fischer@stackable.tech>
+Date: Tue, 30 Sep 2025 15:24:05 +0200
+Subject: Add CycloneDX plugin
+
+---
+ pom.xml | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/pom.xml b/pom.xml
+index 860ffb97..5355571a 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -925,7 +925,7 @@
+         <plugin>
+           <groupId>org.cyclonedx</groupId>
+           <artifactId>cyclonedx-maven-plugin</artifactId>
+-          <version>2.7.9</version>
++          <version>2.8.0</version>
+        </plugin>
+       </plugins>
+     </pluginManagement>
+@@ -1200,6 +1200,11 @@
+       <plugin>
+         <groupId>org.cyclonedx</groupId>
+         <artifactId>cyclonedx-maven-plugin</artifactId>
++        <configuration>
++            <projectType>application</projectType>
++            <schemaVersion>1.5</schemaVersion>
++            <skipNotDeployed>false</skipNotDeployed>
++        </configuration>
+         <executions>
+           <execution>
+             <goals>

--- a/zookeeper/stackable/patches/3.9.4/patchable.toml
+++ b/zookeeper/stackable/patches/3.9.4/patchable.toml
@@ -1,0 +1,2 @@
+mirror = "https://github.com/stackabletech/zookeeper.git"
+base = "7246445ec281f3dbf53dc54e970c914f39713903"


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/docker-images/issues/1275

### Integrationtests

```
--- PASS: kuttl (435.02s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/cluster-operation_zookeeper-latest-3.9.4_openshift-false (45.99s)
        --- PASS: kuttl/harness/logging_zookeeper-3.9.4_openshift-false (126.46s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.4_use-server-tls-false_use-client-auth-tls-true_openshift-false (153.68s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.4_use-server-tls-true_use-client-auth-tls-true_openshift-false (125.88s)
        --- PASS: kuttl/harness/znode_zookeeper-latest-3.9.4_openshift-false (32.33s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.4_use-server-tls-true_use-client-auth-tls-false_openshift-false (143.80s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.4_use-server-tls-false_use-client-auth-tls-false_openshift-false (108.12s)
        --- PASS: kuttl/harness/delete-rolegroup_zookeeper-3.9.4_openshift-false (91.53s)
PASS
```

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
