### PR TITLE
fix(kafka): Make image for version 4.1.0 build again

### DIFF
--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -21,8 +21,13 @@ COPY --chown=${STACKABLE_USER_UID}:0 kafka/stackable/patches/${PRODUCT_VERSION} 
 COPY --chown=${STACKABLE_USER_UID}:0 --from=patched-reload4j /stackable/.m2/repository /stackable/patched-reload4j-libs
 
 RUN <<EOF
-mkdir -p /stackable/.m2/repository
-cp -r /stackable/patched-reload4j-libs/* /stackable/.m2/repository
+    # TODO: remove this later.
+    # reload4j jars are only needed of Kafka 3.x
+    case "${PRODUCT_VERSION}" in
+      3*)
+        mkdir -p /stackable/.m2/repository
+        cp -r /stackable/patched-reload4j-libs/* /stackable/.m2/repository
+    esac
 
 cd "$(/stackable/patchable --images-repo-root=src checkout kafka ${PRODUCT_VERSION})"
 

--- a/kafka/boil-config.toml
+++ b/kafka/boil-config.toml
@@ -25,6 +25,10 @@ java-base = "23"
 java-devel = "23"
 "kafka/kcat" = "1.7.0"
 "kafka/kafka-opa-plugin" = "1.5.1"
+# TODO: this is not used in this version but it's added
+# to avoid major changes to the Kafka image build on short notice.
+# Building this image is quick and in CI should not even be noticed.
+"shared/reload4j" = "1.2.25"
 
 [versions."4.1.0".build-arguments]
 scala-version = "2.13"


### PR DESCRIPTION
# Description

```
Successfully built 1 image:
oci.stackable.tech/sdp/kafka:4.1.0-stackable0.0.0-dev-amd64
```

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
