### PR TITLE
feat: Stabilise HBase OPA authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- hbase: Update `hbase-opa-authorizer` from `0.2.0` ([#1446]).
+- hbase: Update `hbase-opa-authorizer` from `0.1.0` to `0.2.0` ([#1446]).
 
 [#1446]: https://github.com/stackabletech/docker-images/pull/1446
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- hbase: Update `hbase-opa-authorizer` from `0.2.0` ([#1446]).
+
+[#1446]: https://github.com/stackabletech/docker-images/pull/1446
+
 ## [26.3.0] - 2026-03-16
 
 ## [26.3.0-rc1] - 2026-03-16

--- a/hbase/boil-config.toml
+++ b/hbase/boil-config.toml
@@ -2,7 +2,7 @@
 "hbase/hbase" = "2.6.3"
 "hbase/hbase-operator-tools" = "1.3.0-hbase2.6.3"
 "hbase/phoenix" = "5.2.1-hbase2.6.3"
-"hbase/hbase-opa-authorizer" = "0.1.0" # only for HBase 2.6.1
+"hbase/hbase-opa-authorizer" = "0.2.0"
 "hadoop/hadoop" = "3.4.2"
 java-base = "11"
 java-devel = "11"
@@ -15,7 +15,7 @@ delete-caches = "true"
 "hbase/hbase" = "2.6.4"
 "hbase/hbase-operator-tools" = "1.3.0-hbase2.6.4"
 "hbase/phoenix" = "5.3.0-hbase2.6.4"
-"hbase/hbase-opa-authorizer" = "0.1.0" # only for HBase 2.6.1
+"hbase/hbase-opa-authorizer" = "0.2.0"
 "hadoop/hadoop" = "3.4.2"
 java-base = "11"
 java-devel = "11"

--- a/hbase/hbase-opa-authorizer/boil-config.toml
+++ b/hbase/hbase-opa-authorizer/boil-config.toml
@@ -3,3 +3,9 @@ java-devel = "11"
 
 [versions."0.1.0".build-arguments]
 delete-caches = "true"
+
+[versions."0.2.0".local-images]
+java-devel = "11"
+
+[versions."0.2.0".build-arguments]
+delete-caches = "true"

--- a/hbase/hbase-opa-authorizer/boil-config.toml
+++ b/hbase/hbase-opa-authorizer/boil-config.toml
@@ -1,9 +1,3 @@
-[versions."0.1.0".local-images]
-java-devel = "11"
-
-[versions."0.1.0".build-arguments]
-delete-caches = "true"
-
 [versions."0.2.0".local-images]
 java-devel = "11"
 

--- a/hbase/hbase-opa-authorizer/stackable/patches/0.1.0/patchable.toml
+++ b/hbase/hbase-opa-authorizer/stackable/patches/0.1.0/patchable.toml
@@ -1,1 +1,0 @@
-base = "c7eb27ca6a162bbfdb98262ba69e40d109f1fdd4"

--- a/hbase/hbase-opa-authorizer/stackable/patches/0.2.0/patchable.toml
+++ b/hbase/hbase-opa-authorizer/stackable/patches/0.2.0/patchable.toml
@@ -1,0 +1,1 @@
+base = "b81dfdb831d18c8cf5cacd397690cf97d4d4fdcc"

--- a/hbase/hbase-opa-authorizer/stackable/patches/0.2.0/patchable.toml
+++ b/hbase/hbase-opa-authorizer/stackable/patches/0.2.0/patchable.toml
@@ -1,1 +1,1 @@
-base = "b81dfdb831d18c8cf5cacd397690cf97d4d4fdcc"
+base = "950ca4c2b16cc469dd9cfe2ade914c30b19a1402"


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/hbase-opa-authorizer/issues/8

> [!NOTE]
> ~Requires a new release of 0.2.0. The changes in the PR pre-release are used to create a test image.~ * **Done** *

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
