### PR TITLE
chore(stackable-base): Bump `containerdebug` to `0.4.0` and  `config-utils` to `0.4.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to this project will be documented in this file.
 
 - hbase: Update `hbase-opa-authorizer` from `0.1.0` to `0.2.0` and then `0.3.0` ([#1446], [#1454]).
 - ci: Bump `docker/login-action` from `v3.6.0` to `v4.1.0` and `stackabletech/actions` to `v0.14.3` to escape Node.js 20 deprecation ([#1507]).
-- stackable-base: Bump `containerdebug` to `0.4.0` and  `config-utils` to `0.4.0` ([#XXXX]).
+- stackable-base: Bump `containerdebug` to `0.4.0` and  `config-utils` to `0.4.0` ([#1521]).
 
 ### Fixed
 
@@ -53,7 +53,7 @@ All notable changes to this project will be documented in this file.
 [#1512]: https://github.com/stackabletech/docker-images/pull/1512
 [#1518]: https://github.com/stackabletech/docker-images/pull/1518
 [#1520]: https://github.com/stackabletech/docker-images/pull/1520
-[#XXXX]: https://github.com/stackabletech/docker-images/pull/XXXX
+[#1521]: https://github.com/stackabletech/docker-images/pull/1521
 
 ## [26.3.0] - 2026-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 
 - hbase: Update `hbase-opa-authorizer` from `0.1.0` to `0.2.0` and then `0.3.0` ([#1446], [#1454]).
 - ci: Bump `docker/login-action` from `v3.6.0` to `v4.1.0` and `stackabletech/actions` to `v0.14.3` to escape Node.js 20 deprecation ([#1507]).
+- stackable-base: Bump `containerdebug` to `0.4.0` and  `config-utils` to `0.4.0` ([#XXXX]).
 
 ### Fixed
 
@@ -52,6 +53,7 @@ All notable changes to this project will be documented in this file.
 [#1512]: https://github.com/stackabletech/docker-images/pull/1512
 [#1518]: https://github.com/stackabletech/docker-images/pull/1518
 [#1520]: https://github.com/stackabletech/docker-images/pull/1520
+[#XXXX]: https://github.com/stackabletech/docker-images/pull/XXXX
 
 ## [26.3.0] - 2026-03-16
 

--- a/stackable-base/Dockerfile
+++ b/stackable-base/Dockerfile
@@ -11,10 +11,10 @@ FROM local-image/stackable-devel AS rust-binaries
 
 # Find the latest version here: https://github.com/stackabletech/config-utils/tags
 # renovate: datasource=github-tags packageName=stackabletech/config-utils
-ENV CONFIG_UTILS_VERSION=0.3.0
+ENV CONFIG_UTILS_VERSION=0.4.0
 # Find the latest version here: https://github.com/stackabletech/containerdebug/tags
 # renovate: datasource=github-tags packageName=stackabletech/containerdebug
-ENV CONTAINERDEBUG_VERSION=0.3.0
+ENV CONTAINERDEBUG_VERSION=0.4.0
 # Find the latest version here: https://github.com/stackabletech/secret-operator/tags
 # I could not find support for prefixes or regex in https://docs.renovatebot.com/modules/datasource/github-tags/,
 # so I was unable to add a renovate hint.


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/docker-images/issues/1479

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
