### PR TITLE
feat(vector): Bump to 0.55.0

### DIFF
--- a/airflow/boil-config.toml
+++ b/airflow/boil-config.toml
@@ -4,7 +4,7 @@
 # Deprecated since SDP 25.11
 [versions."2.9.3".local-images]
 "shared/statsd-exporter" = "0.28.0"
-vector = "0.52.0"
+vector = "0.55.0"
 stackable-devel = "1.0.0"
 
 [versions."2.9.3".build-arguments]
@@ -21,7 +21,7 @@ nodejs-version = "20"
 # LTS
 [versions."3.0.6".local-images]
 "shared/statsd-exporter" = "0.28.0"
-vector = "0.52.0"
+vector = "0.55.0"
 stackable-devel = "1.0.0"
 
 [versions."3.0.6".build-arguments]
@@ -57,7 +57,7 @@ nodejs-version = "20"
 # Supported
 [versions."3.1.6".local-images]
 "shared/statsd-exporter" = "0.28.0"
-vector = "0.52.0"
+vector = "0.55.0"
 stackable-devel = "1.0.0"
 
 [versions."3.1.6".build-arguments]

--- a/java-base/boil-config.toml
+++ b/java-base/boil-config.toml
@@ -1,17 +1,17 @@
 [versions."8".local-images]
-vector = "0.52.0"
+vector = "0.55.0"
 
 [versions."11".local-images]
-vector = "0.52.0"
+vector = "0.55.0"
 
 [versions."17".local-images]
-vector = "0.52.0"
+vector = "0.55.0"
 
 [versions."21".local-images]
-vector = "0.52.0"
+vector = "0.55.0"
 
 [versions."24".local-images]
-vector = "0.52.0"
+vector = "0.55.0"
 
 [versions."25".local-images]
-vector = "0.52.0"
+vector = "0.55.0"

--- a/jdk-base/boil-config.toml
+++ b/jdk-base/boil-config.toml
@@ -1,5 +1,5 @@
 [versions."21".local-images]
-vector = "0.52.0"
+vector = "0.55.0"
 
 [versions."24".local-images]
-vector = "0.52.0"
+vector = "0.55.0"

--- a/opa/boil-config.toml
+++ b/opa/boil-config.toml
@@ -4,7 +4,7 @@
 # Version 1.8.0
 [versions."1.8.0".local-images]
 stackable-devel = "1.0.0"
-vector = "0.52.0"
+vector = "0.55.0"
 
 [versions."1.8.0".build-arguments]
 golang-version = "1.24.6"
@@ -12,7 +12,7 @@ golang-version = "1.24.6"
 # Version 1.12.3
 [versions."1.12.3".local-images]
 stackable-devel = "1.0.0"
-vector = "0.52.0"
+vector = "0.55.0"
 
 [versions."1.12.3".build-arguments]
 golang-version = "1.24.6"

--- a/opensearch-dashboards/boil-config.toml
+++ b/opensearch-dashboards/boil-config.toml
@@ -3,7 +3,7 @@
 
 [versions."3.1.0".local-images]
 stackable-devel = "1.0.0"
-vector = "0.52.0"
+vector = "0.55.0"
 "opensearch-dashboards/alerting-dashboards-plugin" = "3.1.0.0"
 "opensearch-dashboards/anomaly-detection-dashboards-plugin" = "3.1.0.0"
 "opensearch-dashboards/dashboards-assistant" = "3.1.0.0"
@@ -44,7 +44,7 @@ stackable-devel = "1.0.0"
 "opensearch-dashboards/security-analytics-dashboards-plugin" = "3.4.0.0"
 "opensearch-dashboards/security-dashboards-plugin" = "3.4.0.0"
 "opensearch-dashboards/opensearch-build" = "3.4.0"
-"vector" = "0.52.0"
+"vector" = "0.55.0"
 
 [versions."3.4.0".build-arguments]
 nodejs-version = "20.19.6"

--- a/superset/boil-config.toml
+++ b/superset/boil-config.toml
@@ -4,7 +4,7 @@
 [versions."4.1.4".local-images]
 "shared/statsd-exporter" = "0.28.0"
 stackable-devel = "1.0.0"
-vector = "0.52.0"
+vector = "0.55.0"
 
 [versions."4.1.4".build-arguments]
 cyclonedx-bom-version = "6.0.0"
@@ -19,7 +19,7 @@ nvm-version = "v0.40.4"
 [versions."6.0.0".local-images]
 "shared/statsd-exporter" = "0.28.0"
 stackable-devel = "1.0.0"
-vector = "0.52.0"
+vector = "0.55.0"
 
 [versions."6.0.0".build-arguments]
 cyclonedx-bom-version = "6.0.0"

--- a/vector/boil-config.toml
+++ b/vector/boil-config.toml
@@ -1,13 +1,13 @@
 [metadata.registries]
 "oci.stackable.tech" = { namespace = "sdp" }
 
-[versions."0.52.0".local-images]
+[versions."0.55.0".local-images]
 # We need to point to a special version of stackable-devel which will have the
 # correct toolchain to build vector.
 stackable-devel = "vector-build"
 stackable-base = "1.0.0"
 
-[versions."0.52.0".build-arguments]
+[versions."0.55.0".build-arguments]
 # See .scripts/upload_new_protoc_version.sh
 # Unsure which version is used by vector. They seem to install `buf` in workflows.
 protoc-version = "31.1"

--- a/vector/stackable/patches/0.55.0/patchable.toml
+++ b/vector/stackable/patches/0.55.0/patchable.toml
@@ -1,2 +1,2 @@
 mirror = "https://github.com/stackabletech/vector.git"
-base = "ca5bf2690ffcfc2c95d320cf7156b1df1b28a080"
+base = "cf8de830c6060629092397fd2334fc0f0219363a"


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1486.

Replace vector 0.52.0 with 0.55.0