### PR TITLE
ci(precompiled/hadoop): Build precompiled/hadoop instead of hadoop

### DIFF
--- a/.github/workflows/precompile_hadoop.yaml
+++ b/.github/workflows/precompile_hadoop.yaml
@@ -46,6 +46,6 @@ jobs:
       # Needed for checkout
       contents: read
     with:
-      product-name: hadoop
+      product-name: precompiled/hadoop
       sdp-version: ${{ needs.generate_build_timestamp.outputs.unix_timestamp }}
       registry-namespace: precompiled


### PR DESCRIPTION
The previous workflow built the wrong thing (it built the entire `hadoop` product based on the `hadoop/hadoop` build stage).