### PR TITLE
feat(testing-tools): Add grpcurl utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - nifi: Add version `2.9.0` ([#1463]).
 - nifi: Backport NIFI-15801 to 2.x versions ([#1481]).
 - nifi: Backport NIFI-15901 to 2.x versions ([#1481]).
+- testing-tools: Added grpcurl utility ([#1493]).
 
 ### Changed
 
@@ -32,6 +33,7 @@ All notable changes to this project will be documented in this file.
 [#1474]: https://github.com/stackabletech/docker-images/pull/1474
 [#1476]: https://github.com/stackabletech/docker-images/pull/1476
 [#1481]: https://github.com/stackabletech/docker-images/pull/1481
+[#1493]: https://github.com/stackabletech/docker-images/pull/1493
 
 ## [26.3.0] - 2026-03-16
 

--- a/testing-tools/Dockerfile
+++ b/testing-tools/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.16.0@sha256:e2dd261f92e4b763d789984f6eab84be66ab4f5f08052316d8eb8f173593acf7
 # check=error=true
 
+ARG GRPCURL_VERSION
+FROM fullstorydev/grpcurl:v${GRPCURL_VERSION} AS grpcurl
+
 # Find the latest version at https://catalog.redhat.com/en/software/containers/ubi10/ubi-minimal/66f1504a379b9c2cf23e145c#get-this-image
 # IMPORTANT: Make sure to use the "Manifest List Digest" that references the images for multiple architectures
 # rather than just the "Image Digest" that references the image for the selected architecture.
@@ -43,6 +46,10 @@ COPY stackable-base/stackable/curlrc /root/.curlrc
 # Base requirements for all testing-tools images
 COPY testing-tools/requirements.txt /stackable/requirements.txt
 COPY testing-tools/licenses /licenses
+
+# Required for interacting with the Vcetor Aggregator gRPC endpoint
+# TODO: Use the caching proxy, or mirror the image.
+COPY --from=grpcurl /bin/grpcurl /bin/grpcurl
 
 RUN <<EOF
 microdnf update

--- a/testing-tools/boil-config.toml
+++ b/testing-tools/boil-config.toml
@@ -4,3 +4,4 @@
 [versions."0.3.0".build-arguments]
 kubectl-version = "1.35.0"
 python-version = "3.12"
+grpcurl-version = "1.9.3"


### PR DESCRIPTION
This is needed by Vector Aggregator now that the `/graphql` endpoint is gone

See https://github.com/stackabletech/decisions/issues/87