### PR TITLE
ci(hive): Use Ubicloud runners

### DIFF
--- a/.github/workflows/build_hive.yaml
+++ b/.github/workflows/build_hive.yaml
@@ -6,7 +6,7 @@ run-name: |
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 2 2/2 * *' # https://crontab.guru/#0_2_2/2_*_*
+    - cron: "0 2 2/2 * *" # https://crontab.guru/#0_2_2/2_*_*
   push:
     branches: [main]
     tags:
@@ -36,3 +36,4 @@ jobs:
       product-name: hive
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      runners: ubicloud


### PR DESCRIPTION
The image started to fail to build on January 14th 2026.

We are not exactly sure why the builds now fail due to missing disk space, because Hive itself wasn't changed. It might be because of other changes, like the Vector bump.

Successful est run: https://github.com/stackabletech/docker-images/actions/runs/21028434262