### PR TITLE
ci(ubi9): Use Ubuntu 24.04 on ARM runner

### DIFF
--- a/.github/workflows/ubi-rust-builder.yml
+++ b/.github/workflows/ubi-rust-builder.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: ["ubuntu-latest", "ubicloud-standard-8-arm"]
+        runner: ["ubuntu-latest", "ubicloud-standard-8-arm-ubuntu-2404"]
         ubi-version: ["ubi9"]
     runs-on: ${{ matrix.runner }}
     steps:


### PR DESCRIPTION
This is updated to be in line with the `ubuntu-latest` runner for x86_64 which under the hood also uses Ubuntu 24.04.