### PR TITLE
feat(boil): Improve empty image version filter error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,9 +1703,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,37 @@ targets = [
 [advisories]
 yanked = "deny"
 ignore = [
+  # https://rustsec.org/advisories/RUSTSEC-2023-0071
+  # "rsa" crate: Marvin Attack: potential key recovery through timing sidechannel
+  #
+  # No patch is yet available, however work is underway to migrate to a fully constant-time implementation.
+  # So we need to accept this, as of SDP 26.3 we are "only" using the crate to create private +
+  # public key pairs used by webhooks, such as conversion or mutating webhooks.
+  #
+  # https://github.com/RustCrypto/RSA/issues/19 is the tracking issue
+  "RUSTSEC-2023-0071",
+
+  # https://rustsec.org/advisories/RUSTSEC-2024-0436
+  # The "paste" crate is no longer maintained because the owner states that the implementation is
+  # finished. There are at least two (forked) alternatives which state to be maintained. They'd
+  # need to be vetted before a potential switch. Additionally, they'd need to be in a maintained
+  # state for a couple of years to provide any benefit over using "paste".
+  #
+  # This crate is only used in a single place in the xtask package inside the declarative
+  # "write_crd" macro. The impact of vulnerabilities, if any, should be fairly minimal.
+  #
+  # See thread: https://users.rust-lang.org/t/paste-alternatives/126787/4
+  #
+  # This can only be removed again if we decide to use a different crate.
+  "RUSTSEC-2024-0436",
+
+  # https://rustsec.org/advisories/RUSTSEC-2026-0097
+  # rand 0.8.5 is unsound when log+thread_rng features are enabled and a custom logger calls rand::rng().
+  #
+  # This version is pulled in transitively via num-bigint-dig -> rsa -> stackable-certs and cannot be
+  # updated until the upstream rsa crate bumps its rand dependency.
+  "RUSTSEC-2026-0097",
+
   # https://rustsec.org/advisories/RUSTSEC-2026-0173
   # The author of `proc-macro-error2` has [confirmed](https://github.com/GnomedDev/proc-macro-error-2/issues/17#issuecomment-4643215473)
   # that the crate is no longer maintained and recommends that users migrate away from it.
@@ -72,6 +103,7 @@ license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
+allow-git = ["https://github.com/kube-rs/kube-rs"]
 
 [sources.allow-org]
 github = ["stackabletech"]

--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,20 @@ targets = [
 
 [advisories]
 yanked = "deny"
+ignore = [
+  # https://rustsec.org/advisories/RUSTSEC-2026-0173
+  # The author of `proc-macro-error2` has [confirmed](https://github.com/GnomedDev/proc-macro-error-2/issues/17#issuecomment-4643215473)
+  # that the crate is no longer maintained and recommends that users migrate away from it.
+  #
+  # There currently is no way for us to negate this advisory, because that crate is not used
+  # directly by us. We need to wait for new versions of oci-spec and getset.
+  #
+  # proc-macro-error2 v2.0.1
+  #  └── getset v0.1.6
+  #      └── oci-spec v0.9.0
+  #          └── boil v0.2.1
+  "RUSTSEC-2026-0173",
+]
 
 [bans]
 multiple-versions = "allow"
@@ -31,7 +45,7 @@ allow = [
   "LicenseRef-webpki",
   "MIT",
   "MPL-2.0",
-  "OpenSSL",           # Needed for the ring and/or aws-lc-sys crate. See https://github.com/stackabletech/operator-templating/pull/464 for details
+  "OpenSSL", # Needed for the ring and/or aws-lc-sys crate. See https://github.com/stackabletech/operator-templating/pull/464 for details
   "Unicode-3.0",
   "Unicode-DFS-2016",
   "Zlib",

--- a/deny.toml
+++ b/deny.toml
@@ -20,12 +20,18 @@ ignore = [
   # that the crate is no longer maintained and recommends that users migrate away from it.
   #
   # There currently is no way for us to negate this advisory, because that crate is not used
-  # directly by us. We need to wait for new versions of oci-spec and getset.
+  # directly by us. We need to wait for new versions of oci-spec and getset. See the following
+  # issue which tracks moving to a newer getset version: https://github.com/youki-dev/oci-spec-rs/issues/340
   #
   # proc-macro-error2 v2.0.1
   #  └── getset v0.1.6
   #      └── oci-spec v0.9.0
   #          └── boil v0.2.1
+  #
+  # Alternate crates are:
+  #
+  # - https://crates.io/crates/manyhow
+  # - https://github.com/SergioBenitez/proc-macro2-diagnostics
   "RUSTSEC-2026-0173",
 ]
 

--- a/rust/boil/src/core/bakefile.rs
+++ b/rust/boil/src/core/bakefile.rs
@@ -70,14 +70,17 @@ pub enum Error {
 
 #[derive(Debug, Snafu)]
 pub enum TargetsError {
-    #[snafu(display("encountered invalid image version"))]
-    InvalidImageVersion { source: ImageConfigError },
-
     #[snafu(display("failed to read image config"))]
     ReadImageConfig { source: ImageConfigError },
 
     #[snafu(display("failed to resolve parent directory of image config at {path}", path = path.display()))]
     ResolveParentDirectory { path: PathBuf },
+
+    #[snafu(display("provided filter version(s) ({image_name}={versions}) yielded empty list", versions = versions.join(", ")))]
+    EmptyFilter {
+        versions: Vec<String>,
+        image_name: String,
+    },
 }
 
 #[derive(Debug, Default)]
@@ -187,9 +190,15 @@ impl Targets {
                 ImageConfig::from_file(image_config_path).context(ReadImageConfigSnafu)?;
 
             // Create a list of image versions we need to generate targets for in the bakefile.
-            image_config
-                .filter_by_version(&image.versions)
-                .context(InvalidImageVersionSnafu)?;
+            image_config.filter_by_version(&image.versions);
+
+            ensure!(
+                !image_config.versions.is_empty(),
+                EmptyFilterSnafu {
+                    versions: image.versions.clone(),
+                    image_name: image.name.clone(),
+                }
+            );
 
             targets.insert_targets(image.name.clone(), image_config, &options, true)?;
         }
@@ -222,9 +231,15 @@ impl Targets {
                     let mut image_config =
                         ImageConfig::from_file(image_config_path).context(ReadImageConfigSnafu)?;
 
-                    image_config
-                        .filter_by_version(&[image_version])
-                        .context(InvalidImageVersionSnafu)?;
+                    image_config.filter_by_version(&[image_version]);
+
+                    ensure!(
+                        !image_config.versions.is_empty(),
+                        EmptyFilterSnafu {
+                            versions: vec![image_version.clone()],
+                            image_name: image_name.clone(),
+                        }
+                    );
 
                     // Wowzers, recursion!
                     self.insert_targets(image_name.clone(), image_config, options, false)?;

--- a/rust/boil/src/core/image.rs
+++ b/rust/boil/src/core/image.rs
@@ -108,9 +108,6 @@ pub enum ImageConfigError {
 
     #[snafu(display("failed to deserialize config file from TOML"))]
     Deserialize { source: toml::de::Error },
-
-    #[snafu(display("provided filter version yielded empty list"))]
-    EmptyFilter,
 }
 
 #[derive(Debug, Deserialize)]
@@ -130,16 +127,13 @@ impl ImageConfig {
     pub const FLAT_CONFIG_GLOB_PATTERN: &str = "*/boil-config.toml";
 
     /// This function removes versions in the config filtered out by `versions`.
-    pub fn filter_by_version<V>(&mut self, versions: &[V]) -> Result<(), ImageConfigError>
+    pub fn filter_by_version<V>(&mut self, versions: &[V])
     where
         V: AsRef<str> + PartialEq,
     {
         self.versions.retain(|image_version, _| {
             versions.is_empty() || versions.iter().any(|v| v.as_ref() == image_version)
         });
-
-        ensure!(!self.versions.is_empty(), EmptyFilterSnafu);
-        Ok(())
     }
 }
 


### PR DESCRIPTION
This now reports the image name and the filtered version(s) in the error. Previously, users would have to guess which image and version yielded an empty list.