### PR TITLE
fix(stackable-base): Update expected ca-certificates package name

### DIFF
--- a/stackable-base/Dockerfile
+++ b/stackable-base/Dockerfile
@@ -156,7 +156,7 @@ chown ${STACKABLE_USER_UID}:0 /stackable/.curlrc
 # CVE-2023-37920: Remove "e-Tugra" root certificates
 # e-Tugra's root certificates were subject to an investigation prompted by reporting of security issues in their systems
 # Until they are removed by default from ca-certificates, we should remove them manually
-EXPECTED_CERTS_PACKAGE="ca-certificates-2024.2.69_v8.0.303-91.4.el9_4.noarch"
+EXPECTED_CERTS_PACKAGE="ca-certificates-2025.2.80_v9.0.305-91.el9.noarch"
 ACTUAL_CERTS_PACKAGE="$(rpm -qa ca-certificates)"
 if [ "$ACTUAL_CERTS_PACKAGE" != "$EXPECTED_CERTS_PACKAGE" ]; then
   echo "The ca-certificates package was updated to $ACTUAL_CERTS_PACKAGE. Please check if the e-Tugra root certificates are present. \


### PR DESCRIPTION
The `ca-certificates` packages was recently updated and caused pretty much all image builds to fail. This PR updates the expected package name to the actual package name.

A local test build of the `stackable-base` image was successful.