### PR TITLE
revert(boil): Vendor openssl for better portability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,15 +898,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "openssl-src"
-version = "300.6.0+3.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,7 +905,6 @@ checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ cap-std = "4.0.2"
 clap = { version = "4.5.41", features = ["derive"] }
 clap_complete = "4.5.55"
 clap_complete_nushell = "4.5.8"
-git2 = { version = "0.20.1", features = ["vendored-openssl"] }
+git2 = "0.20.1"
 glob = "0.3.2"
 oci-spec = "0.9.0"
 rstest = "0.26.1"


### PR DESCRIPTION
This reverts commit b1c124dbbb958bfc4838e42db55b3b75a9edcbf7 from #1459.

It currently breaks patchable.