### PR TITLE
fix(vector): Use relative path to patchable checked out source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 - trino: Backport fix for wrong deletes in Delta Lake ([#1453]).
 - opensearch: Scope CycloneDX SBOM to shipped components only, eliminating false positive CVEs from unshipped plugins ([#1452]).
+- vector: Look for SBOM in correct location ([#1471]).
 
 [#1446]: https://github.com/stackabletech/docker-images/pull/1446
 [#1452]: https://github.com/stackabletech/docker-images/pull/1452
@@ -24,6 +25,7 @@ All notable changes to this project will be documented in this file.
 [#1454]: https://github.com/stackabletech/docker-images/pull/1454
 [#1463]: https://github.com/stackabletech/docker-images/pull/1463
 [#1466]: https://github.com/stackabletech/docker-images/pull/1466
+[#1471]: https://github.com/stackabletech/docker-images/pull/1471
 
 ## [26.3.0] - 2026-03-16
 

--- a/vector/copy_artifacts.sh
+++ b/vector/copy_artifacts.sh
@@ -6,5 +6,7 @@
 cp "$1" /app
 
 # And now try to find a BOM file named like the binary + _bin.cdx.xml and copy it over as well if it exists
+# Using `patchable with --images-repo-root=src` makes the path `/stackable/src/vector/patchable-work/worktree/0.52.0`
+# assuming WORKDIR was `/stackable`.
 base=$(basename "$1")
-find /src/ -type f -name "${base}_bin.cdx.xml" -exec cp {} /app \;
+find ./src/ -type f -name "${base}_bin.cdx.xml" -exec cp {} /app \;

--- a/vector/copy_artifacts.sh
+++ b/vector/copy_artifacts.sh
@@ -9,4 +9,4 @@ cp "$1" /app
 # Using `patchable with --images-repo-root=src` makes the path `/stackable/src/vector/patchable-work/worktree/0.52.0`
 # assuming WORKDIR was `/stackable`.
 base=$(basename "$1")
-find ./src/ -type f -name "${base}_bin.cdx.xml" -exec cp {} /app \;
+find . -maxdepth 1 -type f -name "${base}_bin.cdx.xml" -exec cp {} /app \;


### PR DESCRIPTION
Fixes this error:

```
find: '/src/': No such file or directory
```

Because for this (vector) build, WORKDIR is /stackable (so patchable checked out src/ is below that)
