### PR TITLE
ci(trino): Use Ubicloud runners only

### DIFF
--- a/.github/workflows/build_trino.yaml
+++ b/.github/workflows/build_trino.yaml
@@ -35,5 +35,6 @@ jobs:
       product-name: trino
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
-      # We have a too high disk usage for GitHub runners
+      # Since building Vector from source, this build runs out of disk space.
+      # As such, we use the Ubicloud runners which provide bigger disks.
       runners: ubicloud


### PR DESCRIPTION
Since building Vector from source (see #1323), we seem to run out of disk space on the included GitHub runners. As such, we now only use the larger Ubicloud runners to build Trino.

Test run: https://github.com/stackabletech/docker-images/actions/runs/19102981903