### PR TITLE
chore: build boost libs from source

### DIFF
--- a/.scripts/upload_new_boost_version.sh
+++ b/.scripts/upload_new_boost_version.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# This script mirrors the boostorg/boost source bundle for the given version to Nexus.
+# The boost source bundle is architecture independent.
+# It contains it's own build system (b2) which is also built from source before building boost itself, so we don't need to worry about architecture specific builds.
+# This artifact is used by the hadoop/boost local image.
+
+
+set -euo pipefail
+
+VERSION=${1:?"Missing version number argument (arg 1)"}
+NEXUS_USER=${2:?"Missing Nexus username argument (arg 2)"}
+
+read -r -s -p "Nexus Password: " NEXUS_PASSWORD
+echo ""
+
+# https://stackoverflow.com/questions/4632028/how-to-create-a-temporary-directory
+# Find the directory name of the script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# the temp directory used, within $DIR
+WORK_DIR=$(mktemp -d -p "$DIR")
+
+# check if tmp dir was created
+if [[ ! "$WORK_DIR" || ! -d "$WORK_DIR" ]]; then
+  echo "Could not create temp dir"
+  exit 1
+fi
+
+# deletes the temp directory
+function cleanup {
+  rm -rf "$WORK_DIR"
+}
+
+# register the cleanup function to be called on the EXIT signal
+trap cleanup EXIT
+
+cd "$WORK_DIR" || exit
+
+# boost does not currently publish signatures or SBOMs
+BOOST_UNDERSCORE="$(echo "${VERSION}" | tr '.' '_')"
+BOOST_TARBALL="boost_${BOOST_UNDERSCORE}.tar.bz2"
+DOWNLOAD_URL="https://archives.boost.io/release/$VERSION/source/$BOOST_TARBALL"
+
+echo "Downloading boost"
+if ! curl --fail -Ls -O "$DOWNLOAD_URL"; then
+  echo "Failed to download from $DOWNLOAD_URL"
+  exit 1
+fi
+
+FILE_NAME=$(basename "$DOWNLOAD_URL")
+
+echo "Uploading boost to Nexus"
+if ! curl --fail -o /dev/null --progress-bar -u "$NEXUS_USER:$NEXUS_PASSWORD" --upload-file "$FILE_NAME" 'https://repo.stackable.tech/repository/packages/boost/'; then
+  echo "Failed to upload boost to Nexus"
+  exit 1
+fi
+
+echo "Successfully uploaded new version of boost ($VERSION) to Nexus"
+echo "https://repo.stackable.tech/service/rest/repository/browse/packages/boost/"

--- a/.scripts/upload_new_boost_version.sh
+++ b/.scripts/upload_new_boost_version.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # This script mirrors the boostorg/boost source bundle for the given version to Nexus.
 # The boost source bundle is architecture independent.
-# It contains it's own build system (b2) which is also built from source before building boost itself, so we don't need to worry about architecture specific builds.
+# It contains its own build system (b2) which is also built from source before building boost itself, so we don't need to worry about architecture specific builds.
 # This artifact is used by the hadoop/boost local image.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - hbase: Update `hbase-opa-authorizer` from `0.1.0` to `0.2.0` and then `0.3.0` ([#1446], [#1454]).
+- hadoop: Build the boost library from source instead of installing the EPEL package ([#1475]).
+          This is a requirement for the adoption of UBI 10 as base image because the package is not available there.
 
 ### Fixed
 
@@ -25,6 +27,7 @@ All notable changes to this project will be documented in this file.
 [#1463]: https://github.com/stackabletech/docker-images/pull/1463
 [#1466]: https://github.com/stackabletech/docker-images/pull/1466
 [#1474]: https://github.com/stackabletech/docker-images/pull/1474
+[#1475]: https://github.com/stackabletech/docker-images/pull/1475
 
 ## [26.3.0] - 2026-03-16
 

--- a/hadoop/Dockerfile
+++ b/hadoop/Dockerfile
@@ -90,6 +90,7 @@ LABEL \
 
 COPY --chown=${STACKABLE_USER_UID}:0 --from=hadoop-builder /stackable/hadoop-${HADOOP_VERSION}-stackable${RELEASE_VERSION} /stackable/hadoop-${HADOOP_VERSION}-stackable${RELEASE_VERSION}
 COPY --chown=${STACKABLE_USER_UID}:0 --from=hadoop-builder /stackable/*-src.tar.gz /stackable
+COPY --chown=${STACKABLE_USER_UID}:0 --from=hadoop-builder /stackable/boost /stackable/boost
 
 COPY --chown=${STACKABLE_USER_UID}:0 --from=hdfs-utils-builder /stackable/hdfs-utils-${HDFS_UTILS_VERSION}.jar /stackable/hadoop-${HADOOP_VERSION}-stackable${RELEASE_VERSION}/share/hadoop/common/lib/hdfs-utils-${HDFS_UTILS_VERSION}.jar
 COPY --chown=${STACKABLE_USER_UID}:0 --from=hdfs-utils-builder /stackable/hdfs-utils-${HDFS_UTILS_VERSION}-src.tar.gz /stackable
@@ -105,9 +106,11 @@ microdnf update
 # tar is required for `kubectl cp` which can be used to copy the log files
 # or profiler flamegraph from the Pod
 # It is already installed in the base image but leaving here for documentation purposes
+# libstdc++ is a runtime dependency for boost
 microdnf install \
   fuse \
   fuse-libs \
+  libstdc++ \
   tar
 microdnf clean all
 rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE_VERSION}\n" | sort > /stackable/package_manifest.txt
@@ -162,7 +165,7 @@ EOF
 USER ${STACKABLE_USER_UID}
 
 ENV HOME=/stackable
-ENV LD_LIBRARY_PATH=/stackable/hadoop/lib/native:/usr/lib/jvm/jre/lib/server
+ENV LD_LIBRARY_PATH=/stackable/boost/lib:/stackable/hadoop/lib/native:/usr/lib/jvm/jre/lib/server
 ENV PATH="${PATH}":/stackable/hadoop/bin
 ENV HADOOP_HOME=/stackable/hadoop
 ENV HADOOP_CONF_DIR=/stackable/config
@@ -174,6 +177,8 @@ ENV ASYNC_PROFILER_HOME=/stackable/async-profiler
 # if HADOOP_YARN_HOME does not exist at all, so we set it here to a sensible default.
 ENV HADOOP_YARN_HOME=/stackable/hadoop
 ENV HADOOP_MAPRED_HOME=/stackable/hadoop
+ENV BOOST_ROOT=/stackable/boost
+ENV CPATH=/stackable/boost/include
 
 WORKDIR /stackable/hadoop
 CMD ["echo", "This image is not meant to be 'run' directly."]

--- a/hadoop/Dockerfile
+++ b/hadoop/Dockerfile
@@ -135,8 +135,13 @@ chmod -x "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar"
 ln -s "/stackable/jmx/jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar" /stackable/jmx/jmx_prometheus_javaagent.jar
 
 # Set correct permissions and ownerships
-chown --recursive ${STACKABLE_USER_UID}:0 /stackable/hadoop /stackable/jmx /stackable/async-profiler "/stackable/async-profiler-${ASYNC_PROFILER_VERSION}-${TARGETOS}-${ARCH}"
-chmod --recursive g=u /stackable/jmx /stackable/async-profiler "/stackable/hadoop-${HADOOP_VERSION}-stackable${RELEASE_VERSION}"
+chown --recursive ${STACKABLE_USER_UID}:0 \
+/stackable/hadoop /stackable/jmx /stackable/async-profiler \
+"/stackable/async-profiler-${ASYNC_PROFILER_VERSION}-${TARGETOS}-${ARCH}" \
+/stackable/boost
+chmod --recursive g=u /stackable/jmx /stackable/async-profiler \
+"/stackable/hadoop-${HADOOP_VERSION}-stackable${RELEASE_VERSION}" \
+/stackable/boost
 
 # Workaround for https://issues.apache.org/jira/browse/HADOOP-12845
 # The problem is that our stackable-devel image does contain the openssl-devel package

--- a/hadoop/boost/Dockerfile
+++ b/hadoop/boost/Dockerfile
@@ -4,6 +4,13 @@
 # The boost library is a runtime dependency of the Hadoop native code
 # but is not available in the RedHat UBI10 or EPEL10 repositories, so we need to build
 # it ourselves.
+#
+# NOTE: We use a published source bundle instead of the patchable workflow
+#       because boost uses git submodules for it's build system
+#       and patchable doesn't support these.
+#       The source bundle contains everything needed to build b2 (the build system)
+#       and boost except for dependencies which are automatically discovered.
+#
 FROM local-image/stackable-base AS boost-builder
 
 ARG BOOST_VERSION
@@ -18,7 +25,8 @@ microdnf clean all
 
 BOOST_UNDERSCORE="$(echo "${BOOST_VERSION}" | tr '.' '_')"
 BOOST_TARBALL="boost_${BOOST_UNDERSCORE}.tar.bz2"
-BOOST_URL="https://archives.boost.io/release/${BOOST_VERSION}/source/${BOOST_TARBALL}"
+# See .scripts/upload_new_boost_version.sh for how this artifact got there.
+BOOST_URL="https://repo.stackable.tech/repository/packages/boost/${BOOST_TARBALL}"
 
 mkdir -p /stackable/boost
 curl -fsSL "${BOOST_URL}" -o "${BOOST_TARBALL}"

--- a/hadoop/boost/Dockerfile
+++ b/hadoop/boost/Dockerfile
@@ -6,7 +6,7 @@
 # it ourselves.
 #
 # NOTE: We use a published source bundle instead of the patchable workflow
-#       because boost uses git submodules for it's build system
+#       because boost uses git submodules for its build system
 #       and patchable doesn't support these.
 #       The source bundle contains everything needed to build b2 (the build system)
 #       and boost except for dependencies which are automatically discovered.

--- a/hadoop/boost/Dockerfile
+++ b/hadoop/boost/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1.16.0@sha256:e2dd261f92e4b763d789984f6eab84be66ab4f5f08052316d8eb8f173593acf7
+# check=error=true
+
+# The boost library is a runtime dependency of the Hadoop native code
+# but is not available in the RedHat UBI10 or EPEL10 repositories, so we need to build
+# it ourselves.
+FROM local-image/stackable-base AS boost-builder
+
+ARG BOOST_VERSION
+
+WORKDIR /tmp
+
+RUN <<EOF
+microdnf install \
+      gcc gcc-c++ make perl python3 \
+      tar bzip2 xz
+microdnf clean all
+
+BOOST_UNDERSCORE="$(echo "${BOOST_VERSION}" | tr '.' '_')"
+BOOST_TARBALL="boost_${BOOST_UNDERSCORE}.tar.bz2"
+BOOST_URL="https://archives.boost.io/release/${BOOST_VERSION}/source/${BOOST_TARBALL}"
+
+mkdir -p /stackable/boost
+curl -fsSL "${BOOST_URL}" -o "${BOOST_TARBALL}"
+tar -xf "${BOOST_TARBALL}"
+cd "boost_${BOOST_UNDERSCORE}"
+./bootstrap.sh --prefix=/stackable/boost
+./b2 -j"$(nproc)" \
+  link=shared runtime-link=shared variant=release threading=multi \
+  install
+rm -rf /tmp/*
+EOF

--- a/hadoop/boost/boil-config.toml
+++ b/hadoop/boost/boil-config.toml
@@ -1,0 +1,5 @@
+[versions."1.78.0".local-images]
+stackable-base = "1.0.0"
+
+[versions."1.78.0".build-arguments]
+boost-version = "1.78.0"

--- a/hadoop/hadoop/Dockerfile
+++ b/hadoop/hadoop/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.16.0@sha256:e2dd261f92e4b763d789984f6eab84be66ab4f5f08052316d8eb8f173593acf7
 # check=error=true
 
+FROM local-image/hadoop/boost AS boost-builder
 FROM local-image/java-devel AS hadoop-builder
 
 ARG PRODUCT_VERSION
@@ -14,16 +15,20 @@ COPY --chown=${STACKABLE_USER_UID}:0 shared/protobuf/stackable/patches/patchable
 COPY --chown=${STACKABLE_USER_UID}:0 shared/protobuf/stackable/patches/${PROTOBUF_VERSION} /stackable/src/shared/protobuf/stackable/patches/${PROTOBUF_VERSION}
 
 RUN <<EOF
-rpm --install --replacepkgs https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-microdnf update
-# boost is a build dependency starting in Hadoop 3.4.0 if compiling native code
-# automake and libtool are required to build protobuf
-microdnf install boost1.78-devel automake libtool
+# libstdc++ is a runtime dependency for boost,
+# automake and libtool are needed to build protobuf
+microdnf install libstdc++ automake libtool
 microdnf clean all
 rm -rf /var/cache/yum
 mkdir /opt/protobuf
 chown ${STACKABLE_USER_UID}:0 /opt/protobuf
 EOF
+
+COPY --chown=${STACKABLE_USER_UID}:0 --from=boost-builder /stackable/boost /stackable/boost
+
+ENV BOOST_ROOT=/stackable/boost
+ENV LD_LIBRARY_PATH=/stackable/boost/lib
+ENV CPATH=/stackable/boost/include
 
 USER ${STACKABLE_USER_UID}
 # This Protobuf version is the exact version as used in the Hadoop Dockerfile

--- a/hadoop/hadoop/boil-config.toml
+++ b/hadoop/hadoop/boil-config.toml
@@ -1,11 +1,13 @@
 [versions."3.3.6".local-images]
 java-devel = "11"
+"hadoop/boost" = "1.78.0"
 
 [versions."3.3.6".build-arguments]
 protobuf-version = "3.7.1"
 
 [versions."3.4.2".local-images]
 java-devel = "11"
+"hadoop/boost" = "1.78.0"
 
 [versions."3.4.2".build-arguments]
 protobuf-version = "3.7.1"


### PR DESCRIPTION
# Description

> [!WARNING]
> Do not merge yet until there is a resolution for https://github.com/stackabletech/issues/issues/845


Part of https://github.com/stackabletech/docker-images/issues/1349

Build the boost libraries from source instead of installing them as package from EPEL.

:yellow_circle: : Image build https://github.com/stackabletech/docker-images/actions/runs/24739778518 is fine. One failure unrelated to this PR.

:green_circle: Tests (one failed for unrelated reasons):

```
--- FAIL: kuttl (3453.07s)
    --- FAIL: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.2,oci.stackable.tech_sdp_hadoop_3.4.2-stackable0.0.0-boost_zookeeper-3.9.4_zookeeper-latest-3.9.4_number-of-datanodes-1_datanode-pvcs-2hdd-1ssd_listener-class-external-unstable_openshift-false (190.48s)
        --- PASS: kuttl/harness/profiling_hadoop-3.4.2,oci.stackable.tech_sdp_hadoop_3.4.2-stackable0.0.0-boost_zookeeper-latest-3.9.4_openshift-false (193.75s)
        --- PASS: kuttl/harness/cluster-operation_hadoop-latest-3.4.2,oci.stackable.tech_sdp_hadoop_3.4.2-stackable0.0.0-boost_zookeeper-latest-3.9.4_openshift-false (233.13s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.2,oci.stackable.tech_sdp_hadoop_3.4.2-stackable0.0.0-boost_zookeeper-3.9.4_zookeeper-latest-3.9.4_number-of-datanodes-2_datanode-pvcs-2hdd-1ssd_listener-class-external-unstable_openshift-false (194.18s)
        --- PASS: kuttl/harness/logging_hadoop-3.4.2,oci.stackable.tech_sdp_hadoop_3.4.2-stackable0.0.0-boost_zookeeper-latest-3.9.4_openshift-false (565.09s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.2,oci.stackable.tech_sdp_hadoop_3.4.2-stackable0.0.0-boost_zookeeper-3.9.4_zookeeper-latest-3.9.4_number-of-datanodes-2_datanode-pvcs-default_listener-class-external-unstable_openshift-false (205.07s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.2,oci.stackable.tech_sdp_hadoop_3.4.2-stackable0.0.0-boost_zookeeper-3.9.4_zookeeper-latest-3.9.4_number-of-datanodes-1_datanode-pvcs-default_listener-class-external-unstable_openshift-false (178.70s)
        --- FAIL: kuttl/harness/orphaned-resources_hadoop-latest-3.4.2,oci.stackable.tech_sdp_hadoop_3.4.2-stackable0.0.0-boost_zookeeper-latest-3.9.4_openshift-false (483.20s)
        --- PASS: kuttl/harness/topology-provider_hadoop-latest-3.4.2,oci.stackable.tech_sdp_hadoop_3.4.2-stackable0.0.0-boost_zookeeper-latest-3.9.4_krb5-1.21.1_kerberos-backend-mit_openshift-false (343.40s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.2,oci.stackable.tech_sdp_hadoop_3.4.2-stackable0.0.0-boost_zookeeper-3.9.4_zookeeper-latest-3.9.4_number-of-datanodes-1_datanode-pvcs-2hdd-1ssd_listener-class-cluster-internal_openshift-false (191.02s)
        --- PASS: kuttl/harness/kerberos_hadoop-3.4.2,oci.stackable.tech_sdp_hadoop_3.4.2-stackable0.0.0-boost_zookeeper-latest-3.9.4_krb5-1.21.1_opa-1.12.3_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-false (1366.23s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.2,oci.stackable.tech_sdp_hadoop_3.4.2-stackable0.0.0-boost_zookeeper-3.9.4_zookeeper-latest-3.9.4_number-of-datanodes-1_datanode-pvcs-default_listener-class-cluster-internal_openshift-false (174.42s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.2,oci.stackable.tech_sdp_hadoop_3.4.2-stackable0.0.0-boost_zookeeper-3.9.4_zookeeper-latest-3.9.4_number-of-datanodes-2_datanode-pvcs-2hdd-1ssd_listener-class-cluster-internal_openshift-false (976.60s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.2,oci.stackable.tech_sdp_hadoop_3.4.2-stackable0.0.0-boost_zookeeper-3.9.4_zookeeper-latest-3.9.4_number-of-datanodes-2_datanode-pvcs-default_listener-class-cluster-internal_openshift-false (224.92s)
        --- PASS: kuttl/harness/kerberos_hadoop-3.4.2,oci.stackable.tech_sdp_hadoop_3.4.2-stackable0.0.0-boost_zookeeper-latest-3.9.4_krb5-1.21.1_opa-1.12.3_kerberos-realm-CLUSTER.LOCAL_kerberos-backend-mit_openshift-false (1330.80s)
FAIL
ERROR:root:kuttl failed
```

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [x] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [x] Add an entry to the CHANGELOG.md file
- [x] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>