### PR TITLE
feat(zookeeper): Add 3.9.5

### DIFF
--- a/java-devel/boil-config.toml
+++ b/java-devel/boil-config.toml
@@ -13,7 +13,6 @@ stackable-devel = "1.0.0"
 [versions."21".local-images]
 stackable-devel = "1.0.0"
 
-
 [versions."24".local-images]
 stackable-devel = "1.0.0"
 

--- a/zookeeper/boil-config.toml
+++ b/zookeeper/boil-config.toml
@@ -1,10 +1,19 @@
 [metadata.registries]
 "oci.stackable.tech" = { namespace = "sdp" }
 
+# Deprecated since 26.3.0
 [versions."3.9.4".local-images]
 java-base = "17"
 java-devel = "11"
 "shared/logback" = "1.3.15"
 
 [versions."3.9.4".build-arguments]
+jmx-exporter-version = "1.4.0"
+
+[versions."3.9.5".local-images]
+java-base = "17"
+java-devel = "17"
+"shared/logback" = "1.3.15"
+
+[versions."3.9.5".build-arguments]
 jmx-exporter-version = "1.4.0"

--- a/zookeeper/boil-config.toml
+++ b/zookeeper/boil-config.toml
@@ -5,7 +5,7 @@
 [versions."3.9.4".local-images]
 java-base = "17"
 java-devel = "11"
-"shared/logback" = "1.3.15"
+"shared/logback" = "1.3.15" # https://github.com/apache/zookeeper/blob/release-3.9.4/pom.xml#L554
 
 [versions."3.9.4".build-arguments]
 jmx-exporter-version = "1.4.0"
@@ -13,7 +13,7 @@ jmx-exporter-version = "1.4.0"
 [versions."3.9.5".local-images]
 java-base = "17"
 java-devel = "17"
-"shared/logback" = "1.3.15"
+"shared/logback" = "1.3.15" # https://github.com/apache/zookeeper/blob/release-3.9.5/pom.xml#L554
 
 [versions."3.9.5".build-arguments]
 jmx-exporter-version = "1.4.0"

--- a/zookeeper/boil-config.toml
+++ b/zookeeper/boil-config.toml
@@ -1,7 +1,7 @@
 [metadata.registries]
 "oci.stackable.tech" = { namespace = "sdp" }
 
-# Deprecated since 26.3.0
+# Deprecated since 26.7.0
 [versions."3.9.4".local-images]
 java-base = "17"
 java-devel = "11"

--- a/zookeeper/stackable/patches/3.9.5/0001-Add-CycloneDX-plugin.patch
+++ b/zookeeper/stackable/patches/3.9.5/0001-Add-CycloneDX-plugin.patch
@@ -1,0 +1,34 @@
+From d09d1c1c43fee2867ae35c59a4b8967ab822da98 Mon Sep 17 00:00:00 2001
+From: xeniape <xenia.fischer@stackable.tech>
+Date: Tue, 30 Sep 2025 15:24:05 +0200
+Subject: Add CycloneDX plugin
+
+---
+ pom.xml | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/pom.xml b/pom.xml
+index 915d383d..989b74a9 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -925,7 +925,7 @@
+         <plugin>
+           <groupId>org.cyclonedx</groupId>
+           <artifactId>cyclonedx-maven-plugin</artifactId>
+-          <version>2.7.9</version>
++          <version>2.8.0</version>
+        </plugin>
+       </plugins>
+     </pluginManagement>
+@@ -1200,6 +1200,11 @@
+       <plugin>
+         <groupId>org.cyclonedx</groupId>
+         <artifactId>cyclonedx-maven-plugin</artifactId>
++        <configuration>
++            <projectType>application</projectType>
++            <schemaVersion>1.5</schemaVersion>
++            <skipNotDeployed>false</skipNotDeployed>
++        </configuration>
+         <executions>
+           <execution>
+             <goals>

--- a/zookeeper/stackable/patches/3.9.5/patchable.toml
+++ b/zookeeper/stackable/patches/3.9.5/patchable.toml
@@ -1,0 +1,2 @@
+mirror = "https://git@github.com/stackabletech/zookeeper.git"
+base = "293c895a8d966a3ecb92872be4a1daf87d725da2"


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1506.

This PR adds ZooKeeper 3.9.5 and marks 3.9.4 as deprecated. It also uses Java 17 instead of 11 to build ZooKeeper which seems to have worked without issues.

I've ran all integration tests and they passed:

```
--- FAIL: kuttl (446.05s)
    --- FAIL: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/logging_zookeeper-3.9.5_openshift-false (89.68s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.5_use-server-tls-false_use-client-auth-tls-true_openshift-false (102.03s)
        --- PASS: kuttl/harness/cluster-operation_zookeeper-latest-3.9.5_openshift-false (31.72s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.5_use-server-tls-true_use-client-auth-tls-true_openshift-false (91.22s)
        --- PASS: kuttl/harness/znode_zookeeper-latest-3.9.5_openshift-false (27.07s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.5_use-server-tls-false_use-client-auth-tls-false_openshift-false (67.82s)
        --- PASS: kuttl/harness/delete-rolegroup_zookeeper-3.9.5_openshift-false (47.13s)
        --- FAIL: kuttl/harness/smoke_zookeeper-3.9.5_use-server-tls-true_use-client-auth-tls-false_openshift-false (312.27s)
FAIL
ERROR:root:kuttl failed
```

The last test needed a re-run:

```
--- PASS: kuttl (81.80s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.5_use-server-tls-true_use-client-auth-tls-false_openshift-false (81.78s)
PASS
```