### PR TITLE
feat: Add OPA 1.16.2, remove 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - nifi: Add version `2.9.0` ([#1463]).
 - nifi: Backport NIFI-15801 to 2.x versions ([#1481]).
 - nifi: Backport NIFI-15901 to 2.x versions ([#1481]).
-- opa: Add `1.16.2` ([#XXXX]).
+- opa: Add `1.16.2` ([#1509]).
 
 ### Changed
 
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 
-- opa: Remove `1.8.0` ([#XXXX]).
+- opa: Remove `1.8.0` ([#1509]).
 
 [#1446]: https://github.com/stackabletech/docker-images/pull/1446
 [#1452]: https://github.com/stackabletech/docker-images/pull/1452
@@ -37,7 +37,7 @@ All notable changes to this project will be documented in this file.
 [#1474]: https://github.com/stackabletech/docker-images/pull/1474
 [#1476]: https://github.com/stackabletech/docker-images/pull/1476
 [#1481]: https://github.com/stackabletech/docker-images/pull/1481
-[#XXXX]: https://github.com/stackabletech/docker-images/pull/XXXX
+[#1509]: https://github.com/stackabletech/docker-images/pull/1509
 
 ## [26.3.0] - 2026-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - nifi: Add version `2.9.0` ([#1463]).
 - nifi: Backport NIFI-15801 to 2.x versions ([#1481]).
 - nifi: Backport NIFI-15901 to 2.x versions ([#1481]).
+- opa: Add `1.16.2` ([#XXXX]).
 
 ### Changed
 
@@ -22,6 +23,10 @@ All notable changes to this project will be documented in this file.
 - vector: Look for SBOM in correct location ([#1471]).
 - vector: Use correct license ([#1476]).
 
+### Removed
+
+- opa: Remove `1.8.0` ([#XXXX]).
+
 [#1446]: https://github.com/stackabletech/docker-images/pull/1446
 [#1452]: https://github.com/stackabletech/docker-images/pull/1452
 [#1453]: https://github.com/stackabletech/docker-images/pull/1453
@@ -32,6 +37,7 @@ All notable changes to this project will be documented in this file.
 [#1474]: https://github.com/stackabletech/docker-images/pull/1474
 [#1476]: https://github.com/stackabletech/docker-images/pull/1476
 [#1481]: https://github.com/stackabletech/docker-images/pull/1481
+[#XXXX]: https://github.com/stackabletech/docker-images/pull/XXXX
 
 ## [26.3.0] - 2026-03-16
 

--- a/opa/boil-config.toml
+++ b/opa/boil-config.toml
@@ -1,18 +1,18 @@
 [metadata.registries]
 "oci.stackable.tech" = { namespace = "sdp" }
 
-# Version 1.8.0
-[versions."1.8.0".local-images]
-stackable-devel = "1.0.0"
-vector = "0.55.0"
-
-[versions."1.8.0".build-arguments]
-golang-version = "1.24.6"
-
 # Version 1.12.3
 [versions."1.12.3".local-images]
 stackable-devel = "1.0.0"
 vector = "0.55.0"
 
 [versions."1.12.3".build-arguments]
-golang-version = "1.24.6"
+golang-version = "1.26.0"
+
+# Version 1.16.2
+[versions."1.16.2".local-images]
+stackable-devel = "1.0.0"
+vector = "0.55.0"
+
+[versions."1.16.2".build-arguments]
+golang-version = "1.26.0"

--- a/opa/stackable/patches/1.16.2/patchable.toml
+++ b/opa/stackable/patches/1.16.2/patchable.toml
@@ -1,0 +1,2 @@
+mirror = "https://github.com/stackabletech/opa.git"
+base = "85f6d990d19094da38e829561813e7da7fbae272"

--- a/opa/stackable/patches/1.8.0/patchable.toml
+++ b/opa/stackable/patches/1.8.0/patchable.toml
@@ -1,2 +1,0 @@
-mirror = "https://github.com/stackabletech/opa.git"
-base = "78328267fb3fa8aef7d73894ccce05302723daa0"


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/docker-images/issues/1499

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
