### PR TITLE
Remove duplicated '[Adoptium]' entry from java-devel

### DIFF
--- a/java-devel/Dockerfile
+++ b/java-devel/Dockerfile
@@ -17,7 +17,6 @@ ARG MAVEN_VERSION="3.9.11"
 # See: https://adoptium.net/en-gb/installation/linux/#_centosrhelfedora_instructions
 RUN cat <<EOF > /etc/yum.repos.d/adoptium.repo
 [Adoptium]
-[Adoptium]
 name=Adoptium
 # The adoptium mirror times-out often, so we have created a pull-through cache
 # baseurl=https://packages.adoptium.net/artifactory/rpm/rhel/\$releasever/\$basearch


### PR DESCRIPTION
# Description

This removes a duplicated `[Adoptium]` entry in java-devel

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
