### PR TITLE
ci: Add publish toggle

### DIFF
--- a/.github/workflows/build_airflow.yaml
+++ b/.github/workflows/build_airflow.yaml
@@ -46,4 +46,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}

--- a/.github/workflows/build_airflow.yaml
+++ b/.github/workflows/build_airflow.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 0 1/2 * * # https://crontab.guru/#0_0_1/2_*_*
   push:
@@ -39,3 +44,5 @@ jobs:
       product-name: airflow
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}

--- a/.github/workflows/build_airflow.yaml
+++ b/.github/workflows/build_airflow.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 0 1/2 * * # https://crontab.guru/#0_0_1/2_*_*
   push:
@@ -45,4 +46,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true

--- a/.github/workflows/build_airflow.yaml
+++ b/.github/workflows/build_airflow.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
-        description: Publish and sign images
+      skip-publish:
+        description: Skip publishing and signing images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 0 1/2 * * # https://crontab.guru/#0_0_1/2_*_*
   push:
@@ -46,4 +46,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}

--- a/.github/workflows/build_druid.yaml
+++ b/.github/workflows/build_druid.yaml
@@ -48,4 +48,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}

--- a/.github/workflows/build_druid.yaml
+++ b/.github/workflows/build_druid.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_druid.yaml
+++ b/.github/workflows/build_druid.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 1 1/2 * * # https://crontab.guru/#0_1_1/2_*_*
   push:
@@ -41,3 +46,5 @@ jobs:
       product-name: druid
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}

--- a/.github/workflows/build_druid.yaml
+++ b/.github/workflows/build_druid.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 1 1/2 * * # https://crontab.guru/#0_1_1/2_*_*
   push:
@@ -48,4 +48,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}

--- a/.github/workflows/build_druid.yaml
+++ b/.github/workflows/build_druid.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 1 1/2 * * # https://crontab.guru/#0_1_1/2_*_*
   push:
@@ -47,4 +48,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true

--- a/.github/workflows/build_hadoop.yaml
+++ b/.github/workflows/build_hadoop.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 2 1/2 * * # https://crontab.guru/#0_2_1/2_*_*
   push:
@@ -47,4 +48,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true

--- a/.github/workflows/build_hadoop.yaml
+++ b/.github/workflows/build_hadoop.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 2 1/2 * * # https://crontab.guru/#0_2_1/2_*_*
   push:
@@ -41,3 +46,5 @@ jobs:
       product-name: hadoop
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}

--- a/.github/workflows/build_hadoop.yaml
+++ b/.github/workflows/build_hadoop.yaml
@@ -48,4 +48,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}

--- a/.github/workflows/build_hadoop.yaml
+++ b/.github/workflows/build_hadoop.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_hadoop.yaml
+++ b/.github/workflows/build_hadoop.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 2 1/2 * * # https://crontab.guru/#0_2_1/2_*_*
   push:
@@ -48,4 +48,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}

--- a/.github/workflows/build_hbase.yaml
+++ b/.github/workflows/build_hbase.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 0 2/2 * * # https://crontab.guru/#0_0_2/2_*_*
   push:
@@ -48,4 +49,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true

--- a/.github/workflows/build_hbase.yaml
+++ b/.github/workflows/build_hbase.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_hbase.yaml
+++ b/.github/workflows/build_hbase.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 0 2/2 * * # https://crontab.guru/#0_0_2/2_*_*
   push:
@@ -42,3 +47,5 @@ jobs:
       product-name: hbase
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}

--- a/.github/workflows/build_hbase.yaml
+++ b/.github/workflows/build_hbase.yaml
@@ -49,4 +49,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}

--- a/.github/workflows/build_hbase.yaml
+++ b/.github/workflows/build_hbase.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 0 2/2 * * # https://crontab.guru/#0_0_2/2_*_*
   push:
@@ -49,4 +49,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}

--- a/.github/workflows/build_hive.yaml
+++ b/.github/workflows/build_hive.yaml
@@ -49,5 +49,5 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}
       runners: ubicloud

--- a/.github/workflows/build_hive.yaml
+++ b/.github/workflows/build_hive.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_hive.yaml
+++ b/.github/workflows/build_hive.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 2 2/2 * * # https://crontab.guru/#0_2_2/2_*_*
   push:
@@ -42,4 +47,6 @@ jobs:
       product-name: hive
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
       runners: ubicloud

--- a/.github/workflows/build_hive.yaml
+++ b/.github/workflows/build_hive.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 2 2/2 * * # https://crontab.guru/#0_2_2/2_*_*
   push:
@@ -49,5 +49,5 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}
       runners: ubicloud

--- a/.github/workflows/build_hive.yaml
+++ b/.github/workflows/build_hive.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 2 2/2 * * # https://crontab.guru/#0_2_2/2_*_*
   push:
@@ -48,5 +49,5 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true
       runners: ubicloud

--- a/.github/workflows/build_java-base.yaml
+++ b/.github/workflows/build_java-base.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 0 1/2 * * # https://crontab.guru/#0_0_1/2_*_*
   push:
@@ -37,3 +42,5 @@ jobs:
       product-name: java-base
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}

--- a/.github/workflows/build_java-base.yaml
+++ b/.github/workflows/build_java-base.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_java-base.yaml
+++ b/.github/workflows/build_java-base.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 0 1/2 * * # https://crontab.guru/#0_0_1/2_*_*
   push:
@@ -44,4 +44,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}

--- a/.github/workflows/build_java-base.yaml
+++ b/.github/workflows/build_java-base.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 0 1/2 * * # https://crontab.guru/#0_0_1/2_*_*
   push:
@@ -43,4 +44,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true

--- a/.github/workflows/build_java-base.yaml
+++ b/.github/workflows/build_java-base.yaml
@@ -44,4 +44,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}

--- a/.github/workflows/build_java-devel.yaml
+++ b/.github/workflows/build_java-devel.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 1 1/2 * * # https://crontab.guru/#0_1_1/2_*_*
   push:
@@ -43,4 +44,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true

--- a/.github/workflows/build_java-devel.yaml
+++ b/.github/workflows/build_java-devel.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_java-devel.yaml
+++ b/.github/workflows/build_java-devel.yaml
@@ -44,4 +44,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}

--- a/.github/workflows/build_java-devel.yaml
+++ b/.github/workflows/build_java-devel.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 1 1/2 * * # https://crontab.guru/#0_1_1/2_*_*
   push:
@@ -37,3 +42,5 @@ jobs:
       product-name: java-devel
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}

--- a/.github/workflows/build_java-devel.yaml
+++ b/.github/workflows/build_java-devel.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 1 1/2 * * # https://crontab.guru/#0_1_1/2_*_*
   push:
@@ -44,4 +44,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}

--- a/.github/workflows/build_kafka-testing-tools.yaml
+++ b/.github/workflows/build_kafka-testing-tools.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 2 1/2 * * # https://crontab.guru/#0_2_1/2_*_*
   push:
@@ -47,4 +48,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true

--- a/.github/workflows/build_kafka-testing-tools.yaml
+++ b/.github/workflows/build_kafka-testing-tools.yaml
@@ -48,4 +48,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}

--- a/.github/workflows/build_kafka-testing-tools.yaml
+++ b/.github/workflows/build_kafka-testing-tools.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_kafka-testing-tools.yaml
+++ b/.github/workflows/build_kafka-testing-tools.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 2 1/2 * * # https://crontab.guru/#0_2_1/2_*_*
   push:
@@ -48,4 +48,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}

--- a/.github/workflows/build_kafka-testing-tools.yaml
+++ b/.github/workflows/build_kafka-testing-tools.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 2 1/2 * * # https://crontab.guru/#0_2_1/2_*_*
   push:
@@ -41,3 +46,5 @@ jobs:
       product-name: kafka-testing-tools
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}

--- a/.github/workflows/build_kafka.yaml
+++ b/.github/workflows/build_kafka.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 0 2/2 * * # https://crontab.guru/#0_0_2/2_*_*
   push:
@@ -48,4 +49,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true

--- a/.github/workflows/build_kafka.yaml
+++ b/.github/workflows/build_kafka.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_kafka.yaml
+++ b/.github/workflows/build_kafka.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 0 2/2 * * # https://crontab.guru/#0_0_2/2_*_*
   push:
@@ -42,3 +47,5 @@ jobs:
       product-name: kafka
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}

--- a/.github/workflows/build_kafka.yaml
+++ b/.github/workflows/build_kafka.yaml
@@ -49,4 +49,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}

--- a/.github/workflows/build_kafka.yaml
+++ b/.github/workflows/build_kafka.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 0 2/2 * * # https://crontab.guru/#0_0_2/2_*_*
   push:
@@ -49,4 +49,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}

--- a/.github/workflows/build_krb5.yaml
+++ b/.github/workflows/build_krb5.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 2 2/2 * * # https://crontab.guru/#0_2_2/2_*_*
   push:
@@ -43,4 +44,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true

--- a/.github/workflows/build_krb5.yaml
+++ b/.github/workflows/build_krb5.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_krb5.yaml
+++ b/.github/workflows/build_krb5.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 2 2/2 * * # https://crontab.guru/#0_2_2/2_*_*
   push:
@@ -44,4 +44,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}

--- a/.github/workflows/build_krb5.yaml
+++ b/.github/workflows/build_krb5.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 2 2/2 * * # https://crontab.guru/#0_2_2/2_*_*
   push:
@@ -37,3 +42,5 @@ jobs:
       product-name: krb5
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}

--- a/.github/workflows/build_krb5.yaml
+++ b/.github/workflows/build_krb5.yaml
@@ -44,4 +44,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}

--- a/.github/workflows/build_nifi.yaml
+++ b/.github/workflows/build_nifi.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 0 1/2 * * # https://crontab.guru/#0_0_1/2_*_*
   push:
@@ -41,6 +46,8 @@ jobs:
       product-name: nifi
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
       # Since building Vector from source, this build runs out of disk space.
       # As such, we use the Ubicloud runners which provide bigger disks.
       runners: ubicloud

--- a/.github/workflows/build_nifi.yaml
+++ b/.github/workflows/build_nifi.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_nifi.yaml
+++ b/.github/workflows/build_nifi.yaml
@@ -48,7 +48,7 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}
       # Since building Vector from source, this build runs out of disk space.
       # As such, we use the Ubicloud runners which provide bigger disks.
       runners: ubicloud

--- a/.github/workflows/build_nifi.yaml
+++ b/.github/workflows/build_nifi.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 0 1/2 * * # https://crontab.guru/#0_0_1/2_*_*
   push:
@@ -48,7 +48,7 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}
       # Since building Vector from source, this build runs out of disk space.
       # As such, we use the Ubicloud runners which provide bigger disks.
       runners: ubicloud

--- a/.github/workflows/build_nifi.yaml
+++ b/.github/workflows/build_nifi.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 0 1/2 * * # https://crontab.guru/#0_0_1/2_*_*
   push:
@@ -47,7 +48,7 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true
       # Since building Vector from source, this build runs out of disk space.
       # As such, we use the Ubicloud runners which provide bigger disks.
       runners: ubicloud

--- a/.github/workflows/build_omid.yaml
+++ b/.github/workflows/build_omid.yaml
@@ -48,4 +48,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}

--- a/.github/workflows/build_omid.yaml
+++ b/.github/workflows/build_omid.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_omid.yaml
+++ b/.github/workflows/build_omid.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 1 1/2 * * # https://crontab.guru/#0_1_1/2_*_*
   push:
@@ -41,3 +46,5 @@ jobs:
       product-name: omid
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}

--- a/.github/workflows/build_omid.yaml
+++ b/.github/workflows/build_omid.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 1 1/2 * * # https://crontab.guru/#0_1_1/2_*_*
   push:
@@ -48,4 +48,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}

--- a/.github/workflows/build_omid.yaml
+++ b/.github/workflows/build_omid.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 1 1/2 * * # https://crontab.guru/#0_1_1/2_*_*
   push:
@@ -47,4 +48,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true

--- a/.github/workflows/build_opa.yaml
+++ b/.github/workflows/build_opa.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 2 1/2 * * # https://crontab.guru/#0_2_1/2_*_*
   push:
@@ -39,3 +44,5 @@ jobs:
       product-name: opa
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}

--- a/.github/workflows/build_opa.yaml
+++ b/.github/workflows/build_opa.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_opa.yaml
+++ b/.github/workflows/build_opa.yaml
@@ -46,4 +46,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}

--- a/.github/workflows/build_opa.yaml
+++ b/.github/workflows/build_opa.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 2 1/2 * * # https://crontab.guru/#0_2_1/2_*_*
   push:
@@ -46,4 +46,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}

--- a/.github/workflows/build_opa.yaml
+++ b/.github/workflows/build_opa.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 2 1/2 * * # https://crontab.guru/#0_2_1/2_*_*
   push:
@@ -45,4 +46,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true

--- a/.github/workflows/build_opensearch.yaml
+++ b/.github/workflows/build_opensearch.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 0 2/2 * * # https://crontab.guru/#0_0_2/2_*_*
   push:
@@ -48,5 +49,5 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true
       runners: ubicloud

--- a/.github/workflows/build_opensearch.yaml
+++ b/.github/workflows/build_opensearch.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 0 2/2 * * # https://crontab.guru/#0_0_2/2_*_*
   push:
@@ -49,5 +49,5 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}
       runners: ubicloud

--- a/.github/workflows/build_opensearch.yaml
+++ b/.github/workflows/build_opensearch.yaml
@@ -49,5 +49,5 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}
       runners: ubicloud

--- a/.github/workflows/build_opensearch.yaml
+++ b/.github/workflows/build_opensearch.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_opensearch.yaml
+++ b/.github/workflows/build_opensearch.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 0 2/2 * * # https://crontab.guru/#0_0_2/2_*_*
   push:
@@ -42,4 +47,6 @@ jobs:
       product-name: opensearch
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
       runners: ubicloud

--- a/.github/workflows/build_opensearch_dashboards.yaml
+++ b/.github/workflows/build_opensearch_dashboards.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_opensearch_dashboards.yaml
+++ b/.github/workflows/build_opensearch_dashboards.yaml
@@ -47,5 +47,5 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}
       runners: ubicloud

--- a/.github/workflows/build_opensearch_dashboards.yaml
+++ b/.github/workflows/build_opensearch_dashboards.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 0 2/2 * * # https://crontab.guru/#0_0_2/2_*_*
   push:
@@ -47,5 +47,5 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}
       runners: ubicloud

--- a/.github/workflows/build_opensearch_dashboards.yaml
+++ b/.github/workflows/build_opensearch_dashboards.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 0 2/2 * * # https://crontab.guru/#0_0_2/2_*_*
   push:
@@ -46,5 +47,5 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true
       runners: ubicloud

--- a/.github/workflows/build_opensearch_dashboards.yaml
+++ b/.github/workflows/build_opensearch_dashboards.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 0 2/2 * * # https://crontab.guru/#0_0_2/2_*_*
   push:
@@ -40,4 +45,6 @@ jobs:
       product-name: opensearch-dashboards
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
       runners: ubicloud

--- a/.github/workflows/build_spark-connect-client.yaml
+++ b/.github/workflows/build_spark-connect-client.yaml
@@ -49,5 +49,5 @@ jobs:
       # As such, we use the Ubicloud runners which provide bigger disks.
       runners: ubicloud
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}
       publish-to-quay: false

--- a/.github/workflows/build_spark-connect-client.yaml
+++ b/.github/workflows/build_spark-connect-client.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 0 2/2 * * # https://crontab.guru/#0_0_2/2_*_*
   push:
@@ -48,5 +49,5 @@ jobs:
       # As such, we use the Ubicloud runners which provide bigger disks.
       runners: ubicloud
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true
       publish-to-quay: false

--- a/.github/workflows/build_spark-connect-client.yaml
+++ b/.github/workflows/build_spark-connect-client.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_spark-connect-client.yaml
+++ b/.github/workflows/build_spark-connect-client.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 0 2/2 * * # https://crontab.guru/#0_0_2/2_*_*
   push:
@@ -49,5 +49,5 @@ jobs:
       # As such, we use the Ubicloud runners which provide bigger disks.
       runners: ubicloud
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}
       publish-to-quay: false

--- a/.github/workflows/build_spark-connect-client.yaml
+++ b/.github/workflows/build_spark-connect-client.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 0 2/2 * * # https://crontab.guru/#0_0_2/2_*_*
   push:
@@ -42,4 +47,6 @@ jobs:
       # Since building Vector from source, this build runs out of disk space.
       # As such, we use the Ubicloud runners which provide bigger disks.
       runners: ubicloud
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
       publish-to-quay: false

--- a/.github/workflows/build_spark-k8s.yaml
+++ b/.github/workflows/build_spark-k8s.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 0 2/2 * * # https://crontab.guru/#0_0_2/2_*_*
   push:
@@ -48,5 +49,5 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true
       runners: ubicloud

--- a/.github/workflows/build_spark-k8s.yaml
+++ b/.github/workflows/build_spark-k8s.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 0 2/2 * * # https://crontab.guru/#0_0_2/2_*_*
   push:
@@ -49,5 +49,5 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}
       runners: ubicloud

--- a/.github/workflows/build_spark-k8s.yaml
+++ b/.github/workflows/build_spark-k8s.yaml
@@ -49,5 +49,5 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}
       runners: ubicloud

--- a/.github/workflows/build_spark-k8s.yaml
+++ b/.github/workflows/build_spark-k8s.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_spark-k8s.yaml
+++ b/.github/workflows/build_spark-k8s.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 0 2/2 * * # https://crontab.guru/#0_0_2/2_*_*
   push:
@@ -42,4 +47,6 @@ jobs:
       product-name: spark-k8s
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
       runners: ubicloud

--- a/.github/workflows/build_stackable-base.yaml
+++ b/.github/workflows/build_stackable-base.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 1 2/2 * * # https://crontab.guru/#0_1_2/2_*_*
   push:
@@ -45,4 +45,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}

--- a/.github/workflows/build_stackable-base.yaml
+++ b/.github/workflows/build_stackable-base.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_stackable-base.yaml
+++ b/.github/workflows/build_stackable-base.yaml
@@ -45,4 +45,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}

--- a/.github/workflows/build_stackable-base.yaml
+++ b/.github/workflows/build_stackable-base.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 1 2/2 * * # https://crontab.guru/#0_1_2/2_*_*
   push:
@@ -38,3 +43,5 @@ jobs:
       product-name: stackable-base
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}

--- a/.github/workflows/build_stackable-base.yaml
+++ b/.github/workflows/build_stackable-base.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 1 2/2 * * # https://crontab.guru/#0_1_2/2_*_*
   push:
@@ -44,4 +45,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true

--- a/.github/workflows/build_superset.yaml
+++ b/.github/workflows/build_superset.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 2 2/2 * * # https://crontab.guru/#0_2_2/2_*_*
   push:
@@ -45,4 +46,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true

--- a/.github/workflows/build_superset.yaml
+++ b/.github/workflows/build_superset.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 2 2/2 * * # https://crontab.guru/#0_2_2/2_*_*
   push:
@@ -46,4 +46,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}

--- a/.github/workflows/build_superset.yaml
+++ b/.github/workflows/build_superset.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_superset.yaml
+++ b/.github/workflows/build_superset.yaml
@@ -46,4 +46,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}

--- a/.github/workflows/build_superset.yaml
+++ b/.github/workflows/build_superset.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 2 2/2 * * # https://crontab.guru/#0_2_2/2_*_*
   push:
@@ -39,3 +44,5 @@ jobs:
       product-name: superset
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}

--- a/.github/workflows/build_testing-tools.yaml
+++ b/.github/workflows/build_testing-tools.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 0 1/2 * * # https://crontab.guru/#0_0_1/2_*_*
   push:
@@ -52,4 +52,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}

--- a/.github/workflows/build_testing-tools.yaml
+++ b/.github/workflows/build_testing-tools.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_testing-tools.yaml
+++ b/.github/workflows/build_testing-tools.yaml
@@ -52,4 +52,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}

--- a/.github/workflows/build_testing-tools.yaml
+++ b/.github/workflows/build_testing-tools.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 0 1/2 * * # https://crontab.guru/#0_0_1/2_*_*
   push:
@@ -51,4 +52,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true

--- a/.github/workflows/build_testing-tools.yaml
+++ b/.github/workflows/build_testing-tools.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 0 1/2 * * # https://crontab.guru/#0_0_1/2_*_*
   push:
@@ -45,3 +50,5 @@ jobs:
       product-name: ${{ matrix.product-name }}
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}

--- a/.github/workflows/build_tools.yaml
+++ b/.github/workflows/build_tools.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 1 1/2 * * # https://crontab.guru/#0_1_1/2_*_*
   push:
@@ -44,4 +45,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true

--- a/.github/workflows/build_tools.yaml
+++ b/.github/workflows/build_tools.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_tools.yaml
+++ b/.github/workflows/build_tools.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 1 1/2 * * # https://crontab.guru/#0_1_1/2_*_*
   push:
@@ -38,3 +43,5 @@ jobs:
       product-name: tools
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}

--- a/.github/workflows/build_tools.yaml
+++ b/.github/workflows/build_tools.yaml
@@ -45,4 +45,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}

--- a/.github/workflows/build_tools.yaml
+++ b/.github/workflows/build_tools.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 1 1/2 * * # https://crontab.guru/#0_1_1/2_*_*
   push:
@@ -45,4 +45,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}

--- a/.github/workflows/build_trino-cli.yaml
+++ b/.github/workflows/build_trino-cli.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_trino-cli.yaml
+++ b/.github/workflows/build_trino-cli.yaml
@@ -47,4 +47,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}

--- a/.github/workflows/build_trino-cli.yaml
+++ b/.github/workflows/build_trino-cli.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 2 1/2 * * # https://crontab.guru/#0_2_1/2_*_*
   push:
@@ -40,3 +45,5 @@ jobs:
       product-name: trino-cli
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}

--- a/.github/workflows/build_trino-cli.yaml
+++ b/.github/workflows/build_trino-cli.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 2 1/2 * * # https://crontab.guru/#0_2_1/2_*_*
   push:
@@ -46,4 +47,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true

--- a/.github/workflows/build_trino-cli.yaml
+++ b/.github/workflows/build_trino-cli.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 2 1/2 * * # https://crontab.guru/#0_2_1/2_*_*
   push:
@@ -47,4 +47,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}

--- a/.github/workflows/build_trino.yaml
+++ b/.github/workflows/build_trino.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_trino.yaml
+++ b/.github/workflows/build_trino.yaml
@@ -48,7 +48,7 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}
       # Since building Vector from source, this build runs out of disk space.
       # As such, we use the Ubicloud runners which provide bigger disks.
       runners: ubicloud

--- a/.github/workflows/build_trino.yaml
+++ b/.github/workflows/build_trino.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 0 2/2 * * # https://crontab.guru/#0_0_2/2_*_*
   push:
@@ -41,6 +46,8 @@ jobs:
       product-name: trino
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
       # Since building Vector from source, this build runs out of disk space.
       # As such, we use the Ubicloud runners which provide bigger disks.
       runners: ubicloud

--- a/.github/workflows/build_trino.yaml
+++ b/.github/workflows/build_trino.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 0 2/2 * * # https://crontab.guru/#0_0_2/2_*_*
   push:
@@ -48,7 +48,7 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}
       # Since building Vector from source, this build runs out of disk space.
       # As such, we use the Ubicloud runners which provide bigger disks.
       runners: ubicloud

--- a/.github/workflows/build_trino.yaml
+++ b/.github/workflows/build_trino.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 0 2/2 * * # https://crontab.guru/#0_0_2/2_*_*
   push:
@@ -47,7 +48,7 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true
       # Since building Vector from source, this build runs out of disk space.
       # As such, we use the Ubicloud runners which provide bigger disks.
       runners: ubicloud

--- a/.github/workflows/build_vector.yaml
+++ b/.github/workflows/build_vector.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 1 2/2 * * # https://crontab.guru/#0_1_2/2_*_*
   push:
@@ -43,4 +44,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true

--- a/.github/workflows/build_vector.yaml
+++ b/.github/workflows/build_vector.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_vector.yaml
+++ b/.github/workflows/build_vector.yaml
@@ -44,4 +44,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}

--- a/.github/workflows/build_vector.yaml
+++ b/.github/workflows/build_vector.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 1 2/2 * * # https://crontab.guru/#0_1_2/2_*_*
   push:
@@ -37,3 +42,5 @@ jobs:
       product-name: vector
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}

--- a/.github/workflows/build_vector.yaml
+++ b/.github/workflows/build_vector.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 1 2/2 * * # https://crontab.guru/#0_1_2/2_*_*
   push:
@@ -44,4 +44,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}

--- a/.github/workflows/build_zookeeper.yaml
+++ b/.github/workflows/build_zookeeper.yaml
@@ -5,6 +5,11 @@ run-name: |
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish and sign images
+        required: true
+        default: "true"
   schedule:
     - cron: 0 2 2/2 * * # https://crontab.guru/#0_2_2/2_*_*
   push:
@@ -41,3 +46,5 @@ jobs:
       product-name: zookeeper
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
+      # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}

--- a/.github/workflows/build_zookeeper.yaml
+++ b/.github/workflows/build_zookeeper.yaml
@@ -48,4 +48,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: inputs.publish || true
+      publish: ${{ inputs.publish || true }}

--- a/.github/workflows/build_zookeeper.yaml
+++ b/.github/workflows/build_zookeeper.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: Publish and sign images
+        description: Skip publishing and signing images
         type: boolean
         required: true
         default: false

--- a/.github/workflows/build_zookeeper.yaml
+++ b/.github/workflows/build_zookeeper.yaml
@@ -8,8 +8,9 @@ on:
     inputs:
       publish:
         description: Publish and sign images
+        type: boolean
         required: true
-        default: "true"
+        default: true
   schedule:
     - cron: 0 2 2/2 * * # https://crontab.guru/#0_2_2/2_*_*
   push:
@@ -47,4 +48,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish == '' || inputs.publish == 'true' }}
+      publish: inputs.publish || true

--- a/.github/workflows/build_zookeeper.yaml
+++ b/.github/workflows/build_zookeeper.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      publish:
+      skip-publish:
         description: Publish and sign images
         type: boolean
         required: true
-        default: true
+        default: false
   schedule:
     - cron: 0 2 2/2 * * # https://crontab.guru/#0_2_2/2_*_*
   push:
@@ -48,4 +48,4 @@ jobs:
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
+      publish: ${{ !inputs.skip-publish }}

--- a/.github/workflows/reusable_build_image.yaml
+++ b/.github/workflows/reusable_build_image.yaml
@@ -26,6 +26,10 @@ on:
           - `ubicloud`: Both the x86_64 and the aarch64 builds run on the Ubicloud runners
         default: mixed
         type: string
+      publish:
+        description: Whether to publish and sign images.
+        type: boolean
+        default: true
       publish-to-quay:
         description: |
           Whether to publish to quay.io or not. If `true`, the `quay-robot-secret` needs to be
@@ -123,6 +127,7 @@ jobs:
           sdp-version: ${{ inputs.sdp-version }}
 
       - name: Publish Container Image on oci.stackable.tech
+        if: inputs.publish
         uses: stackabletech/actions/publish-image@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
         with:
           image-registry-uri: oci.stackable.tech
@@ -138,7 +143,7 @@ jobs:
           source-image-uri: localhost/${{ inputs.registry-namespace }}/${{ inputs.product-name }}:${{ steps.build.outputs.image-manifest-tag }}
 
       - name: Publish Container Image on quay.io
-        if: inputs.publish-to-quay
+        if: inputs.publish && inputs.publish-to-quay
         uses: stackabletech/actions/publish-image@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
         with:
           image-registry-uri: quay.io
@@ -171,6 +176,7 @@ jobs:
           persist-credentials: false
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
+        if: inputs.publish
         uses: stackabletech/actions/publish-image-index-manifest@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
         with:
           image-registry-uri: oci.stackable.tech
@@ -185,7 +191,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ inputs.sdp-version }}
 
       - name: Publish and Sign Image Index Manifest to quay.io
-        if: inputs.publish-to-quay
+        if: inputs.publish && inputs.publish-to-quay
         uses: stackabletech/actions/publish-image-index-manifest@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
         with:
           image-registry-uri: quay.io


### PR DESCRIPTION
This PR adds a toggle to the reusable action and the manual workflow dispatch to enable (default) or disable pushing and signing images _in general_.

It should be noted, that a `publish-to-quay` input is already available to control whether the images are pushed to quay.io.

> [!NOTE]
> Test CI runs:
> - https://github.com/stackabletech/docker-images/actions/runs/26561331798 (no skip)
> - https://github.com/stackabletech/docker-images/actions/runs/26563813501 (skip)
>
> There is unfortunately no way (before merging) for us to test other workflow triggers and ensure the defaulting of `input.skip-publish` works.