### PR TITLE
docs: extended Patchable readme

### DIFF
--- a/rust/patchable/README.md
+++ b/rust/patchable/README.md
@@ -242,13 +242,13 @@ pushd $(cargo patchable checkout zookeeper 3.9.3)
 Fetch the upstream commit using:
 
 ```sh
-git fetch https://github.com/apache/zookeeper 8532163
+git fetch https://github.com/apache/zookeeper 3d6c0d1164dc9ec96a02de383e410b1b0ef64565
 ```
 
 Then cherry-pick it with:
 
 ```sh
-git cherry-pick 8532163
+git cherry-pick 3d6c0d1
 ```
 
 Finally, export the patches as .patch files:


### PR DESCRIPTION
# Description

Has been on my todo list for a while, this adds some information to the Patchable README that was only available in Nuclino.

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
