### PR TITLE
ci(spark-connect-client): Use Ubicloud runners only

### DIFF
--- a/.github/workflows/build_spark-connect-client.yaml
+++ b/.github/workflows/build_spark-connect-client.yaml
@@ -6,7 +6,7 @@ run-name: |
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 2/2 * *' # https://crontab.guru/#0_0_2/2_*_*
+    - cron: "0 0 2/2 * *" # https://crontab.guru/#0_0_2/2_*_*
   push:
     branches: [main]
     tags:
@@ -34,3 +34,6 @@ jobs:
       product-name: spark-connect-client
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: stackable
+      # Since building Vector from source, this build runs out of disk space.
+      # As such, we use the Ubicloud runners which provide bigger disks.
+      runners: ubicloud


### PR DESCRIPTION
Same change as #1331 and #1332, just for Spark Connect.

Test run: https://github.com/stackabletech/docker-images/actions/runs/19105833924