### PR TITLE
Backport "Added patch for HDFS-17891 on Hadoop 3.4.2"

### DIFF
--- a/hadoop/hadoop/stackable/patches/3.4.2/0009-HDFS-17891-fix-for-hostname-resolution-bug-with-data.patch
+++ b/hadoop/hadoop/stackable/patches/3.4.2/0009-HDFS-17891-fix-for-hostname-resolution-bug-with-data.patch
@@ -1,0 +1,48 @@
+From cb5487dcd3e6e170014604478a3d8cef03285007 Mon Sep 17 00:00:00 2001
+From: Jim Halfpenny <jim.halfpenny@stackable.tech>
+Date: Mon, 16 Mar 2026 09:18:46 +0000
+Subject: HDFS-17891 fix for hostname resolution bug with datanodes
+
+---
+ .../hadoop/hdfs/server/blockmanagement/HostSet.java   | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/HostSet.java b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/HostSet.java
+index d12e5fbae1..3da753f1cb 100644
+--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/HostSet.java
++++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/HostSet.java
+@@ -18,10 +18,11 @@
+ package org.apache.hadoop.hdfs.server.blockmanagement;
+ 
+ 
+-import org.apache.hadoop.util.Preconditions;
+ import org.apache.hadoop.thirdparty.com.google.common.collect.HashMultimap;
+ import org.apache.hadoop.thirdparty.com.google.common.collect.Multimap;
+ import org.apache.hadoop.thirdparty.com.google.common.collect.UnmodifiableIterator;
++import org.slf4j.Logger;
++import org.slf4j.LoggerFactory;
+ 
+ import java.net.InetAddress;
+ import java.net.InetSocketAddress;
+@@ -38,6 +39,8 @@
+  * .getPort() || B.getPort() == 0.
+  */
+ public class HostSet implements Iterable<InetSocketAddress> {
++  private static final Logger LOG = LoggerFactory.getLogger(HostSet.class);
++
+   // Host -> lists of ports
+   private final Multimap<InetAddress, Integer> addrs = HashMultimap.create();
+ 
+@@ -72,7 +75,11 @@ int size() {
+   }
+ 
+   void add(InetSocketAddress addr) {
+-    Preconditions.checkArgument(!addr.isUnresolved());
++  LOG.debug("Adding address to HostSet: {}", addr);
++     if (addr.isUnresolved()) {
++      LOG.warn("Unresolved address not added to HostSet: {}", addr);
++     return;
++    }
+     addrs.put(addr.getAddress(), addr.getPort());
+   }
+ 


### PR DESCRIPTION
# Description

Backports https://github.com/stackabletech/docker-images/commit/c8bae3760f9f545c29223c45baef743dec1ecf9e to SDP 26.3.x

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [x] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
