### PR TITLE
fix: pin luxon to fix 4.1.2 build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ All notable changes to this project will be documented in this file.
 - hbase: move hbck2.env to hbase-operator-tools image and add log4j2 properties for this tool ([#1300]).
 - hbase: replace `sed` calls with `config-utils template` where possible ([#1301]).
 - superset: Fix the 4.1.2 build when building from source ([#1309])
-- superset: Pin `luxon` to version 3.6.1 to fix build ([#1315])
+- superset: Pin `luxon` to version 3.6.1 to fix build ([#1315], [#1316])
 
 ### Fixed
 
@@ -108,6 +108,7 @@ All notable changes to this project will be documented in this file.
 [#1309]: https://github.com/stackabletech/docker-images/pull/1309
 [#1311]: https://github.com/stackabletech/docker-images/pull/1311
 [#1315]: https://github.com/stackabletech/docker-images/pull/1315
+[#1316]: https://github.com/stackabletech/docker-images/pull/1316
 
 ## [25.7.0] - 2025-07-23
 

--- a/superset/stackable/patches/4.1.2/0001-fix-pin-luxon-to-fix-build.patch
+++ b/superset/stackable/patches/4.1.2/0001-fix-pin-luxon-to-fix-build.patch
@@ -1,15 +1,15 @@
-From 1b11f3ff47f46105289f7f9dcaa4fc10d6ea3571 Mon Sep 17 00:00:00 2001
+From fcff47eb39942ca5699ca31046ac0130da54fee8 Mon Sep 17 00:00:00 2001
 From: dervoeti <lukas.krug@stackable.tech>
 Date: Wed, 22 Oct 2025 17:04:19 +0200
 Subject: fix: pin luxon to fix build
 
-For some reason npm tries to use a newer version of luxon than the version in the lock file. I suspect this might be related to how npm before version 11 handles workspace dependencies in lock files. The luxon version is set to 3.6.1 now to prevent npm from trying to select a newer version, so that the same packages as in the original Superset build are used.
+For some reason npm tries to use a newer version of luxon than the version in the lock file. I suspect this might be related to how npm before version 11 handles workspace dependencies in lock files. The luxon version is set to 3.5.0 now to prevent npm from trying to select a newer version, so that the same packages as in the original Superset build are used.
 ---
  superset-frontend/package.json | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/superset-frontend/package.json b/superset-frontend/package.json
-index ebca197a25..3490ecaa93 100644
+index ebca197a25..bb2641a67f 100644
 --- a/superset-frontend/package.json
 +++ b/superset-frontend/package.json
 @@ -148,7 +148,7 @@
@@ -17,7 +17,7 @@ index ebca197a25..3490ecaa93 100644
      "json-stringify-pretty-compact": "^2.0.0",
      "lodash": "^4.17.21",
 -    "luxon": "^3.5.0",
-+    "luxon": "3.6.1",
++    "luxon": "3.5.0",
      "mapbox-gl": "^2.10.0",
      "markdown-to-jsx": "^7.4.7",
      "match-sorter": "^6.3.4",


### PR DESCRIPTION
# Description

I committed the wrong patch file for Superset 4.1.2 in https://github.com/stackabletech/docker-images/pull/1315 :confused: 

This PR fixes it, luxon needs to be pinned to 3.5.0 in 4.1.2 and not to version 3.6.1 (which Superset 4.1.4 uses).

Local build and smoke test succeeded.

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [x] Add an entry to the CHANGELOG.md file
- [x] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
