### PR TITLE
ci: Add publish-to-quay toggle

### DIFF
--- a/.github/workflows/build_spark-connect-client.yaml
+++ b/.github/workflows/build_spark-connect-client.yaml
@@ -42,3 +42,4 @@ jobs:
       # Since building Vector from source, this build runs out of disk space.
       # As such, we use the Ubicloud runners which provide bigger disks.
       runners: ubicloud
+      push-to-quay: false

--- a/.github/workflows/build_spark-connect-client.yaml
+++ b/.github/workflows/build_spark-connect-client.yaml
@@ -42,4 +42,4 @@ jobs:
       # Since building Vector from source, this build runs out of disk space.
       # As such, we use the Ubicloud runners which provide bigger disks.
       runners: ubicloud
-      push-to-quay: false
+      publish-to-quay: false

--- a/.github/workflows/reusable_build_image.yaml
+++ b/.github/workflows/reusable_build_image.yaml
@@ -26,13 +26,17 @@ on:
           - `ubicloud`: Both the x86_64 and the aarch64 builds run on the Ubicloud runners
         default: mixed
         type: string
+      push-to-quay:
+        description: |
+          Whether to push to quay.io or not. If `true`, the `quay-robot-secret` needs to be provided.
+        type: boolean
+        default: true
     secrets:
       harbor-robot-secret:
         description: The secret for the Harbor robot user used to push images and manifest
         required: true
       quay-robot-secret:
         description: The secret for the Quay.io robot user used to push images and manifest
-        required: true
       slack-token:
         description: The Slack token used to post failure notifications
         required: true
@@ -133,6 +137,7 @@ jobs:
           source-image-uri: localhost/${{ inputs.registry-namespace }}/${{ inputs.product-name }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on quay.io
+        if: inputs.push-to-quay
         uses: stackabletech/actions/publish-image@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
         with:
           image-registry-uri: quay.io
@@ -179,6 +184,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ inputs.sdp-version }}
 
       - name: Publish and Sign Image Index Manifest to quay.io
+        if: inputs.push-to-quay
         uses: stackabletech/actions/publish-image-index-manifest@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
         with:
           image-registry-uri: quay.io

--- a/.github/workflows/reusable_build_image.yaml
+++ b/.github/workflows/reusable_build_image.yaml
@@ -26,9 +26,10 @@ on:
           - `ubicloud`: Both the x86_64 and the aarch64 builds run on the Ubicloud runners
         default: mixed
         type: string
-      push-to-quay:
+      publish-to-quay:
         description: |
-          Whether to push to quay.io or not. If `true`, the `quay-robot-secret` needs to be provided.
+          Whether to publish to quay.io or not. If `true`, the `quay-robot-secret` needs to be
+          provided.
         type: boolean
         default: true
     secrets:
@@ -137,7 +138,7 @@ jobs:
           source-image-uri: localhost/${{ inputs.registry-namespace }}/${{ inputs.product-name }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on quay.io
-        if: inputs.push-to-quay
+        if: inputs.publish-to-quay
         uses: stackabletech/actions/publish-image@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
         with:
           image-registry-uri: quay.io
@@ -184,7 +185,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ inputs.sdp-version }}
 
       - name: Publish and Sign Image Index Manifest to quay.io
-        if: inputs.push-to-quay
+        if: inputs.publish-to-quay
         uses: stackabletech/actions/publish-image-index-manifest@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
         with:
           image-registry-uri: quay.io


### PR DESCRIPTION
This came up after merging #1492.

We consider this an "internal" image and as such don't see the need to publish it to quay. As such, this PR introduces a toggle which controls if images should be published to quay.io or not.

Test CI run: https://github.com/stackabletech/docker-images/actions/runs/26226133632