### PR TITLE
fix(nifi): Do not require SNI checks

### DIFF
--- a/nifi/stackable/patches/2.6.0/0004-NIFI-14858-Make-SNI-checking-configurable.patch
+++ b/nifi/stackable/patches/2.6.0/0004-NIFI-14858-Make-SNI-checking-configurable.patch
@@ -81,7 +81,7 @@ index 9e85c05d22..89d81813f4 100644
      }
  
 +    public boolean isWebHttpsSniRequired() {
-+        return Boolean.parseBoolean(getProperty(WEB_HTTPS_SNI_REQUIRED, "true"));
++        return Boolean.parseBoolean(getProperty(WEB_HTTPS_SNI_REQUIRED, "false"));
 +    }
 +
 +    public boolean isWebHttpsSniHostCheck() {


### PR DESCRIPTION
This was already done for 2.4.0 in https://github.com/stackabletech/docker-images/pull/1265

> [!TIP]
> No, this isn't going against agreed upon values. We did have a discussion about setting the Host header check to false, but "secure by default" was the reason for keeping that enabled and documenting how to disable it.