### PR TITLE
feat(trino): Add 481

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ All notable changes to this project will be documented in this file.
 - nifi: Backport NIFI-15901 to 2.x versions ([#1481]).
 - testing-tools: Added grpcurl utility ([#1493]).
 - opa: Add `1.16.2` ([#1509]).
-- kafka: Add `3.9.2` and `4.2.1` ([#1483])
+- kafka: Add `3.9.2` and `4.2.1` ([#1483]).
+- trino: Add `481` ([#XXXX]).
 
 ### Changed
 
@@ -48,6 +49,7 @@ All notable changes to this project will be documented in this file.
 [#1509]: https://github.com/stackabletech/docker-images/pull/1509
 [#1510]: https://github.com/stackabletech/docker-images/pull/1510
 [#1512]: https://github.com/stackabletech/docker-images/pull/1512
+[#XXXX]: https://github.com/stackabletech/docker-images/pull/XXXX
 
 ## [26.3.0] - 2026-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 - testing-tools: Added grpcurl utility ([#1493]).
 - opa: Add `1.16.2` ([#1509]).
 - kafka: Add `3.9.2` and `4.2.1` ([#1483]).
-- trino: Add `481` ([#XXXX]).
+- trino: Add `481` ([#1518]).
 
 ### Changed
 
@@ -49,7 +49,7 @@ All notable changes to this project will be documented in this file.
 [#1509]: https://github.com/stackabletech/docker-images/pull/1509
 [#1510]: https://github.com/stackabletech/docker-images/pull/1510
 [#1512]: https://github.com/stackabletech/docker-images/pull/1512
-[#XXXX]: https://github.com/stackabletech/docker-images/pull/XXXX
+[#1518]: https://github.com/stackabletech/docker-images/pull/1518
 
 ## [26.3.0] - 2026-03-16
 

--- a/trino-cli/boil-config.toml
+++ b/trino-cli/boil-config.toml
@@ -1,5 +1,5 @@
 [metadata.registries]
 "oci.stackable.tech" = { namespace = "sdp" }
 
-[versions."479".local-images]
-java-base = "25"
+[versions."481".local-images]
+java-base = "25" # Same version as the "trino" image

--- a/trino/airlift/boil-config.toml
+++ b/trino/airlift/boil-config.toml
@@ -1,5 +1,8 @@
 [versions."361".local-images]
-java-devel = "24"
+java-devel = "24" # Same version as Trino 477
 
 [versions."386".local-images]
-java-devel = "25"
+java-devel = "25" # Same version as Trino 479
+
+[versions."424".local-images]
+java-devel = "25" # Same version as Trino 481

--- a/trino/airlift/stackable/patches/424/0001-Apply-max-response-header-size-to-Jetty-maxResponseH.patch
+++ b/trino/airlift/stackable/patches/424/0001-Apply-max-response-header-size-to-Jetty-maxResponseH.patch
@@ -1,0 +1,35 @@
+From 359fe4dbf5154df20701cea742177bd874949009 Mon Sep 17 00:00:00 2001
+From: Lukas Krug <lukas.krug@stackable.tech>
+Date: Wed, 27 May 2026 21:58:48 +0200
+Subject: Apply max response header size to Jetty maxResponseHeaderSize
+
+---
+ .../src/main/java/io/airlift/http/server/HttpServer.java        | 2 +-
+ .../src/main/java/io/airlift/http/server/HttpServerConfig.java  | 1 +
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/http-server/src/main/java/io/airlift/http/server/HttpServer.java b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+index 49a7de9374..fe3fa345aa 100644
+--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
++++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+@@ -204,7 +204,7 @@ public class HttpServer
+             baseHttpConfiguration.setRequestHeaderSize(toIntExact(config.getMaxRequestHeaderSize().toBytes()));
+         }
+         if (config.getMaxResponseHeaderSize() != null) {
+-            baseHttpConfiguration.setResponseHeaderSize(toIntExact(config.getMaxResponseHeaderSize().toBytes()));
++            baseHttpConfiguration.setMaxResponseHeaderSize(toIntExact(config.getMaxResponseHeaderSize().toBytes()));
+         }
+         if (config.getOutputBufferSize() != null) {
+             baseHttpConfiguration.setOutputBufferSize(toIntExact(config.getOutputBufferSize().toBytes()));
+diff --git a/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java b/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
+index ee53d470f6..3abbfeaabb 100644
+--- a/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
++++ b/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
+@@ -387,6 +387,7 @@ public class HttpServerConfig
+         return this;
+     }
+ 
++    @MaxDataSize("1GB")
+     public DataSize getMaxResponseHeaderSize()
+     {
+         return maxResponseHeaderSize;

--- a/trino/airlift/stackable/patches/424/patchable.toml
+++ b/trino/airlift/stackable/patches/424/patchable.toml
@@ -1,0 +1,2 @@
+mirror = "https://github.com/stackabletech/airlift.git"
+base = "9714f9095cea760f8a195f15c44a7f4f909ff23c"

--- a/trino/boil-config.toml
+++ b/trino/boil-config.toml
@@ -9,6 +9,7 @@ java-base = "24" # https://trino.io/docs/477/installation/deployment.html#java-r
 [versions."477".build-arguments]
 jmx-exporter-version = "1.3.0"
 
+# Deprecated since 26.7.0
 [versions."479".local-images]
 java-base = "25" # https://trino.io/docs/479/installation/deployment.html#java-runtime-environment states 24, but the docs are wrong: https://github.com/trinodb/trino/commit/1ddb0f9976fcd9917aaf0b689ca0acc8635e24f1
 "trino/trino" = "479"

--- a/trino/boil-config.toml
+++ b/trino/boil-config.toml
@@ -2,7 +2,7 @@
 "oci.stackable.tech" = { namespace = "sdp" }
 
 [versions."477".local-images]
-java-base = "24"
+java-base = "24" # https://trino.io/docs/477/installation/deployment.html#java-runtime-environment
 "trino/trino" = "477"
 "trino/storage-connector" = "477"
 
@@ -10,11 +10,17 @@ java-base = "24"
 jmx-exporter-version = "1.3.0"
 
 [versions."479".local-images]
-java-base = "25"
+java-base = "25" # https://trino.io/docs/479/installation/deployment.html#java-runtime-environment states 24, but the docs are wrong: https://github.com/trinodb/trino/commit/1ddb0f9976fcd9917aaf0b689ca0acc8635e24f1
 "trino/trino" = "479"
-"trino/storage-connector" = "477"
-# There is no 479 connector yet
-# "trino/storage-connector" = "479"
+"trino/storage-connector" = "477" # There is no 479 connector (yet?)
 
 [versions."479".build-arguments]
+jmx-exporter-version = "1.3.0"
+
+[versions."481".local-images]
+java-base = "25" # https://trino.io/docs/481/installation/deployment.html#java-runtime-environment
+"trino/trino" = "481"
+"trino/storage-connector" = "477" # There is no 481 connector (yet?)
+
+[versions."481".build-arguments]
 jmx-exporter-version = "1.3.0"

--- a/trino/trino/boil-config.toml
+++ b/trino/trino/boil-config.toml
@@ -1,11 +1,11 @@
 [versions."477".local-images]
-java-devel = "24"
-# Airlift version comes from <dep.airlift.version> in
-# https://github.com/trinodb/trino/blob/477/pom.xml
-"trino/airlift" = "361"
+java-devel = "24" # Same version as the "trino" image
+"trino/airlift" = "361" # https://github.com/trinodb/trino/blob/477/pom.xml#L184
 
 [versions."479".local-images]
-java-devel = "25"
-# Airlift version comes from <dep.airlift.version> in
-# https://github.com/trinodb/trino/blob/479/pom.xml
-"trino/airlift" = "386"
+java-devel = "25" # Same version as the "trino" image
+"trino/airlift" = "386" # https://github.com/trinodb/trino/blob/479/pom.xml#L185
+
+[versions."481".local-images]
+java-devel = "25" # Same version as the "trino" image
+"trino/airlift" = "424" # https://github.com/trinodb/trino/blob/481/pom.xml#L188

--- a/trino/trino/boil-config.toml
+++ b/trino/trino/boil-config.toml
@@ -1,11 +1,11 @@
 [versions."477".local-images]
 java-devel = "24" # Same version as the "trino" image
-"trino/airlift" = "361" # https://github.com/trinodb/trino/blob/477/pom.xml#L184
+"trino/airlift" = "361" # https://github.com/trinodb/trino/blob/477/pom.xml#L184 (dep.airlift.version)
 
 [versions."479".local-images]
 java-devel = "25" # Same version as the "trino" image
-"trino/airlift" = "386" # https://github.com/trinodb/trino/blob/479/pom.xml#L185
+"trino/airlift" = "386" # https://github.com/trinodb/trino/blob/479/pom.xml#L185 (dep.airlift.version)
 
 [versions."481".local-images]
 java-devel = "25" # Same version as the "trino" image
-"trino/airlift" = "424" # https://github.com/trinodb/trino/blob/481/pom.xml#L188
+"trino/airlift" = "424" # https://github.com/trinodb/trino/blob/481/pom.xml#L188 (dep.airlift.version)

--- a/trino/trino/stackable/patches/477/0002-Disable-web-ui-code-checking-because-flow-v0.241.0-f.patch
+++ b/trino/trino/stackable/patches/477/0002-Disable-web-ui-code-checking-because-flow-v0.241.0-f.patch
@@ -2,7 +2,7 @@ From 5800f14ed19ffaafb7286b5b17639a5df806c1c6 Mon Sep 17 00:00:00 2001
 From: dervoeti <lukas.krug@stackable.tech>
 Date: Wed, 18 Jun 2025 14:05:10 +0200
 Subject: Disable web-ui code checking, because flow v0.241.0 for non-x86
- systems requires glibc 2.35, as of 2025-06-18 our UBI image comes with glibc
+ systems requires glibc 2.35, as of 2026-06-02 our UBI image comes with glibc
  2.34. This patch can likely be removed once we ship a newer version of glibc.
 
 ---

--- a/trino/trino/stackable/patches/481/0001-Add-CycloneDX-plugin.patch
+++ b/trino/trino/stackable/patches/481/0001-Add-CycloneDX-plugin.patch
@@ -1,0 +1,38 @@
+From 8a2396b467657c4f6fefc6a213148af062d45064 Mon Sep 17 00:00:00 2001
+From: Lukas Voetmand <lukas.voetmand@stackable.tech>
+Date: Fri, 6 Sep 2024 17:53:52 +0200
+Subject: Add CycloneDX plugin
+
+---
+ pom.xml | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/pom.xml b/pom.xml
+index 06089658e13..64211354c06 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -2841,6 +2841,24 @@
+                     </excludes>
+                 </configuration>
+             </plugin>
++            <plugin>
++                <groupId>org.cyclonedx</groupId>
++                <artifactId>cyclonedx-maven-plugin</artifactId>
++                <version>2.9.1</version>
++                <configuration>
++                    <projectType>application</projectType>
++                    <schemaVersion>1.6</schemaVersion>
++                    <skipNotDeployed>false</skipNotDeployed>
++                </configuration>
++                <executions>
++                    <execution>
++                        <goals>
++                            <goal>makeBom</goal>
++                        </goals>
++                        <phase>package</phase>
++                    </execution>
++                </executions>
++            </plugin>
+         </plugins>
+     </build>
+ 

--- a/trino/trino/stackable/patches/481/0002-Disable-web-ui-code-checking-because-flow-v0.241.0-f.patch
+++ b/trino/trino/stackable/patches/481/0002-Disable-web-ui-code-checking-because-flow-v0.241.0-f.patch
@@ -1,4 +1,4 @@
-From 403776233d76994d21fb76c5e3ea89e82afca44e Mon Sep 17 00:00:00 2001
+From 25c453b54fcf184934d3057d4f57606ddf8594ea Mon Sep 17 00:00:00 2001
 From: dervoeti <lukas.krug@stackable.tech>
 Date: Wed, 18 Jun 2025 14:05:10 +0200
 Subject: Disable web-ui code checking, because flow v0.241.0 for non-x86
@@ -10,7 +10,7 @@ Subject: Disable web-ui code checking, because flow v0.241.0 for non-x86
  1 file changed, 22 deletions(-)
 
 diff --git a/core/trino-web-ui/pom.xml b/core/trino-web-ui/pom.xml
-index 565a5adf0c0..e172db8dabb 100644
+index 986d69101b2..3eb18fc3a2d 100644
 --- a/core/trino-web-ui/pom.xml
 +++ b/core/trino-web-ui/pom.xml
 @@ -104,28 +104,6 @@

--- a/trino/trino/stackable/patches/481/patchable.toml
+++ b/trino/trino/stackable/patches/481/patchable.toml
@@ -1,0 +1,2 @@
+mirror = "https://github.com/stackabletech/trino.git"
+base = "c4ac66cb4f86728b48f15b10d6ab3c1aa0166d3c"


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/docker-images/issues/1505.

This PR adds Trino 481 and marks 479 as deprecated. The trino-storage-connector still uses Trino 477, as there is no upstream version for 481 (or 479).

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [x] Changes are OpenShift compatible
- [x] All added packages (via microdnf or otherwise) have a comment on why they are added
- [x] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [x] All packages should have (if available) signatures/hashes verified
- [x] Add an entry to the CHANGELOG.md file
- [x] Integration tests (only smoke) ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
