### PR TITLE
chore: Use upstream deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -5,65 +5,65 @@
 
 [graph]
 targets = [
-  { triple = "x86_64-unknown-linux-gnu" },
-  { triple = "aarch64-unknown-linux-gnu" },
-  { triple = "x86_64-unknown-linux-musl" },
-  { triple = "aarch64-apple-darwin" },
-  { triple = "x86_64-apple-darwin" },
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "aarch64-unknown-linux-gnu" },
+    { triple = "x86_64-unknown-linux-musl" },
+    { triple = "aarch64-apple-darwin" },
+    { triple = "x86_64-apple-darwin" },
 ]
 
 [advisories]
 yanked = "deny"
 ignore = [
-  # https://rustsec.org/advisories/RUSTSEC-2023-0071
-  # "rsa" crate: Marvin Attack: potential key recovery through timing sidechannel
-  #
-  # No patch is yet available, however work is underway to migrate to a fully constant-time implementation.
-  # So we need to accept this, as of SDP 26.3 we are "only" using the crate to create private +
-  # public key pairs used by webhooks, such as conversion or mutating webhooks.
-  #
-  # https://github.com/RustCrypto/RSA/issues/19 is the tracking issue
-  "RUSTSEC-2023-0071",
+    # https://rustsec.org/advisories/RUSTSEC-2023-0071
+    # "rsa" crate: Marvin Attack: potential key recovery through timing sidechannel
+    #
+    # No patch is yet available, however work is underway to migrate to a fully constant-time implementation.
+    # So we need to accept this, as of SDP 26.3 we are "only" using the crate to create private +
+    # public key pairs used by webhooks, such as conversion or mutating webhooks.
+    #
+    # https://github.com/RustCrypto/RSA/issues/19 is the tracking issue
+    "RUSTSEC-2023-0071",
 
-  # https://rustsec.org/advisories/RUSTSEC-2024-0436
-  # The "paste" crate is no longer maintained because the owner states that the implementation is
-  # finished. There are at least two (forked) alternatives which state to be maintained. They'd
-  # need to be vetted before a potential switch. Additionally, they'd need to be in a maintained
-  # state for a couple of years to provide any benefit over using "paste".
-  #
-  # This crate is only used in a single place in the xtask package inside the declarative
-  # "write_crd" macro. The impact of vulnerabilities, if any, should be fairly minimal.
-  #
-  # See thread: https://users.rust-lang.org/t/paste-alternatives/126787/4
-  #
-  # This can only be removed again if we decide to use a different crate.
-  "RUSTSEC-2024-0436",
+    # https://rustsec.org/advisories/RUSTSEC-2024-0436
+    # The "paste" crate is no longer maintained because the owner states that the implementation is
+    # finished. There are at least two (forked) alternatives which state to be maintained. They'd
+    # need to be vetted before a potential switch. Additionally, they'd need to be in a maintained
+    # state for a couple of years to provide any benefit over using "paste".
+    #
+    # This crate is only used in a single place in the xtask package inside the declarative
+    # "write_crd" macro. The impact of vulnerabilities, if any, should be fairly minimal.
+    #
+    # See thread: https://users.rust-lang.org/t/paste-alternatives/126787/4
+    #
+    # This can only be removed again if we decide to use a different crate.
+    "RUSTSEC-2024-0436",
 
-  # https://rustsec.org/advisories/RUSTSEC-2026-0097
-  # rand 0.8.5 is unsound when log+thread_rng features are enabled and a custom logger calls rand::rng().
-  #
-  # This version is pulled in transitively via num-bigint-dig -> rsa -> stackable-certs and cannot be
-  # updated until the upstream rsa crate bumps its rand dependency.
-  "RUSTSEC-2026-0097",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0097
+    # rand 0.8.5 is unsound when log+thread_rng features are enabled and a custom logger calls rand::rng().
+    #
+    # This version is pulled in transitively via num-bigint-dig -> rsa -> stackable-certs and cannot be
+    # updated until the upstream rsa crate bumps its rand dependency.
+    "RUSTSEC-2026-0097",
 
-  # https://rustsec.org/advisories/RUSTSEC-2026-0173
-  # The author of `proc-macro-error2` has [confirmed](https://github.com/GnomedDev/proc-macro-error-2/issues/17#issuecomment-4643215473)
-  # that the crate is no longer maintained and recommends that users migrate away from it.
-  #
-  # There currently is no way for us to negate this advisory, because that crate is not used
-  # directly by us. We need to wait for new versions of oci-spec and getset. See the following
-  # issue which tracks moving to a newer getset version: https://github.com/youki-dev/oci-spec-rs/issues/340
-  #
-  # proc-macro-error2 v2.0.1
-  #  └── getset v0.1.6
-  #      └── oci-spec v0.9.0
-  #          └── boil v0.2.1
-  #
-  # Alternate crates are:
-  #
-  # - https://crates.io/crates/manyhow
-  # - https://github.com/SergioBenitez/proc-macro2-diagnostics
-  "RUSTSEC-2026-0173",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0173
+    # The author of `proc-macro-error2` has [confirmed](https://github.com/GnomedDev/proc-macro-error-2/issues/17#issuecomment-4643215473)
+    # that the crate is no longer maintained and recommends that users migrate away from it.
+    #
+    # There currently is no way for us to negate this advisory, because that crate is not used
+    # directly by us. We need to wait for new versions of oci-spec and getset. See the following
+    # issue which tracks moving to a newer getset version: https://github.com/youki-dev/oci-spec-rs/issues/340
+    #
+    # proc-macro-error2 v2.0.1
+    #  └── getset v0.1.6
+    #      └── oci-spec v0.9.0
+    #          └── boil v0.2.1
+    #
+    # Alternate crates are:
+    #
+    # - https://crates.io/crates/manyhow
+    # - https://github.com/SergioBenitez/proc-macro2-diagnostics
+    "RUSTSEC-2026-0173",
 ]
 
 [bans]
@@ -73,37 +73,43 @@ multiple-versions = "allow"
 unused-allowed-license = "allow"
 confidence-threshold = 1.0
 allow = [
-  "Apache-2.0",
-  "BSD-2-Clause",
-  "BSD-3-Clause",
-  "CC0-1.0",
-  "ISC",
-  "LicenseRef-ring",
-  "LicenseRef-webpki",
-  "MIT",
-  "MPL-2.0",
-  "OpenSSL", # Needed for the ring and/or aws-lc-sys crate. See https://github.com/stackabletech/operator-templating/pull/464 for details
-  "Unicode-3.0",
-  "Unicode-DFS-2016",
-  "Zlib",
-  "Unlicense",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "ISC",
+    "LicenseRef-ring",
+    "LicenseRef-webpki",
+    "MIT",
+    "MPL-2.0",
+    "OpenSSL", # Needed for the ring and/or aws-lc-sys crate. See https://github.com/stackabletech/operator-templating/pull/464 for details
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "Unlicense",
 ]
 private = { ignore = true }
 
 [[licenses.clarify]]
 name = "ring"
 expression = "LicenseRef-ring"
-license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
+]
 
 [[licenses.clarify]]
 name = "webpki"
 expression = "LicenseRef-webpki"
-license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]
+license-files = [
+    { path = "LICENSE", hash = 0x001c7e6c },
+]
 
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-allow-git = ["https://github.com/kube-rs/kube-rs"]
+allow-git = [
+    "https://github.com/kube-rs/kube-rs",
+]
 
 [sources.allow-org]
 github = ["stackabletech"]


### PR DESCRIPTION
Pull in the upstream version https://github.com/stackabletech/operator-templating/blob/main/template/deny.toml.
Yes, there is no templating in this repo, so I ran `cp ../operator-templating/template/deny.toml deny.toml` manually

Related to https://github.com/stackabletech/docker-images/pull/1527