### PR TITLE
chore(vector): Speep up build by reducing enabled features

### DIFF
--- a/vector/Dockerfile
+++ b/vector/Dockerfile
@@ -80,7 +80,7 @@ tar -czf /stackable/vector-${NEW_VERSION}-src.tar.gz .
 #   - opentelemetry: Ship logs to an OTLP endpoint
 #   - console/blackhole: Useful for debugging and are "cheap"
 # Other:
-#   - api: Needed for /health checks
+#   - api: Needed for /health checks (or /graphql queries)
 #   - unix: Enables jemalloc allocator on Linux for better performance
 cargo auditable --quiet build --release --no-default-features --features "
   sources-file,

--- a/vector/Dockerfile
+++ b/vector/Dockerfile
@@ -63,9 +63,38 @@ tar -czf /stackable/vector-${NEW_VERSION}-src.tar.gz .
 
 . "$HOME/.cargo/env"
 
-# Build vector with default features
-# TODO (@NickLarsenNZ): Consider reducing the feature-set to only what we need in the sidecar.
-cargo auditable --quiet build --release
+# Build vector with a minimal feature-set for use as a log-shipping sidecar.
+# We only need to read logs from disk (file source) and ship them to either
+# a Vector aggregator (vector sink) or an OTLP endpoint (opentelemetry sink).
+#
+# Sources:
+#   - file: Read log files from disk (core use case)
+#   - internal_logs: Vector's own log output
+# Transforms:
+#   - remap: VRL-based log parsing and structuring (used by operator-generated configs)
+#   - filter: Drop unwanted log lines
+#   - route: Route logs to different sinks based on conditions. It's currently not used,
+#     but might be helpful in the future.
+# Sinks:
+#   - vector: Ship logs to a Vector aggregator
+#   - opentelemetry: Ship logs to an OTLP endpoint
+#   - console/blackhole: Useful for debugging and are "cheap"
+# Other:
+#   - api: Needed for /health checks
+#   - unix: Enables jemalloc allocator on Linux for better performance
+cargo auditable --quiet build --release --no-default-features --features "
+  sources-file,
+  sources-internal_logs,
+  transforms-remap,
+  transforms-filter,
+  transforms-route,
+  sinks-vector,
+  sinks-opentelemetry,
+  sinks-console,
+  sinks-blackhole,
+  api,
+  unix
+"
 
 # Generate SBOMs and copy them to /app (via a script)
 cargo cyclonedx --all --spec-version 1.5 --describe binaries


### PR DESCRIPTION
# Description

Speed up Vector build times

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
