### PR TITLE
Add ZOOCFGDIR env variable to ZooKeeper to make scripts work

### DIFF
--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -123,6 +123,9 @@ EOF
 
 ENV ZOOKEEPER_HOME=/stackable/zookeeper
 ENV PATH="${PATH}":/stackable/zookeeper/bin
+# This is used by zkEnv.sh and for the shell scripts in bin/
+# If unset it tries to find the conf directory automatically and that fails
+ENV ZOOCFGDIR=/stackable/config
 
 USER ${STACKABLE_USER_UID}
 WORKDIR /stackable/zookeeper


### PR DESCRIPTION
# Description

This works around https://issues.apache.org/jira/browse/ZOOKEEPER-4985
If we don't set this variable most of the shell scripts will fail (definitely zkCleanup.sh).
It can be set manually before every call but we do know the location of the config directory so no harm in making it a bit easier.

I didn't think this needed a changelog entry, happy to add if you think otherwise.

## Definition of Done Checklist

- [ ] Add an entry to the CHANGELOG.md file
- [x] Integration tests ran successfully
