### PR TITLE
ci: Bump stackabletech/actions to v0.14.1

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -60,7 +60,7 @@ jobs:
           echo "IMAGE_REPOSITORY=$(.scripts/get_repo_name.sh)" | tee -a "$GITHUB_ENV"
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@7fb064db885e006f6a9eeff69c7cd5ff5dea68bc # v0.13.0
+        uses: stackabletech/actions/publish-image@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -88,7 +88,7 @@ jobs:
           echo "IMAGE_REPOSITORY=$(.scripts/get_repo_name.sh)" | tee -a "$GITHUB_ENV"
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-image-index-manifest@7fb064db885e006f6a9eeff69c7cd5ff5dea68bc # v0.13.0
+        uses: stackabletech/actions/publish-image-index-manifest@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/pr_pre-commit.yaml
+++ b/.github/workflows/pr_pre-commit.yaml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - uses: stackabletech/actions/run-pre-commit@7fb064db885e006f6a9eeff69c7cd5ff5dea68bc # v0.13.0
+      - uses: stackabletech/actions/run-pre-commit@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           rust: ${{ env.RUST_TOOLCHAIN_VERSION }}

--- a/.github/workflows/reusable_build_image.yaml
+++ b/.github/workflows/reusable_build_image.yaml
@@ -68,7 +68,7 @@ jobs:
           persist-credentials: false
 
       - id: shard
-        uses: stackabletech/actions/shard@7fb064db885e006f6a9eeff69c7cd5ff5dea68bc # v0.13.0
+        uses: stackabletech/actions/shard@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
         with:
           product-name: ${{ inputs.product-name }}
     outputs:
@@ -95,11 +95,11 @@ jobs:
           persist-credentials: false
 
       - name: Free Disk Space
-        uses: stackabletech/actions/free-disk-space@7fb064db885e006f6a9eeff69c7cd5ff5dea68bc # v0.13.0
+        uses: stackabletech/actions/free-disk-space@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@7fb064db885e006f6a9eeff69c7cd5ff5dea68bc # v0.13.0
+        uses: stackabletech/actions/build-product-image@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
         with:
           registry-namespace: ${{ inputs.registry-namespace }}
           product-name: ${{ inputs.product-name }}
@@ -107,7 +107,7 @@ jobs:
           sdp-version: ${{ inputs.sdp-version }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@7fb064db885e006f6a9eeff69c7cd5ff5dea68bc # v0.13.0
+        uses: stackabletech/actions/publish-image@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$${{ inputs.registry-namespace }}+github-action-build
@@ -134,7 +134,7 @@ jobs:
           persist-credentials: false
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-image-index-manifest@7fb064db885e006f6a9eeff69c7cd5ff5dea68bc # v0.13.0
+        uses: stackabletech/actions/publish-image-index-manifest@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$${{ inputs.registry-namespace }}+github-action-build
@@ -149,7 +149,7 @@ jobs:
     if: failure() || (github.run_attempt > 1 && !cancelled())
     steps:
       - name: Send Notification
-        uses: stackabletech/actions/send-slack-notification@7fb064db885e006f6a9eeff69c7cd5ff5dea68bc # v0.13.0
+        uses: stackabletech/actions/send-slack-notification@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
         with:
           publish-manifests-result: ${{ needs.publish_manifests.result }}
           build-result: ${{ needs.build.result }}

--- a/.github/workflows/ubi-rust-builder.yml
+++ b/.github/workflows/ubi-rust-builder.yml
@@ -123,7 +123,7 @@ jobs:
     if: failure() || (github.run_attempt > 1 && !cancelled())
     steps:
       - name: Send Notification
-        uses: stackabletech/actions/send-slack-notification@7fb064db885e006f6a9eeff69c7cd5ff5dea68bc # v0.13.0
+        uses: stackabletech/actions/send-slack-notification@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
         with:
           publish-manifests-result: ${{ needs.publish_manifests.result }}
           build-result: ${{ needs.build.result }}


### PR DESCRIPTION
This bumps all stackabletech/actions to v0.14.1 to be compatible with the latest boil release.