### PR TITLE
fix(nifi): Bump nifi-opa-plugin to v0.3.2

### DIFF
--- a/nifi/boil-config.toml
+++ b/nifi/boil-config.toml
@@ -7,7 +7,7 @@ java-devel = "11"
 git-sync-version = "v4.4.1"
 # Check for new versions at the upstream: https://github.com/DavidGitter/nifi-opa-plugin/tags
 # Checkout a Patchable version (patch-series) for the new tag
-nifi-opa-authorizer-plugin-version = "0.3.0"
+nifi-opa-authorizer-plugin-version = "0.3.2"
 
 [versions."1.28.1".local-images]
 java-base = "11"
@@ -18,7 +18,7 @@ java-devel = "11"
 git-sync-version = "v4.4.1"
 # Check for new versions at the upstream: https://github.com/DavidGitter/nifi-opa-plugin/tags
 # Checkout a Patchable version (patch-series) for the new tag
-nifi-opa-authorizer-plugin-version = "0.3.0"
+nifi-opa-authorizer-plugin-version = "0.3.2"
 
 [versions."2.4.0".local-images]
 java-base = "21"
@@ -29,7 +29,7 @@ java-devel = "21"
 git-sync-version = "v4.4.1"
 # Check for new versions at the upstream: https://github.com/DavidGitter/nifi-opa-plugin/tags
 # Checkout a Patchable version (patch-series) for the new tag
-nifi-opa-authorizer-plugin-version = "0.3.0"
+nifi-opa-authorizer-plugin-version = "0.3.2"
 # Release a new version here: https://github.com/stackabletech/nifi-iceberg-bundle
 # Checkout a Patchable version (patch-series) for the new tag
 nifi-iceberg-bundle-version = "0.0.5"
@@ -43,7 +43,7 @@ java-devel = "21"
 git-sync-version = "v4.4.1"
 # Check for new versions at the upstream: https://github.com/DavidGitter/nifi-opa-plugin/tags
 # Checkout a Patchable version (patch-series) for the new tag
-nifi-opa-authorizer-plugin-version = "0.3.0"
+nifi-opa-authorizer-plugin-version = "0.3.2"
 
 # Release a new version here: https://github.com/stackabletech/nifi-iceberg-bundle
 # Checkout a Patchable version (patch-series) for the new tag

--- a/nifi/opa-plugin/stackable/patches/0.3.2/patchable.toml
+++ b/nifi/opa-plugin/stackable/patches/0.3.2/patchable.toml
@@ -1,0 +1,2 @@
+mirror = "https://github.com/stackabletech/nifi-opa-plugin.git"
+base = "3ec5432824d89c204c306dd7c5e0a4c39ad83691"


### PR DESCRIPTION
# Description
Bump `nifi-opa-plugin` to `v0.3.2` to fix a [bug](https://github.com/DavidGitter/nifi-opa-plugin/pull/22) where `ResourceContext` was not correctly sent in the authorization request to OPA.

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
