### PR TITLE
fix(spark-connect-client): Remove 3.5.7 and 4.0.1

### DIFF
--- a/spark-connect-client/boil-config.toml
+++ b/spark-connect-client/boil-config.toml
@@ -1,26 +1,12 @@
 [metadata.registries]
 "oci.stackable.tech" = { namespace = "stackable" }
 
-[versions."3.5.7".local-images]
-spark-k8s = "3.5.7"
-java-base = "17"
-
-[versions."3.5.7".build-arguments]
-python-version = "3.11"
-
 [versions."3.5.8".local-images]
 spark-k8s = "3.5.8"
 java-base = "17"
 
 [versions."3.5.8".build-arguments]
 python-version = "3.11"
-
-[versions."4.0.1".local-images]
-spark-k8s = "4.0.1"
-java-base = "21"
-
-[versions."4.0.1".build-arguments]
-python-version = "3.12"
 
 [versions."4.1.1".local-images]
 spark-k8s = "4.1.1"

--- a/spark-k8s/boil-config.toml
+++ b/spark-k8s/boil-config.toml
@@ -24,7 +24,6 @@ jmx-exporter-version = "1.3.0"
 tini-version = "0.19.0"
 hbase-connector-version = "1.0.1_3.5.8"
 
-
 # LTS since 26.7.0
 [versions."4.1.1"]
 containerfile = "Dockerfile.4"


### PR DESCRIPTION
This was missed in #1525 and results in image build failures.