### PR TITLE
chore!(nifi): Remove 1.28.1, deprecate 2.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - hadoop: Add precompiled hadoop for later reuse in dependent images ([#1466], [#1474]).
 - nifi: Add version `2.9.0` ([#1463]).
+- nifi: Remove `1.28.1`, deprecate `2.7.2` ([#1520]).
 - nifi: Backport NIFI-15801 to 2.x versions ([#1481]).
 - nifi: Backport NIFI-15901 to 2.x versions ([#1481]).
 - testing-tools: Added grpcurl utility ([#1493]).
@@ -50,6 +51,7 @@ All notable changes to this project will be documented in this file.
 [#1510]: https://github.com/stackabletech/docker-images/pull/1510
 [#1512]: https://github.com/stackabletech/docker-images/pull/1512
 [#1518]: https://github.com/stackabletech/docker-images/pull/1518
+[#1520]: https://github.com/stackabletech/docker-images/pull/1520
 
 ## [26.3.0] - 2026-03-16
 

--- a/nifi/boil-config.toml
+++ b/nifi/boil-config.toml
@@ -1,17 +1,6 @@
 [metadata.registries]
 "oci.stackable.tech" = { namespace = "sdp" }
 
-[versions."1.28.1".local-images]
-java-base = "11"
-java-devel = "11"
-"shared/logback" = "1.3.14" # https://github.com/apache/nifi/blob/rel/nifi-1.28.1/pom.xml#L146
-
-[versions."1.28.1".build-arguments]
-git-sync-version = "v4.4.1"
-# Check for new versions at the upstream: https://github.com/stackabletech/nifi-opa-plugin/tags
-# Checkout a Patchable version (patch-series) for the new tag
-nifi-opa-authorizer-plugin-version = "0.5.0"
-
 [versions."2.6.0".local-images]
 java-base = "21"
 java-devel = "21"

--- a/nifi/boil-config.toml
+++ b/nifi/boil-config.toml
@@ -16,6 +16,7 @@ nifi-opa-authorizer-plugin-version = "0.5.0"
 # Checkout a Patchable version (patch-series) for the new tag
 nifi-iceberg-bundle-version = "0.0.5"
 
+# Deprecated since 26.7.0
 [versions."2.7.2".local-images]
 java-base = "21" # As stated in GitHub README
 java-devel = "21"


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1498.

NiFi 2.9.0 was already added in #1463 and as such, only 1.28.1 is removed and 2.7.2 is deprecated.