### PR TITLE
ci(build): Add runners selection

### DIFF
--- a/.github/workflows/reusable_build_image.yaml
+++ b/.github/workflows/reusable_build_image.yaml
@@ -10,6 +10,13 @@ on:
       registry-namespace:
         required: true
         type: string
+      runners:
+        description: |
+          The type of runners used.
+          - `mixed`: x86_64 builds run on the GitHub hosted runners and the aarch64 builds run on the Ubicloud runners
+          - `ubicloud`: Both the x86_64 and the aarch64 builds run on the Ubicloud runners
+        default: mixed
+        type: string
     secrets:
       harbor-robot-secret:
         description: The secret for the Harbor robot user used to push images and manifest
@@ -19,8 +26,33 @@ on:
         required: true
 
 jobs:
-  generate_matrix:
-    name: Generate Version List
+  generate_runner_dimension:
+    name: Generate Runner Dimension
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - id: runners
+        shell: bash
+        env:
+          RUNNERS_TYPE: ${{ inputs.runners }}
+        run: |
+          if [ "$RUNNERS_TYPE" == "mixed" ]; then
+            RUNNERS=$(cat .github/workflows/runners/mixed.json)
+            echo "RUNNERS<<EOF\n$RUNNERS\nEOF" | tee -a "$GITHUB_OUTPUT"
+          elif [ "$RUNNERS_TYPE" == "ubicloud" ]; then
+            RUNNERS=$(cat .github/workflows/runners/ubicloud.json)
+            echo "RUNNERS<<EOF\n$RUNNERS\nEOF" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "Invalid runners type, expected 'mixed' or 'ubicloud'"
+            exit 1
+          fi
+    outputs:
+      runners: ${{ steps.runners.outputs.RUNNERS }}
+
+  generate_version_dimension:
+    name: Generate Version Dimension
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -35,17 +67,17 @@ jobs:
 
   build:
     name: Build/Publish ${{ matrix.versions }}-${{ matrix.runner.arch }} Image
-    needs: [generate_matrix]
+    needs:
+      - generate_version_dimension
+      - generate_runner_dimension
     permissions:
       id-token: write
     runs-on: ${{ matrix.runner.name }}
     strategy:
       fail-fast: false
       matrix:
-        runner:
-          - {name: "ubuntu-latest", arch: "amd64"}
-          - {name: "ubicloud-standard-8-arm-ubuntu-2404", arch: "arm64"}
-        versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
+        versions: ${{ fromJson(needs.generate_version_dimension.outputs.versions) }}
+        runner: ${{ fromJson(needs.generate_runner_dimension.outputs.runners) }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -76,14 +108,14 @@ jobs:
 
   publish_manifests:
     name: Build/Publish ${{ matrix.versions }} Manifests
-    needs: [generate_matrix, build]
+    needs: [generate_version_dimension, build]
     permissions:
       id-token: write
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
+        versions: ${{ fromJson(needs.generate_version_dimension.outputs.versions) }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -101,7 +133,7 @@ jobs:
 
   notify:
     name: Failure Notification
-    needs: [generate_matrix, build, publish_manifests]
+    needs: [generate_version_dimension, build, publish_manifests]
     runs-on: ubuntu-latest
     if: failure() || (github.run_attempt > 1 && !cancelled())
     steps:

--- a/.github/workflows/runners/mixed.json
+++ b/.github/workflows/runners/mixed.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "ubuntu-latest",
+    "arch": "amd64"
+  },
+  {
+    "name": "ubicloud-standard-8-arm-ubuntu-2404",
+    "arch": "arm64"
+  }
+]

--- a/.github/workflows/runners/ubicloud.json
+++ b/.github/workflows/runners/ubicloud.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "ubicloud-standard-8-ubuntu-2404",
+    "arch": "amd64"
+  },
+  {
+    "name": "ubicloud-standard-8-arm-ubuntu-2404",
+    "arch": "arm64"
+  }
+]


### PR DESCRIPTION
> [!CAUTION]
> Currently untested. A test run will be triggered to confirm this change works as expected.

With this PR, container image build pipelines can now select one of the following set of runners:

- `mixed`: x86_64 builds run on the GitHub hosted runners and the aarch64 builds run on the Ubicloud runners
- `ubicloud`: Both the x86_64 and the aarch64 builds run on the Ubicloud runners

This PR is raised to fix the OpenSearch Dashboards build on x86_64. It is very likely that this feature will be removed or adjusted in the future when the set of available/used runners changes.