### PR TITLE
chore(nifi): Bump gitsync to 4.6.0 for all images

### DIFF
--- a/nifi/boil-config.toml
+++ b/nifi/boil-config.toml
@@ -7,7 +7,7 @@ java-devel = "21"
 "shared/logback" = "1.5.18" # https://github.com/apache/nifi/blob/rel/nifi-2.6.0/pom.xml#L156
 
 [versions."2.6.0".build-arguments]
-git-sync-version = "v4.4.1"
+git-sync-version = "v4.6.0"
 # Check for new versions at the upstream: https://github.com/stackabletech/nifi-opa-plugin/tags
 # Checkout a Patchable version (patch-series) for the new tag
 nifi-opa-authorizer-plugin-version = "0.5.0"
@@ -23,7 +23,7 @@ java-devel = "21"
 "shared/logback" = "1.5.24" # https://github.com/apache/nifi/blob/rel/nifi-2.7.2/pom.xml#L167
 
 [versions."2.7.2".build-arguments]
-git-sync-version = "v4.4.1"
+git-sync-version = "v4.6.0"
 # Check for new versions at the upstream: https://github.com/stackabletech/nifi-opa-plugin/tags
 # Checkout a Patchable version (patch-series) for the new tag
 nifi-opa-authorizer-plugin-version = "0.5.0"
@@ -34,7 +34,7 @@ java-devel = "21"
 "shared/logback" = "1.5.32" # https://github.com/apache/nifi/blob/rel/nifi-2.9.0/pom.xml#L171
 
 [versions."2.9.0".build-arguments]
-git-sync-version = "v4.4.1"
+git-sync-version = "v4.6.0"
 # Check for new versions at the upstream: https://github.com/stackabletech/nifi-opa-plugin/tags
 # Checkout a Patchable version (patch-series) for the new tag
 nifi-opa-authorizer-plugin-version = "0.5.0"


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1498