### PR TITLE
chore(java-devel): Bump Maven to 3.9.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to this project will be documented in this file.
 - spark-k8s: Remove `3.5.7` and `4.0.1` ([#1525]).
 - hive: Remove `4.1.0` ([#1539]).
 - druid: Remove `34.0.0` ([#1535]).
+- java-base: Drop Java 8 ([#1548]).
 
 [#1446]: https://github.com/stackabletech/docker-images/pull/1446
 [#1452]: https://github.com/stackabletech/docker-images/pull/1452

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 - hadoop: Refactor cloud library provisioning to downstream images. The jars are now conveniently placed in `/stackable/hadoop-cloud-libraries/` to be easily picked up ([#1511]).
 - spark: bump hadoop `3.4.2` to `3.4.3` ([#1533])
 - hive: Bump `4.2.0` to Hadoop `3.4.3` ([#1539]).
+- java-devel: Bump Maven to 3.9.16 ([#1548]).
 
 ### Fixed
 
@@ -79,6 +80,7 @@ All notable changes to this project will be documented in this file.
 [#1535]: https://github.com/stackabletech/docker-images/pull/1535
 [#1539]: https://github.com/stackabletech/docker-images/pull/1539
 [#1541]: https://github.com/stackabletech/docker-images/pull/1541
+[#1548]: https://github.com/stackabletech/docker-images/pull/1548
 
 ## [26.3.0] - 2026-03-16
 

--- a/java-base/boil-config.toml
+++ b/java-base/boil-config.toml
@@ -1,6 +1,3 @@
-[versions."8".local-images]
-vector = "0.55.0"
-
 [versions."11".local-images]
 vector = "0.55.0"
 

--- a/java-devel/Dockerfile
+++ b/java-devel/Dockerfile
@@ -12,7 +12,7 @@ ARG STACKABLE_USER_UID
 
 # Find the latest version here: https://github.com/apache/maven/releases
 # renovate: datasource=github-tags packageName=apache/maven
-ARG MAVEN_VERSION="3.9.14"
+ARG MAVEN_VERSION="3.9.16"
 
 # See: https://adoptium.net/en-gb/installation/linux/#_centosrhelfedora_instructions
 RUN cat <<EOF > /etc/yum.repos.d/adoptium.repo

--- a/shared/logback/boil-config.toml
+++ b/shared/logback/boil-config.toml
@@ -1,11 +1,15 @@
+# Used by ZooKeeper 3.9.4, 3.9.5
 [versions."1.3.15".local-images]
 java-devel = "21"
 
+# Used by NiFi 2.6.0
 [versions."1.5.18".local-images]
 java-devel = "21"
 
+# Used by NiFi 2.7.2 (Deprecated since 26.7)
 [versions."1.5.24".local-images]
 java-devel = "21"
 
+# Used by NiFi 2.9.0
 [versions."1.5.32".local-images]
 java-devel = "21"

--- a/shared/logback/boil-config.toml
+++ b/shared/logback/boil-config.toml
@@ -1,9 +1,3 @@
-[versions."1.2.13".local-images]
-java-devel = "8"
-
-[versions."1.3.14".local-images]
-java-devel = "21"
-
 [versions."1.3.15".local-images]
 java-devel = "21"
 


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1487

### Maven

Bump Maven to 3.9.16.

Changes since 3.9.14:
- https://github.com/apache/maven/releases/tag/maven-3.9.15
- https://github.com/apache/maven/releases/tag/maven-3.9.16

### java-base

Removed java-base 8 (nothing uses it).

> [!NOTE]
> Our deprecated Hive versions still uses java-devel 8, along with reload4j.

### logback

Remove `1.2.13` and `1.3.14`
