### PR TITLE
fix(trino): Backport airlift/airlift#1943 for max response header size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to this project will be documented in this file.
 - opensearch: Scope CycloneDX SBOM to shipped components only, eliminating false positive CVEs from unshipped plugins ([#1452]).
 - vector: Look for SBOM in correct location ([#1471]).
 - vector: Use correct license ([#1476]).
-- trino: Build a patched Airlift from source and depend on it to backport [airlift/airlift#1943](https://github.com/airlift/airlift/pull/1943), applying the configured max response header size to Jetty's `maxResponseHeaderSize` ([#XXXX]).
+- trino: Build a patched Airlift from source and depend on it to backport [airlift/airlift#1943](https://github.com/airlift/airlift/pull/1943), applying the configured max response header size to Jetty's `maxResponseHeaderSize` ([#1510]).
 
 [#1446]: https://github.com/stackabletech/docker-images/pull/1446
 [#1452]: https://github.com/stackabletech/docker-images/pull/1452
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file.
 [#1474]: https://github.com/stackabletech/docker-images/pull/1474
 [#1476]: https://github.com/stackabletech/docker-images/pull/1476
 [#1481]: https://github.com/stackabletech/docker-images/pull/1481
-[#XXXX]: https://github.com/stackabletech/docker-images/pull/XXXX
+[#1510]: https://github.com/stackabletech/docker-images/pull/1510
 
 ## [26.3.0] - 2026-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - opensearch: Scope CycloneDX SBOM to shipped components only, eliminating false positive CVEs from unshipped plugins ([#1452]).
 - vector: Look for SBOM in correct location ([#1471]).
 - vector: Use correct license ([#1476]).
+- trino: Build a patched Airlift from source and depend on it to backport [airlift/airlift#1943](https://github.com/airlift/airlift/pull/1943), applying the configured max response header size to Jetty's `maxResponseHeaderSize` ([#XXXX]).
 
 [#1446]: https://github.com/stackabletech/docker-images/pull/1446
 [#1452]: https://github.com/stackabletech/docker-images/pull/1452
@@ -32,6 +33,7 @@ All notable changes to this project will be documented in this file.
 [#1474]: https://github.com/stackabletech/docker-images/pull/1474
 [#1476]: https://github.com/stackabletech/docker-images/pull/1476
 [#1481]: https://github.com/stackabletech/docker-images/pull/1481
+[#XXXX]: https://github.com/stackabletech/docker-images/pull/XXXX
 
 ## [26.3.0] - 2026-03-16
 

--- a/trino/airlift/Dockerfile
+++ b/trino/airlift/Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1.16.0@sha256:e2dd261f92e4b763d789984f6eab84be66ab4f5f08052316d8eb8f173593acf7
+# check=error=true
+
+# We use a custom patched airlift version to fast track https://github.com/airlift/airlift/pull/1943
+# This can be removed once the PR is merged and Trino makes use of the new Airlift version containing the fix
+
+FROM local-image/java-devel AS airlift-builder
+
+ARG PRODUCT_VERSION
+ARG RELEASE_VERSION
+ARG STACKABLE_USER_UID
+
+WORKDIR /stackable
+
+COPY --chown=${STACKABLE_USER_UID}:0 trino/airlift/stackable/patches/patchable.toml /stackable/src/trino/airlift/stackable/patches/patchable.toml
+COPY --chown=${STACKABLE_USER_UID}:0 trino/airlift/stackable/patches/${PRODUCT_VERSION} /stackable/src/trino/airlift/stackable/patches/${PRODUCT_VERSION}
+
+# hadolint ignore=SC2215
+RUN --mount=type=cache,id=maven-airlift-${PRODUCT_VERSION},target=/root/.m2/repository <<EOF
+cd "$(/stackable/patchable --images-repo-root=src checkout trino/airlift ${PRODUCT_VERSION})"
+
+NEW_VERSION="${PRODUCT_VERSION}-stackable${RELEASE_VERSION}"
+
+mvn versions:set -DnewVersion=$NEW_VERSION -DartifactId='*' -DgroupId='*' -DgenerateBackupPoms=false
+
+mvn \
+  install \
+  -DskipTests \
+  -Dair.check.skip-all \
+  -Dcheckstyle.skip \
+  -Dmaven.javadoc.skip=true \
+  -Dmaven.gitcommitid.skip=true \
+  --projects='!sample-server,!skeleton-server'
+
+mkdir -p /stackable/patched-libs/maven/io
+cp -r /root/.m2/repository/io/airlift /stackable/patched-libs/maven/io
+
+chmod --recursive g=u /stackable/patched-libs
+EOF

--- a/trino/airlift/boil-config.toml
+++ b/trino/airlift/boil-config.toml
@@ -1,0 +1,5 @@
+[versions."361".local-images]
+java-devel = "24"
+
+[versions."386".local-images]
+java-devel = "25"

--- a/trino/airlift/stackable/patches/361/0001-Apply-max-response-header-size-to-Jetty-maxResponseH.patch
+++ b/trino/airlift/stackable/patches/361/0001-Apply-max-response-header-size-to-Jetty-maxResponseH.patch
@@ -1,24 +1,35 @@
-From 1c8349ce1ce8397896db17aca28661a2b4fb1e4f Mon Sep 17 00:00:00 2001
-From: dervoeti <lukas.krug@stackable.tech>
-Date: Mon, 25 May 2026 15:25:18 +0200
+From 679fd94b89dbb51c704a7602b94e9d492d7c1a8f Mon Sep 17 00:00:00 2001
+From: Lukas Krug <lukas@luvosys.de>
+Date: Wed, 27 May 2026 21:58:48 +0200
 Subject: Apply max response header size to Jetty maxResponseHeaderSize
 
 ---
- .../src/main/java/io/airlift/http/server/HttpServer.java      | 4 +++-
- 1 file changed, 3 insertions(+), 1 deletion(-)
+ .../src/main/java/io/airlift/http/server/HttpServer.java        | 2 +-
+ .../src/main/java/io/airlift/http/server/HttpServerConfig.java  | 1 +
+ 2 files changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/http-server/src/main/java/io/airlift/http/server/HttpServer.java b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
-index 6da8193eb..d43d795e7 100644
+index 6da8193ebe..5a8f4009bf 100644
 --- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
 +++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
-@@ -193,7 +193,9 @@ public class HttpServer
+@@ -193,7 +193,7 @@ public class HttpServer
              baseHttpConfiguration.setRequestHeaderSize(toIntExact(config.getMaxRequestHeaderSize().toBytes()));
          }
          if (config.getMaxResponseHeaderSize() != null) {
 -            baseHttpConfiguration.setResponseHeaderSize(toIntExact(config.getMaxResponseHeaderSize().toBytes()));
-+            int maxResponseHeaderSizeBytes = toIntExact(config.getMaxResponseHeaderSize().toBytes());
-+            baseHttpConfiguration.setResponseHeaderSize(maxResponseHeaderSizeBytes);
-+            baseHttpConfiguration.setMaxResponseHeaderSize(maxResponseHeaderSizeBytes);
++            baseHttpConfiguration.setMaxResponseHeaderSize(toIntExact(config.getMaxResponseHeaderSize().toBytes()));
          }
          if (config.getOutputBufferSize() != null) {
              baseHttpConfiguration.setOutputBufferSize(toIntExact(config.getOutputBufferSize().toBytes()));
+diff --git a/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java b/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
+index c4ebbdf9d3..760f72347a 100644
+--- a/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
++++ b/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
+@@ -372,6 +372,7 @@ public class HttpServerConfig
+         return this;
+     }
+ 
++    @MaxDataSize("1GB")
+     public DataSize getMaxResponseHeaderSize()
+     {
+         return maxResponseHeaderSize;

--- a/trino/airlift/stackable/patches/361/0001-Apply-max-response-header-size-to-Jetty-maxResponseH.patch
+++ b/trino/airlift/stackable/patches/361/0001-Apply-max-response-header-size-to-Jetty-maxResponseH.patch
@@ -1,5 +1,5 @@
-From 679fd94b89dbb51c704a7602b94e9d492d7c1a8f Mon Sep 17 00:00:00 2001
-From: Lukas Krug <lukas@luvosys.de>
+From 846dafacf01735c4eb507959f7b9456d8fe8ebdc Mon Sep 17 00:00:00 2001
+From: Lukas Krug <lukas.krug@stackable.tech>
 Date: Wed, 27 May 2026 21:58:48 +0200
 Subject: Apply max response header size to Jetty maxResponseHeaderSize
 

--- a/trino/airlift/stackable/patches/361/0001-Apply-max-response-header-size-to-Jetty-maxResponseH.patch
+++ b/trino/airlift/stackable/patches/361/0001-Apply-max-response-header-size-to-Jetty-maxResponseH.patch
@@ -1,0 +1,24 @@
+From 1c8349ce1ce8397896db17aca28661a2b4fb1e4f Mon Sep 17 00:00:00 2001
+From: dervoeti <lukas.krug@stackable.tech>
+Date: Mon, 25 May 2026 15:25:18 +0200
+Subject: Apply max response header size to Jetty maxResponseHeaderSize
+
+---
+ .../src/main/java/io/airlift/http/server/HttpServer.java      | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/http-server/src/main/java/io/airlift/http/server/HttpServer.java b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+index 6da8193eb..d43d795e7 100644
+--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
++++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+@@ -193,7 +193,9 @@ public class HttpServer
+             baseHttpConfiguration.setRequestHeaderSize(toIntExact(config.getMaxRequestHeaderSize().toBytes()));
+         }
+         if (config.getMaxResponseHeaderSize() != null) {
+-            baseHttpConfiguration.setResponseHeaderSize(toIntExact(config.getMaxResponseHeaderSize().toBytes()));
++            int maxResponseHeaderSizeBytes = toIntExact(config.getMaxResponseHeaderSize().toBytes());
++            baseHttpConfiguration.setResponseHeaderSize(maxResponseHeaderSizeBytes);
++            baseHttpConfiguration.setMaxResponseHeaderSize(maxResponseHeaderSizeBytes);
+         }
+         if (config.getOutputBufferSize() != null) {
+             baseHttpConfiguration.setOutputBufferSize(toIntExact(config.getOutputBufferSize().toBytes()));

--- a/trino/airlift/stackable/patches/361/patchable.toml
+++ b/trino/airlift/stackable/patches/361/patchable.toml
@@ -1,0 +1,2 @@
+mirror = "https://github.com/stackabletech/airlift.git"
+base = "69314d3f2d3a72533704b8ef08d68b23875c5513"

--- a/trino/airlift/stackable/patches/386/0001-Apply-max-response-header-size-to-Jetty-maxResponseH.patch
+++ b/trino/airlift/stackable/patches/386/0001-Apply-max-response-header-size-to-Jetty-maxResponseH.patch
@@ -1,5 +1,5 @@
-From 75075dd681a97e7901f1a889c02c6049bfe1b733 Mon Sep 17 00:00:00 2001
-From: Lukas Krug <lukas@luvosys.de>
+From 359fe4dbf5154df20701cea742177bd874949009 Mon Sep 17 00:00:00 2001
+From: Lukas Krug <lukas.krug@stackable.tech>
 Date: Wed, 27 May 2026 21:58:48 +0200
 Subject: Apply max response header size to Jetty maxResponseHeaderSize
 

--- a/trino/airlift/stackable/patches/386/0001-Apply-max-response-header-size-to-Jetty-maxResponseH.patch
+++ b/trino/airlift/stackable/patches/386/0001-Apply-max-response-header-size-to-Jetty-maxResponseH.patch
@@ -1,0 +1,24 @@
+From c3efb84821ee56d72dab45373d316c854583f351 Mon Sep 17 00:00:00 2001
+From: dervoeti <lukas.krug@stackable.tech>
+Date: Mon, 25 May 2026 15:25:18 +0200
+Subject: Apply max response header size to Jetty maxResponseHeaderSize
+
+---
+ .../src/main/java/io/airlift/http/server/HttpServer.java      | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/http-server/src/main/java/io/airlift/http/server/HttpServer.java b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+index 49a7de937..390255320 100644
+--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
++++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+@@ -204,7 +204,9 @@ public class HttpServer
+             baseHttpConfiguration.setRequestHeaderSize(toIntExact(config.getMaxRequestHeaderSize().toBytes()));
+         }
+         if (config.getMaxResponseHeaderSize() != null) {
+-            baseHttpConfiguration.setResponseHeaderSize(toIntExact(config.getMaxResponseHeaderSize().toBytes()));
++            int maxResponseHeaderSizeBytes = toIntExact(config.getMaxResponseHeaderSize().toBytes());
++            baseHttpConfiguration.setResponseHeaderSize(maxResponseHeaderSizeBytes);
++            baseHttpConfiguration.setMaxResponseHeaderSize(maxResponseHeaderSizeBytes);
+         }
+         if (config.getOutputBufferSize() != null) {
+             baseHttpConfiguration.setOutputBufferSize(toIntExact(config.getOutputBufferSize().toBytes()));

--- a/trino/airlift/stackable/patches/386/0001-Apply-max-response-header-size-to-Jetty-maxResponseH.patch
+++ b/trino/airlift/stackable/patches/386/0001-Apply-max-response-header-size-to-Jetty-maxResponseH.patch
@@ -1,24 +1,35 @@
-From c3efb84821ee56d72dab45373d316c854583f351 Mon Sep 17 00:00:00 2001
-From: dervoeti <lukas.krug@stackable.tech>
-Date: Mon, 25 May 2026 15:25:18 +0200
+From 75075dd681a97e7901f1a889c02c6049bfe1b733 Mon Sep 17 00:00:00 2001
+From: Lukas Krug <lukas@luvosys.de>
+Date: Wed, 27 May 2026 21:58:48 +0200
 Subject: Apply max response header size to Jetty maxResponseHeaderSize
 
 ---
- .../src/main/java/io/airlift/http/server/HttpServer.java      | 4 +++-
- 1 file changed, 3 insertions(+), 1 deletion(-)
+ .../src/main/java/io/airlift/http/server/HttpServer.java        | 2 +-
+ .../src/main/java/io/airlift/http/server/HttpServerConfig.java  | 1 +
+ 2 files changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/http-server/src/main/java/io/airlift/http/server/HttpServer.java b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
-index 49a7de937..390255320 100644
+index 49a7de9374..fe3fa345aa 100644
 --- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
 +++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
-@@ -204,7 +204,9 @@ public class HttpServer
+@@ -204,7 +204,7 @@ public class HttpServer
              baseHttpConfiguration.setRequestHeaderSize(toIntExact(config.getMaxRequestHeaderSize().toBytes()));
          }
          if (config.getMaxResponseHeaderSize() != null) {
 -            baseHttpConfiguration.setResponseHeaderSize(toIntExact(config.getMaxResponseHeaderSize().toBytes()));
-+            int maxResponseHeaderSizeBytes = toIntExact(config.getMaxResponseHeaderSize().toBytes());
-+            baseHttpConfiguration.setResponseHeaderSize(maxResponseHeaderSizeBytes);
-+            baseHttpConfiguration.setMaxResponseHeaderSize(maxResponseHeaderSizeBytes);
++            baseHttpConfiguration.setMaxResponseHeaderSize(toIntExact(config.getMaxResponseHeaderSize().toBytes()));
          }
          if (config.getOutputBufferSize() != null) {
              baseHttpConfiguration.setOutputBufferSize(toIntExact(config.getOutputBufferSize().toBytes()));
+diff --git a/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java b/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
+index ee53d470f6..3abbfeaabb 100644
+--- a/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
++++ b/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
+@@ -387,6 +387,7 @@ public class HttpServerConfig
+         return this;
+     }
+ 
++    @MaxDataSize("1GB")
+     public DataSize getMaxResponseHeaderSize()
+     {
+         return maxResponseHeaderSize;

--- a/trino/airlift/stackable/patches/386/patchable.toml
+++ b/trino/airlift/stackable/patches/386/patchable.toml
@@ -1,0 +1,2 @@
+mirror = "https://github.com/stackabletech/airlift.git"
+base = "edaccb04be472282c74507af9b7c38470b385685"

--- a/trino/airlift/stackable/patches/patchable.toml
+++ b/trino/airlift/stackable/patches/patchable.toml
@@ -1,0 +1,2 @@
+upstream = "https://github.com/airlift/airlift.git"
+default-mirror = "https://github.com/stackabletech/airlift.git"

--- a/trino/trino/Dockerfile
+++ b/trino/trino/Dockerfile
@@ -1,20 +1,27 @@
 # syntax=docker/dockerfile:1.16.0@sha256:e2dd261f92e4b763d789984f6eab84be66ab4f5f08052316d8eb8f173593acf7
 # check=error=true
+FROM local-image/trino/airlift AS airlift-builder
+
 FROM local-image/java-devel AS trino-builder
 
 ARG PRODUCT_VERSION
 ARG RELEASE_VERSION
 ARG STACKABLE_USER_UID
+ARG TRINO_AIRLIFT_VERSION
 
 WORKDIR /stackable
 
 COPY --chown=${STACKABLE_USER_UID}:0 trino/trino/stackable/patches/patchable.toml /stackable/src/trino/trino/stackable/patches/patchable.toml
 COPY --chown=${STACKABLE_USER_UID}:0 trino/trino/stackable/patches/${PRODUCT_VERSION} /stackable/src/trino/trino/stackable/patches/${PRODUCT_VERSION}
+COPY --chown=${STACKABLE_USER_UID}:0 --from=airlift-builder /stackable/patched-libs /stackable/patched-libs
 
 # adding a hadolint ignore for SC2215, due to https://github.com/hadolint/hadolint/issues/980
 # hadolint ignore=SC2215
 RUN --mount=type=cache,id=maven-${PRODUCT_VERSION},target=/root/.m2/repository <<EOF
 cd "$(/stackable/patchable --images-repo-root=src checkout trino/trino ${PRODUCT_VERSION})"
+
+# Make Maven aware of the patched Airlift artifacts before resolving deps
+cp -r /stackable/patched-libs/maven/* /root/.m2/repository
 
 NEW_VERSION="${PRODUCT_VERSION}-stackable${RELEASE_VERSION}"
 
@@ -49,6 +56,7 @@ mvn \
   -Dcheckstyle.skip `# Skip checkstyle checks. We dont care if the code is properly formatted, it just wastes time` \
   -Dmaven.javadoc.skip=true `# Dont generate javadoc` \
   -Ddep.presto-jdbc-under-test=${NEW_VERSION} \
+  -Ddep.airlift.version=${TRINO_AIRLIFT_VERSION}-stackable${RELEASE_VERSION} `# Use Stackable-patched Airlift; see local-image/trino/airlift` \
   --projects="$SKIP_PROJECTS"
 
 mkdir -p /stackable/patched-libs/maven/io

--- a/trino/trino/boil-config.toml
+++ b/trino/trino/boil-config.toml
@@ -1,5 +1,7 @@
 [versions."477".local-images]
 java-devel = "24"
+"trino/airlift" = "361"
 
 [versions."479".local-images]
 java-devel = "25"
+"trino/airlift" = "386"

--- a/trino/trino/boil-config.toml
+++ b/trino/trino/boil-config.toml
@@ -1,7 +1,11 @@
 [versions."477".local-images]
 java-devel = "24"
+# Airlift version comes from <dep.airlift.version> in
+# https://github.com/trinodb/trino/blob/477/pom.xml
 "trino/airlift" = "361"
 
 [versions."479".local-images]
 java-devel = "25"
+# Airlift version comes from <dep.airlift.version> in
+# https://github.com/trinodb/trino/blob/479/pom.xml
 "trino/airlift" = "386"


### PR DESCRIPTION
# Description

Backport [airlift/airlift#1943](https://github.com/airlift/airlift/pull/1943) into the Airlift dependency shipped with Trino, so Jetty actually honours the configured max response header size (calls `setMaxResponseHeaderSize` in addition to `setResponseHeaderSize`).

To do that, a new `trino/airlift` image is added that builds Airlift from source and applies the patch. The existing `trino/trino` build then uses this patched Airlift instead of the original dependency.

Two Airlift versions are patched, matching what Trino expects:

- Airlift `361` for Trino `477`
- Airlift `386` for Trino `479`

Once airlift/airlift#1943 is merged and Trino picks up a new Airlift release that contains the fix, the entire `trino/airlift` directory and the `airlift-builder` stage in `trino/trino/Dockerfile` can be removed again.

Smoke test passes:
```
--- PASS: kuttl (586.26s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_trino-477,oci.stackable.tech_sandbox_trino_477-stackable0.0.0-dev-amd64_hive-4.2.0_opa-1.12.3_hdfs-3.4.2_zookeeper-3.9.4_openshift-false (586.22s)
```

## Definition of Done Checklist

  - [x] Changes are OpenShift compatible
  - [x] All added packages (via microdnf or otherwise) have a comment on why they are added
  - [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
  - [x] All packages should have (if available) signatures/hashes verified
  - [x] Add an entry to the CHANGELOG.md file
  - [x] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
