### PR TITLE
fix(opa): Use $PRODUCT_VERSION instead of $PRODUCT

### DIFF
--- a/opa/Dockerfile
+++ b/opa/Dockerfile
@@ -66,7 +66,7 @@ COPY --from=golang-image /usr/local/go/ /usr/local/go/
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 COPY --chown=${STACKABLE_USER_UID}:0 opa/stackable/patches/patchable.toml /stackable/src/opa/stackable/patches/patchable.toml
-COPY --chown=${STACKABLE_USER_UID}:0 opa/stackable/patches/${PRODUCT} /stackable/src/opa/stackable/patches/${PRODUCT}
+COPY --chown=${STACKABLE_USER_UID}:0 opa/stackable/patches/${PRODUCT_VERSION} /stackable/src/opa/stackable/patches/${PRODUCT_VERSION}
 
 WORKDIR /stackable
 


### PR DESCRIPTION
This previously only worked by accident, because $PRODUCT expanded to nothing/an empty string and resulted in the complete 'patches' folder to be copied into the image. patchable was then able to properly patch OPA. #1524 added check=error=true to the Dockerfile which likely causes the current failures.

This PR fixes the error by using the proper variable.
