### PR TITLE
ci(opensearch): Use Ubicloud runners

### DIFF
--- a/.github/workflows/build_opensearch.yaml
+++ b/.github/workflows/build_opensearch.yaml
@@ -6,7 +6,7 @@ run-name: |
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 2/2 * *' # https://crontab.guru/#0_0_2/2_*_*
+    - cron: "0 0 2/2 * *" # https://crontab.guru/#0_0_2/2_*_*
   push:
     branches: [main]
     tags:
@@ -36,3 +36,4 @@ jobs:
       product-name: opensearch
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      runners: ubicloud


### PR DESCRIPTION
Needed because OpenSearch doesn't build on the GH hosted runner anymore because of missing disk space (bloat).

Successful test run: https://github.com/stackabletech/docker-images/actions/runs/21028162566