### PR TITLE
ci: Bump actions off Node.js 20

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -60,7 +60,7 @@ jobs:
           echo "IMAGE_REPOSITORY=$(.scripts/get_repo_name.sh)" | tee -a "$GITHUB_ENV"
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
+        uses: stackabletech/actions/publish-image@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -88,7 +88,7 @@ jobs:
           echo "IMAGE_REPOSITORY=$(.scripts/get_repo_name.sh)" | tee -a "$GITHUB_ENV"
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-image-index-manifest@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
+        uses: stackabletech/actions/publish-image-index-manifest@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build

--- a/.github/workflows/pr_pre-commit.yaml
+++ b/.github/workflows/pr_pre-commit.yaml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - uses: stackabletech/actions/run-pre-commit@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
+      - uses: stackabletech/actions/run-pre-commit@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           rust: ${{ env.RUST_TOOLCHAIN_VERSION }}

--- a/.github/workflows/reusable_build_image.yaml
+++ b/.github/workflows/reusable_build_image.yaml
@@ -79,7 +79,7 @@ jobs:
           persist-credentials: false
 
       - id: shard
-        uses: stackabletech/actions/shard@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
+        uses: stackabletech/actions/shard@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
         with:
           product-name: ${{ inputs.product-name }}
     outputs:
@@ -106,11 +106,11 @@ jobs:
           persist-credentials: false
 
       - name: Free Disk Space
-        uses: stackabletech/actions/free-disk-space@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
+        uses: stackabletech/actions/free-disk-space@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
+        uses: stackabletech/actions/build-product-image@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
         with:
           registry-namespace: ${{ inputs.registry-namespace }}
           product-name: ${{ inputs.product-name }}
@@ -118,7 +118,7 @@ jobs:
           sdp-version: ${{ inputs.sdp-version }}
 
       - name: Publish Container Image on oci.stackable.tech
-        uses: stackabletech/actions/publish-image@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
+        uses: stackabletech/actions/publish-image@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$${{ inputs.registry-namespace }}+github-action-build
@@ -133,7 +133,7 @@ jobs:
           source-image-uri: localhost/${{ inputs.registry-namespace }}/${{ inputs.product-name }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on quay.io
-        uses: stackabletech/actions/publish-image@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
+        uses: stackabletech/actions/publish-image@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
         with:
           image-registry-uri: quay.io
           image-registry-username: stackable+robot_${{ inputs.registry-namespace }}_github_action_build
@@ -165,7 +165,7 @@ jobs:
           persist-credentials: false
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-image-index-manifest@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
+        uses: stackabletech/actions/publish-image-index-manifest@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$${{ inputs.registry-namespace }}+github-action-build
@@ -179,7 +179,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ inputs.sdp-version }}
 
       - name: Publish and Sign Image Index Manifest to quay.io
-        uses: stackabletech/actions/publish-image-index-manifest@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
+        uses: stackabletech/actions/publish-image-index-manifest@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
         with:
           image-registry-uri: quay.io
           image-registry-username: stackable+robot_${{ inputs.registry-namespace }}_github_action_build
@@ -201,7 +201,7 @@ jobs:
     if: failure() || (github.run_attempt > 1 && !cancelled())
     steps:
       - name: Send Notification
-        uses: stackabletech/actions/send-slack-notification@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
+        uses: stackabletech/actions/send-slack-notification@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
         with:
           publish-manifests-result: ${{ needs.publish_manifests.result }}
           build-result: ${{ needs.build.result }}

--- a/.github/workflows/ubi-rust-builder.yml
+++ b/.github/workflows/ubi-rust-builder.yml
@@ -40,7 +40,7 @@ jobs:
           persist-credentials: false
 
       - name: Login to Stackable Harbor
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: oci.stackable.tech
           username: robot$sdp+github-action-build
@@ -92,7 +92,7 @@ jobs:
           persist-credentials: false
 
       - name: Login to Stackable Harbor
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: oci.stackable.tech
           username: robot$sdp+github-action-build

--- a/.github/workflows/ubi-rust-builder.yml
+++ b/.github/workflows/ubi-rust-builder.yml
@@ -123,7 +123,7 @@ jobs:
     if: failure() || (github.run_attempt > 1 && !cancelled())
     steps:
       - name: Send Notification
-        uses: stackabletech/actions/send-slack-notification@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
+        uses: stackabletech/actions/send-slack-notification@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
         with:
           publish-manifests-result: ${{ needs.publish_manifests.result }}
           build-result: ${{ needs.build.result }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - hbase: Update `hbase-opa-authorizer` from `0.1.0` to `0.2.0` and then `0.3.0` ([#1446], [#1454]).
+- ci: Bump `docker/login-action` from `v3.6.0` to `v4.1.0` to escape Node.js 20 deprecation ([#1507]).
 
 ### Fixed
 
@@ -32,6 +33,7 @@ All notable changes to this project will be documented in this file.
 [#1474]: https://github.com/stackabletech/docker-images/pull/1474
 [#1476]: https://github.com/stackabletech/docker-images/pull/1476
 [#1481]: https://github.com/stackabletech/docker-images/pull/1481
+[#1507]: https://github.com/stackabletech/docker-images/pull/1507
 
 ## [26.3.0] - 2026-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - hbase: Update `hbase-opa-authorizer` from `0.1.0` to `0.2.0` and then `0.3.0` ([#1446], [#1454]).
-- ci: Bump `docker/login-action` from `v3.6.0` to `v4.1.0` to escape Node.js 20 deprecation ([#1507]).
+- ci: Bump `docker/login-action` from `v3.6.0` to `v4.1.0` and `stackabletech/actions` to `v0.14.3` to escape Node.js 20 deprecation ([#1507]).
 
 ### Fixed
 


### PR DESCRIPTION
# Description
We should probably merge https://github.com/stackabletech/actions/pull/105 first and then bump the actions here as well.

We'll soon be affected by this (see the warnings in [this PR run](https://github.com/stackabletech/docker-images/actions/runs/26222422201/job/77160580606#annotation:13:2) for example):
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: anchore/sbom-action/download-syft@0b82b0b1a22399a1c542d4d656f70cd903571b5c, docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef, docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

This bumps `docker/login-action` from v3.6.0 to v4.1.0 to get off Node.js 20 before the GitHub Actions runner deprecation.

I checked the changelog for breaking changes, didn't spot anything that would affect us.

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [x] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
