### PR TITLE
fix(opensearch): Use the Maven repository of OpenSearch instead of Sonatype

### DIFF
--- a/opensearch/security-plugin/stackable/patches/3.1.0.0/0003-Use-the-Maven-repository-of-OpenSearch-instead-of-So.patch
+++ b/opensearch/security-plugin/stackable/patches/3.1.0.0/0003-Use-the-Maven-repository-of-OpenSearch-instead-of-So.patch
@@ -1,0 +1,82 @@
+From 94d4d6621b32221177127f457e2594e669b1d801 Mon Sep 17 00:00:00 2001
+From: Siegfried Weber <mail@siegfriedweber.net>
+Date: Mon, 2 Feb 2026 11:49:08 +0100
+Subject: Use the Maven repository of OpenSearch instead of Sonatype
+
+---
+ build.gradle                        | 4 ++--
+ bwc-test/build.gradle               | 4 ++--
+ sample-resource-plugin/build.gradle | 2 +-
+ spi/build.gradle                    | 2 +-
+ 4 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/build.gradle b/build.gradle
+index 15a882a2..78b46262 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -48,7 +48,7 @@ buildscript {
+         mavenLocal()
+         mavenCentral()
+         maven { url "https://plugins.gradle.org/m2/" }
+-        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
++        maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+         maven { url "https://artifacts.opensearch.org/snapshots/lucene/" }
+         maven { url "https://build.shibboleth.net/nexus/content/groups/public" }
+         maven { url "https://build.shibboleth.net/nexus/content/repositories/releases" }
+@@ -516,7 +516,7 @@ allprojects {
+         mavenLocal()
+         mavenCentral()
+         maven { url "https://plugins.gradle.org/m2/" }
+-        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
++        maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+         maven { url "https://artifacts.opensearch.org/snapshots/lucene/" }
+         maven { url "https://build.shibboleth.net/nexus/content/repositories/releases" }
+     }
+diff --git a/bwc-test/build.gradle b/bwc-test/build.gradle
+index d5f4db95..d6c7b2bc 100644
+--- a/bwc-test/build.gradle
++++ b/bwc-test/build.gradle
+@@ -51,7 +51,7 @@ buildscript {
+     }
+     repositories {
+         mavenLocal()
+-        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
++        maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+         mavenCentral()
+         maven { url "https://plugins.gradle.org/m2/" }
+     }
+@@ -63,7 +63,7 @@ buildscript {
+ 
+ repositories {
+     mavenLocal()
+-    maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
++    maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+     mavenCentral()
+     maven { url "https://plugins.gradle.org/m2/" }
+ }
+diff --git a/sample-resource-plugin/build.gradle b/sample-resource-plugin/build.gradle
+index a881b781..d9975b0b 100644
+--- a/sample-resource-plugin/build.gradle
++++ b/sample-resource-plugin/build.gradle
+@@ -55,7 +55,7 @@ ext {
+ repositories {
+     mavenLocal()
+     mavenCentral()
+-    maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
++    maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+ }
+ 
+ configurations.all {
+diff --git a/spi/build.gradle b/spi/build.gradle
+index f75814f7..f35a4091 100644
+--- a/spi/build.gradle
++++ b/spi/build.gradle
+@@ -16,7 +16,7 @@ ext {
+ repositories {
+     mavenLocal()
+     mavenCentral()
+-    maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
++    maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+ }
+ 
+ dependencies {


### PR DESCRIPTION
# Description

The build of OpenSearch 3.1.0 failed with the following error:

```
A problem occurred configuring root project 'opensearch-security'.
> Could not resolve all artifacts for configuration 'classpath'.
   > Could not resolve org.opensearch.gradle:build-tools:3.1.0-SNAPSHOT.
     Required by:
         root project :
      > Could not resolve org.opensearch.gradle:build-tools:3.1.0-SNAPSHOT.
         > Unable to load Maven meta-data from https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/gradle/build-tools/3.1.0-SNAPSHOT/maven-metadata.xml.
            > Could not GET 'https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/gradle/build-tools/3.1.0-SNAPSHOT/maven-metadata.xml'. Received status code 402 from server: Payment Required
      > Could not resolve org.opensearch.gradle:build-tools:3.1.0-SNAPSHOT.
         > Unable to load Maven meta-data from https://artifacts.opensearch.org/snapshots/lucene/org/opensearch/gradle/build-tools/3.1.0-SNAPSHOT/maven-metadata.xml.
            > Could not GET 'https://artifacts.opensearch.org/snapshots/lucene/org/opensearch/gradle/build-tools/3.1.0-SNAPSHOT/maven-metadata.xml'. Received status code 403 from server: Forbidden
```

The OpenSearch Security Plugin 3.1.0.0 uses SNAPSHOT artifacts for the build. These artifacts are downloaded from Sonatype. Sonatype changed its policy to remove snapshot artifacts after 30 days which resulted in the error above. Therefore, in OpenSearch 3.4.0 the Sonatype Maven repository was replaced with the one from OpenSearch ([opensearch-project/opensearch-build#5360](https://www.github.com/opensearch-project/opensearch-build/issues/5360)). This change was backported to OpenSearch 3.3.0, but not to 3.1.0. This pull request backports [opensearch-project/security#5711](https://github.com/opensearch-project/security/pull/5711) and solves the issue.

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [x] Changes are OpenShift compatible

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
