### PR TITLE
chore(zookeeper): Speed up build by removing unnecessary steps

### DIFF
--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -42,7 +42,7 @@ tar -czf /stackable/zookeeper-${NEW_VERSION}-src.tar.gz .
 # that created all kinds of issues for the build container
 mvn \
   -pl "!zookeeper-client/zookeeper-client-c" \
-  clean install checkstyle:check spotbugs:check \
+  clean install \
   -DskipTests \
   -Pfull-build
 


### PR DESCRIPTION
I believe the build is now quicker than it was.

This was discussed in a [slack thread](https://stackable-workspace.slack.com/archives/C02FZ581UCD/p1761830809168619).

```
--- PASS: kuttl (912.71s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/delete-rolegroup_zookeeper-3.9.3,oci.stackable.tech_sandbox_nick_zookeeper_3.9.3-stackable0.0.0-dev-amd64_openshift-false (42.03s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.3,oci.stackable.tech_sandbox_nick_zookeeper_3.9.3-stackable0.0.0-dev-amd64_use-server-tls-true_use-client-auth-tls-true_openshift-false (104.47s)
        --- PASS: kuttl/harness/logging_zookeeper-3.9.4,oci.stackable.tech_sandbox_nick_zookeeper_3.9.4-stackable0.0.0-dev-amd64_openshift-false (68.15s)
        --- PASS: kuttl/harness/logging_zookeeper-3.9.3,oci.stackable.tech_sandbox_nick_zookeeper_3.9.3-stackable0.0.0-dev-amd64_openshift-false (64.91s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.4,oci.stackable.tech_sandbox_nick_zookeeper_3.9.4-stackable0.0.0-dev-amd64_use-server-tls-true_use-client-auth-tls-true_openshift-false (78.96s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.4,oci.stackable.tech_sandbox_nick_zookeeper_3.9.4-stackable0.0.0-dev-amd64_use-server-tls-true_use-client-auth-tls-false_openshift-false (74.74s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.4,oci.stackable.tech_sandbox_nick_zookeeper_3.9.4-stackable0.0.0-dev-amd64_use-server-tls-false_use-client-auth-tls-true_openshift-false (78.59s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.4,oci.stackable.tech_sandbox_nick_zookeeper_3.9.4-stackable0.0.0-dev-amd64_use-server-tls-false_use-client-auth-tls-false_openshift-false (78.94s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.3,oci.stackable.tech_sandbox_nick_zookeeper_3.9.3-stackable0.0.0-dev-amd64_use-server-tls-false_use-client-auth-tls-false_openshift-false (64.65s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.3,oci.stackable.tech_sandbox_nick_zookeeper_3.9.3-stackable0.0.0-dev-amd64_use-server-tls-true_use-client-auth-tls-false_openshift-false (75.10s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.3,oci.stackable.tech_sandbox_nick_zookeeper_3.9.3-stackable0.0.0-dev-amd64_use-server-tls-false_use-client-auth-tls-true_openshift-false (79.02s)
        --- PASS: kuttl/harness/cluster-operation_zookeeper-latest-3.9.4,oci.stackable.tech_sandbox_nick_zookeeper_3.9.4-stackable0.0.0-dev-amd64_openshift-false (29.35s)
        --- PASS: kuttl/harness/znode_zookeeper-latest-3.9.4,oci.stackable.tech_sandbox_nick_zookeeper_3.9.4-stackable0.0.0-dev-amd64_openshift-false (27.51s)
        --- PASS: kuttl/harness/delete-rolegroup_zookeeper-3.9.4,oci.stackable.tech_sandbox_nick_zookeeper_3.9.4-stackable0.0.0-dev-amd64_openshift-false (46.26s)
PASS
```