### PR TITLE
fix(vector): Use correct license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 - trino: Backport fix for wrong deletes in Delta Lake ([#1453]).
 - opensearch: Scope CycloneDX SBOM to shipped components only, eliminating false positive CVEs from unshipped plugins ([#1452]).
+- vector: Use correct license ([#1476]).
 
 [#1446]: https://github.com/stackabletech/docker-images/pull/1446
 [#1452]: https://github.com/stackabletech/docker-images/pull/1452
@@ -25,6 +26,7 @@ All notable changes to this project will be documented in this file.
 [#1463]: https://github.com/stackabletech/docker-images/pull/1463
 [#1466]: https://github.com/stackabletech/docker-images/pull/1466
 [#1474]: https://github.com/stackabletech/docker-images/pull/1474
+[#1476]: https://github.com/stackabletech/docker-images/pull/1476
 
 ## [26.3.0] - 2026-03-16
 

--- a/vector/Dockerfile
+++ b/vector/Dockerfile
@@ -126,7 +126,7 @@ ARG STACKABLE_USER_UID
 
 LABEL maintainer="Stackable GmbH"
 
-COPY --chown=${STACKABLE_USER_UID}:0 opa/licenses /licenses
+COPY --chown=${STACKABLE_USER_UID}:0 vector/licenses /licenses
 COPY --from=vector-builder --chown=${STACKABLE_USER_UID}:0 /app/* /usr/local/bin/
 
 # Init Jobs/Pods often start a Vector Sidecar Container which collects the logs.


### PR DESCRIPTION
I had inadvertently copied the wrong license into the vector image since building it from source.