### PR TITLE
feat(trino): Add 481

### DIFF
--- a/trino/airlift/boil-config.toml
+++ b/trino/airlift/boil-config.toml
@@ -3,3 +3,6 @@ java-devel = "24"
 
 [versions."386".local-images]
 java-devel = "25"
+
+[versions."424".local-images]
+java-devel = "25"

--- a/trino/airlift/stackable/patches/424/0001-Apply-max-response-header-size-to-Jetty-maxResponseH.patch
+++ b/trino/airlift/stackable/patches/424/0001-Apply-max-response-header-size-to-Jetty-maxResponseH.patch
@@ -1,0 +1,35 @@
+From e00f9698117f651aa60ce5a96828577ac960d0c9 Mon Sep 17 00:00:00 2001
+From: Lukas Krug <lukas.krug@stackable.tech>
+Date: Wed, 27 May 2026 21:58:48 +0200
+Subject: Apply max response header size to Jetty maxResponseHeaderSize
+
+---
+ .../src/main/java/io/airlift/http/server/HttpServer.java        | 2 +-
+ .../src/main/java/io/airlift/http/server/HttpServerConfig.java  | 1 +
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/http-server/src/main/java/io/airlift/http/server/HttpServer.java b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+index b57b871f3..e874a03af 100644
+--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
++++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+@@ -204,7 +204,7 @@ public class HttpServer
+             baseHttpConfiguration.setRequestHeaderSize(toIntExact(config.getMaxRequestHeaderSize().toBytes()));
+         }
+         if (config.getMaxResponseHeaderSize() != null) {
+-            baseHttpConfiguration.setResponseHeaderSize(toIntExact(config.getMaxResponseHeaderSize().toBytes()));
++            baseHttpConfiguration.setMaxResponseHeaderSize(toIntExact(config.getMaxResponseHeaderSize().toBytes()));
+         }
+         if (config.getOutputBufferSize() != null) {
+             baseHttpConfiguration.setOutputBufferSize(toIntExact(config.getOutputBufferSize().toBytes()));
+diff --git a/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java b/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
+index ee53d470f..3abbfeaab 100644
+--- a/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
++++ b/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
+@@ -387,6 +387,7 @@ public class HttpServerConfig
+         return this;
+     }
+ 
++    @MaxDataSize("1GB")
+     public DataSize getMaxResponseHeaderSize()
+     {
+         return maxResponseHeaderSize;

--- a/trino/airlift/stackable/patches/424/patchable.toml
+++ b/trino/airlift/stackable/patches/424/patchable.toml
@@ -1,0 +1,2 @@
+mirror = "https://github.com/stackabletech/airlift.git"
+base = "9714f9095cea760f8a195f15c44a7f4f909ff23c"

--- a/trino/boil-config.toml
+++ b/trino/boil-config.toml
@@ -9,6 +9,7 @@ java-base = "24"
 [versions."477".build-arguments]
 jmx-exporter-version = "1.3.0"
 
+# Deprecated since 26.7.0
 [versions."479".local-images]
 java-base = "25"
 "trino/trino" = "479"
@@ -17,4 +18,14 @@ java-base = "25"
 # "trino/storage-connector" = "479"
 
 [versions."479".build-arguments]
+jmx-exporter-version = "1.3.0"
+
+[versions."481".local-images]
+java-base = "25"
+"trino/trino" = "481"
+"trino/storage-connector" = "477"
+# There is no 481 connector yet
+# "trino/storage-connector" = "481"
+
+[versions."481".build-arguments]
 jmx-exporter-version = "1.3.0"

--- a/trino/trino/boil-config.toml
+++ b/trino/trino/boil-config.toml
@@ -9,3 +9,9 @@ java-devel = "25"
 # Airlift version comes from <dep.airlift.version> in
 # https://github.com/trinodb/trino/blob/479/pom.xml
 "trino/airlift" = "386"
+
+[versions."481".local-images]
+java-devel = "25"
+# Airlift version comes from <dep.airlift.version> in
+# https://github.com/trinodb/trino/blob/481/pom.xml
+"trino/airlift" = "424"

--- a/trino/trino/stackable/patches/481/0001-Add-CycloneDX-plugin.patch
+++ b/trino/trino/stackable/patches/481/0001-Add-CycloneDX-plugin.patch
@@ -1,0 +1,38 @@
+From 8a2396b467657c4f6fefc6a213148af062d45064 Mon Sep 17 00:00:00 2001
+From: Lukas Voetmand <lukas.voetmand@stackable.tech>
+Date: Fri, 6 Sep 2024 17:53:52 +0200
+Subject: Add CycloneDX plugin
+
+---
+ pom.xml | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/pom.xml b/pom.xml
+index 06089658e13..64211354c06 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -2841,6 +2841,24 @@
+                     </excludes>
+                 </configuration>
+             </plugin>
++            <plugin>
++                <groupId>org.cyclonedx</groupId>
++                <artifactId>cyclonedx-maven-plugin</artifactId>
++                <version>2.9.1</version>
++                <configuration>
++                    <projectType>application</projectType>
++                    <schemaVersion>1.6</schemaVersion>
++                    <skipNotDeployed>false</skipNotDeployed>
++                </configuration>
++                <executions>
++                    <execution>
++                        <goals>
++                            <goal>makeBom</goal>
++                        </goals>
++                        <phase>package</phase>
++                    </execution>
++                </executions>
++            </plugin>
+         </plugins>
+     </build>
+ 

--- a/trino/trino/stackable/patches/481/0002-Disable-web-ui-code-checking-because-flow-v0.241.0-f.patch
+++ b/trino/trino/stackable/patches/481/0002-Disable-web-ui-code-checking-because-flow-v0.241.0-f.patch
@@ -1,0 +1,44 @@
+From 25c453b54fcf184934d3057d4f57606ddf8594ea Mon Sep 17 00:00:00 2001
+From: dervoeti <lukas.krug@stackable.tech>
+Date: Wed, 18 Jun 2025 14:05:10 +0200
+Subject: Disable web-ui code checking, because flow v0.241.0 for non-x86
+ systems requires glibc 2.35, as of 2025-06-18 our UBI image comes with glibc
+ 2.34. This patch can likely be removed once we ship a newer version of glibc.
+
+---
+ core/trino-web-ui/pom.xml | 22 ----------------------
+ 1 file changed, 22 deletions(-)
+
+diff --git a/core/trino-web-ui/pom.xml b/core/trino-web-ui/pom.xml
+index 986d69101b2..3eb18fc3a2d 100644
+--- a/core/trino-web-ui/pom.xml
++++ b/core/trino-web-ui/pom.xml
+@@ -104,28 +104,6 @@
+                             <workingDirectory>src/main/resources/webapp/src</workingDirectory>
+                         </configuration>
+                     </execution>
+-                    <execution>
+-                        <id>check (webapp)</id>
+-                        <goals>
+-                            <goal>npm</goal>
+-                        </goals>
+-                        <phase>verify</phase>
+-                        <configuration>
+-                            <arguments>run ${frontend.check.goal}</arguments>
+-                            <workingDirectory>src/main/resources/webapp/src</workingDirectory>
+-                        </configuration>
+-                    </execution>
+-                    <execution>
+-                        <id>check (webapp-preview)</id>
+-                        <goals>
+-                            <goal>npm</goal>
+-                        </goals>
+-                        <phase>verify</phase>
+-                        <configuration>
+-                            <arguments>run ${frontend.check.goal}</arguments>
+-                            <workingDirectory>src/main/resources/webapp-preview</workingDirectory>
+-                        </configuration>
+-                    </execution>
+                     <execution>
+                         <id>package (webapp-preview)</id>
+                         <goals>

--- a/trino/trino/stackable/patches/481/patchable.toml
+++ b/trino/trino/stackable/patches/481/patchable.toml
@@ -1,0 +1,2 @@
+mirror = "https://github.com/stackabletech/trino.git"
+base = "c4ac66cb4f86728b48f15b10d6ab3c1aa0166d3c"


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1505.

This PR adds Trino 481 and marks 479 as deprecated. The trino-storage-connector still uses Trino 477, as there is no upstream version for 481 (or 479).