### PR TITLE
ci(reusable_build_image): Add support for nested boil images

### DIFF
--- a/.github/workflows/precompile_hadoop.yaml
+++ b/.github/workflows/precompile_hadoop.yaml
@@ -47,5 +47,6 @@ jobs:
       contents: read
     with:
       product-name: precompiled/hadoop
-      sdp-version: ${{ needs.generate_build_timestamp.outputs.unix_timestamp }}
       registry-namespace: precompiled
+      image-name: hadoop
+      sdp-version: ${{ needs.generate_build_timestamp.outputs.unix_timestamp }}

--- a/.github/workflows/reusable_build_image.yaml
+++ b/.github/workflows/reusable_build_image.yaml
@@ -3,7 +3,15 @@ on:
   workflow_call:
     inputs:
       product-name:
+        description: The boil product directory name (e.g. "hadoop" or "precompiled/hadoop")
         required: true
+        type: string
+      image-name:
+        description: |
+          The image name used in the OCI registry. Defaults to product-name if not set.
+          This is used when the boil directory is nested (eg: precompiled/hadoop) but
+          the parent directory will be used as the namespace (eg: precompiled).
+        default: ""
         type: string
       sdp-version:
         required: true
@@ -112,10 +120,14 @@ jobs:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$${{ inputs.registry-namespace }}+github-action-build
           image-registry-password: ${{ secrets.harbor-robot-secret }}
-          image-repository: ${{ inputs.registry-namespace }}/${{ inputs.product-name }}
+          # NOTE (@NickLarsenNZ): This fallback is just for now so we can support both repo level
+          # image folders that go under the sdp namespace AND nested image folders that contain the
+          # namespace (for example precommit/hadoop).
+          # In future, we probably want to encode this information in the boil config metadata per
+          # registry so we don't have to do such gymnastics in the workflow.
+          image-repository: ${{ inputs.registry-namespace }}/${{ inputs.image-name || inputs.product-name }}
           image-manifest-tag: ${{ steps.build.outputs.image-manifest-tag }}
           source-image-uri: localhost/${{ inputs.registry-namespace }}/${{ inputs.product-name }}:${{ steps.build.outputs.image-manifest-tag }}
-
   publish_manifests:
     name: Build/Publish ${{ matrix.versions }} Manifests
     needs: [generate_version_dimension, build]
@@ -139,7 +151,12 @@ jobs:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$${{ inputs.registry-namespace }}+github-action-build
           image-registry-password: ${{ secrets.harbor-robot-secret }}
-          image-repository: ${{ inputs.registry-namespace }}/${{ inputs.product-name }}
+          # NOTE (@NickLarsenNZ): This fallback is just for now so we can support both repo level
+          # image folders that go under the sdp namespace AND nested image folders that contain the
+          # namespace (for example precommit/hadoop).
+          # In future, we probably want to encode this information in the boil config metadata per
+          # registry so we don't have to do such gymnastics in the workflow.
+          image-repository: ${{ inputs.registry-namespace }}/${{ inputs.image-name || inputs.product-name }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ inputs.sdp-version }}
 
   notify:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- hadoop: Add precompiled hadoop for later reuse in dependent images ([#1466]).
+- hadoop: Add precompiled hadoop for later reuse in dependent images ([#1466], [#1474]).
 - nifi: Add version `2.9.0` ([#1463]).
 
 ### Changed
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 [#1454]: https://github.com/stackabletech/docker-images/pull/1454
 [#1463]: https://github.com/stackabletech/docker-images/pull/1463
 [#1466]: https://github.com/stackabletech/docker-images/pull/1466
+[#1474]: https://github.com/stackabletech/docker-images/pull/1474
 
 ## [26.3.0] - 2026-03-16
 


### PR DESCRIPTION
Needed so that boil can find the config via the 'product-name', while using the 'namespace' and 'image-name' (without the parent directory) to tag the image with before pushing.

<details>

The build action uses the product-name to locate the boil config. Eg:

```yaml
product-name: hadoop # reads hadoop/boil-config.toml
namespace: sdp # this is used when the image is tagged
```

This broke twice when I wanted to build precompiled/hadoop:

```yaml
product-name: hadoop
namespace: precompiled # want to put it in a different project in Harbor
```

That built the product image via `hadoop/boil-config.toml`.

So I changed it to:

```yaml
product-name: precompiled/hadoop # Now it builds the hadoop source
namespace: precompiled # but now we have a duplicate "precompiled" when tagging the image
```

</details>

~Waiting~ on two workflow runs (to ensure it fixes the issue and doesn't break existing stuff):
- :green_circle: [precompiled/hadoop](https://github.com/stackabletech/docker-images/actions/runs/24687341680) (nested)
  - Correctly builds and publishes `oci.stackable.tech/precompiled/hadoop:3.4.2-stackable1776715076`
- :green_circle: [vector](https://github.com/stackabletech/docker-images/actions/runs/24687414824) (not nested, and relatively fast)
  - Correctly builds and publishes `oci.stackable.tech/sdp/vector:0.52.0-stackable0.0.0-dev`