### PR TITLE
spike(nifi): Customize the theme

### DIFF
--- a/nifi/stackable/patches/2.9.0/0008-Apply-Stackable-Data-Platform-theme-to-web-UI.patch
+++ b/nifi/stackable/patches/2.9.0/0008-Apply-Stackable-Data-Platform-theme-to-web-UI.patch
@@ -1,0 +1,360 @@
+From 3b7dda63bbd01b44eacbf5e554cb0cc608f73000 Mon Sep 17 00:00:00 2001
+From: Nick Larsen <nick.larsen@stackable.tech>
+Date: Tue, 30 Jun 2026 19:07:19 +0200
+Subject: Apply Stackable Data Platform theme to web UI
+
+Re-themes the NiFi 2.x Angular UI with Stackable brand colors:
+- primary -> Stackable blue (#1680bd)
+- secondary -> Stackable magenta (#b80068)
+- tertiary -> Stackable accent blue (#7ca8d3)
+- error -> Stackable red (#dc2626 / #ef4444)
+- status colors (--nf-success/caution/error) aligned to Stackable tokens
+- dark-mode surfaces and canvas use the Stackable navy ladder (#0e1822 -> #3a5876)
+
+All changes are CSS-variable values in the shared Material theme; no logic changes.
+---
+ .../shared/src/assets/themes/material.scss    | 266 +++++++++---------
+ 1 file changed, 138 insertions(+), 128 deletions(-)
+
+diff --git a/nifi-frontend/src/main/frontend/libs/shared/src/assets/themes/material.scss b/nifi-frontend/src/main/frontend/libs/shared/src/assets/themes/material.scss
+index be93da637a..faaadbd93e 100644
+--- a/nifi-frontend/src/main/frontend/libs/shared/src/assets/themes/material.scss
++++ b/nifi-frontend/src/main/frontend/libs/shared/src/assets/themes/material.scss
+@@ -31,69 +31,73 @@
+
+ :root {
+     /* Material Design color palettes and typography for light mode. These are used by Angular Material SASS api's to define the theme for all Angular Material components. These variable should NOT be referenced outside of the theme file. */
++    /* Stackable theme: Tailwind/Stackable red ramp (#dc2626 / #ef4444) */
+     --md-ref-palette-error-0: #000000; /* Error 0 */
+     --md-ref-palette-error-10: #000000; /* Error 10 */
+     --md-ref-palette-error-20: #000000; /* Error 20 */
+-    --md-ref-palette-error-25: #a8372a; /* Error 25 */
+-    --md-ref-palette-error-30: #ba554a; /* Error 30 */
+-    --md-ref-palette-error-35: #ba554a; /* Error 35 */
+-    --md-ref-palette-error-40: #ba554a; /* Error 40 */
+-    --md-ref-palette-error-50: #eb7071; /* Error 50 */
+-    --md-ref-palette-error-60: #eb7071; /* Error 60 */
+-    --md-ref-palette-error-70: #eb7071; /* Error 70 */
+-    --md-ref-palette-error-80: #eb7071; /* Error 80 */
+-    --md-ref-palette-error-90: #f49999; /* Error 90 */
+-    --md-ref-palette-error-95: #f49999; /* Error 95 */
+-    --md-ref-palette-error-98: #ffccd2; /* Error 98 */
+-    --md-ref-palette-error-99: #ffccd2; /* Error 99 */
++    --md-ref-palette-error-25: #7f1d1d; /* Error 25 */
++    --md-ref-palette-error-30: #991b1b; /* Error 30 */
++    --md-ref-palette-error-35: #b91c1c; /* Error 35 */
++    --md-ref-palette-error-40: #dc2626; /* Error 40 */
++    --md-ref-palette-error-50: #ef4444; /* Error 50 */
++    --md-ref-palette-error-60: #ef4444; /* Error 60 */
++    --md-ref-palette-error-70: #f87171; /* Error 70 */
++    --md-ref-palette-error-80: #f87171; /* Error 80 */
++    --md-ref-palette-error-90: #fca5a5; /* Error 90 */
++    --md-ref-palette-error-95: #fecaca; /* Error 95 */
++    --md-ref-palette-error-98: #fee2e2; /* Error 98 */
++    --md-ref-palette-error-99: #fef2f2; /* Error 99 */
+     --md-ref-palette-error-100: #ffffff; /* Error 100 */
++    /* Stackable theme: accent blue ramp (#7ca8d3) used for the tertiary role */
+     --md-ref-palette-tertiary-0: #000000; /* Tertiary 0 */
+-    --md-ref-palette-tertiary-10: #3e2723; /* Tertiary 10 */
+-    --md-ref-palette-tertiary-20: #4e342e; /* Tertiary 20 */
+-    --md-ref-palette-tertiary-25: #4e342e; /* Tertiary 25 */
+-    --md-ref-palette-tertiary-30: #5d4037; /* Tertiary 30 */
+-    --md-ref-palette-tertiary-35: #6d4c41; /* Tertiary 35 */
+-    --md-ref-palette-tertiary-40: #795548; /* Tertiary 40 */
+-    --md-ref-palette-tertiary-50: #8d6e63; /* Tertiary 50 */
+-    --md-ref-palette-tertiary-60: #a1887f; /* Tertiary 60 */
+-    --md-ref-palette-tertiary-70: #bcaaa4; /* Tertiary 70 */
+-    --md-ref-palette-tertiary-80: #d7ccc8; /* Tertiary 80 */
+-    --md-ref-palette-tertiary-90: #d7ccc8; /* Tertiary 90 */
+-    --md-ref-palette-tertiary-95: #efebe9; /* Tertiary 95 */
+-    --md-ref-palette-tertiary-98: #efebe9; /* Tertiary 98 */
+-    --md-ref-palette-tertiary-99: #efebe9; /* Tertiary 99 */
++    --md-ref-palette-tertiary-10: #0d1f30; /* Tertiary 10 */
++    --md-ref-palette-tertiary-20: #1f3a52; /* Tertiary 20 */
++    --md-ref-palette-tertiary-25: #284763; /* Tertiary 25 */
++    --md-ref-palette-tertiary-30: #315473; /* Tertiary 30 */
++    --md-ref-palette-tertiary-35: #3a6184; /* Tertiary 35 */
++    --md-ref-palette-tertiary-40: #436f96; /* Tertiary 40 */
++    --md-ref-palette-tertiary-50: #5d88af; /* Tertiary 50 */
++    --md-ref-palette-tertiary-60: #7ca8d3; /* Tertiary 60 */
++    --md-ref-palette-tertiary-70: #9cc0e0; /* Tertiary 70 */
++    --md-ref-palette-tertiary-80: #bdd6ec; /* Tertiary 80 */
++    --md-ref-palette-tertiary-90: #deeaf7; /* Tertiary 90 */
++    --md-ref-palette-tertiary-95: #eef4fb; /* Tertiary 95 */
++    --md-ref-palette-tertiary-98: #f8fbfe; /* Tertiary 98 */
++    --md-ref-palette-tertiary-99: #fcfdff; /* Tertiary 99 */
+     --md-ref-palette-tertiary-100: #ffffff; /* Tertiary 100 */
++    /* Stackable theme: secondary magenta ramp (#b80068 / #d4107d) */
+     --md-ref-palette-secondary-0: #000000; /* Secondary 0 */
+-    --md-ref-palette-secondary-10: #314149; /* Secondary 10 */
+-    --md-ref-palette-secondary-20: #3f5863; /* Secondary 20 */
+-    --md-ref-palette-secondary-25: #4e6c79; /* Secondary 25 */
+-    --md-ref-palette-secondary-30: #597b8a; /* Secondary 30 */
+-    --md-ref-palette-secondary-35: #728e9b; /* Secondary 35 */
+-    --md-ref-palette-secondary-40: #8aa2ad; /* Secondary 40 */
+-    --md-ref-palette-secondary-50: #abbdc5; /* Secondary 50 */
+-    --md-ref-palette-secondary-60: #abbdc5; /* Secondary 60 */
+-    --md-ref-palette-secondary-70: #abbdc5; /* Secondary 70 */
+-    --md-ref-palette-secondary-80: #cbd8dd; /* Secondary 80 */
+-    --md-ref-palette-secondary-90: #cbd8dd; /* Secondary 90 */
+-    --md-ref-palette-secondary-95: #cbd8dd; /* Secondary 95 */
+-    --md-ref-palette-secondary-98: #cbd8dd; /* Secondary 98 */
+-    --md-ref-palette-secondary-99: #cbd8dd; /* Secondary 99 */
++    --md-ref-palette-secondary-10: #3d0021; /* Secondary 10 */
++    --md-ref-palette-secondary-20: #650038; /* Secondary 20 */
++    --md-ref-palette-secondary-25: #790043; /* Secondary 25 */
++    --md-ref-palette-secondary-30: #8e004e; /* Secondary 30 */
++    --md-ref-palette-secondary-35: #a3005a; /* Secondary 35 */
++    --md-ref-palette-secondary-40: #b80068; /* Secondary 40 */
++    --md-ref-palette-secondary-50: #d4107d; /* Secondary 50 */
++    --md-ref-palette-secondary-60: #e2569f; /* Secondary 60 */
++    --md-ref-palette-secondary-70: #ee85bc; /* Secondary 70 */
++    --md-ref-palette-secondary-80: #f7b3d6; /* Secondary 80 */
++    --md-ref-palette-secondary-90: #ffd9e9; /* Secondary 90 */
++    --md-ref-palette-secondary-95: #ffecf2; /* Secondary 95 */
++    --md-ref-palette-secondary-98: #fff8fa; /* Secondary 98 */
++    --md-ref-palette-secondary-99: #fffbfc; /* Secondary 99 */
+     --md-ref-palette-secondary-100: #ffffff; /* Secondary 100 */
++    /* Stackable theme: primary blue ramp (#1680bd) */
+     --md-ref-palette-primary-0: #000000; /* Primary 0 */
+-    --md-ref-palette-primary-10: #002020; /* Primary 10 */
+-    --md-ref-palette-primary-20: #003738; /* Primary 20 */
+-    --md-ref-palette-primary-25: #004344; /* Primary 25 */
+-    --md-ref-palette-primary-30: #004849; /* Primary 30 */
+-    --md-ref-palette-primary-35: #004849; /* Primary 35 */
+-    --md-ref-palette-primary-40: #004849; /* Primary 40 */
+-    --md-ref-palette-primary-50: #478081; /* Primary 50 */
+-    --md-ref-palette-primary-60: #629a9b; /* Primary 60 */
+-    --md-ref-palette-primary-70: #7cb5b6; /* Primary 70 */
+-    --md-ref-palette-primary-80: #97d1d1; /* Primary 80 */
+-    --md-ref-palette-primary-90: #b3eded; /* Primary 90 */
+-    --md-ref-palette-primary-95: #c1fbfc; /* Primary 95 */
+-    --md-ref-palette-primary-98: #e2ffff; /* Primary 98 */
+-    --md-ref-palette-primary-99: #f1fffe; /* Primary 99 */
++    --md-ref-palette-primary-10: #001e30; /* Primary 10 */
++    --md-ref-palette-primary-20: #00344f; /* Primary 20 */
++    --md-ref-palette-primary-25: #003f5f; /* Primary 25 */
++    --md-ref-palette-primary-30: #004b70; /* Primary 30 */
++    --md-ref-palette-primary-35: #005a86; /* Primary 35 */
++    --md-ref-palette-primary-40: #1680bd; /* Primary 40 */
++    --md-ref-palette-primary-50: #2f93cf; /* Primary 50 */
++    --md-ref-palette-primary-60: #5aa9da; /* Primary 60 */
++    --md-ref-palette-primary-70: #82c0ea; /* Primary 70 */
++    --md-ref-palette-primary-80: #a6d3f3; /* Primary 80 */
++    --md-ref-palette-primary-90: #cfe7fa; /* Primary 90 */
++    --md-ref-palette-primary-95: #e7f3fd; /* Primary 95 */
++    --md-ref-palette-primary-98: #f4faff; /* Primary 98 */
++    --md-ref-palette-primary-99: #fafdff; /* Primary 99 */
+     --md-ref-palette-primary-100: #ffffff; /* Primary 100 */
+     --md-ref-palette-neutral-variant-0: #000000; /* Neutral Variant 0 */
+     --md-ref-palette-neutral-variant-10: #303030; /* Neutral Variant 10 */
+@@ -144,15 +148,15 @@
+     --md-ref-typeface-weight-regular: 400; /* Regular weight */
+
+     /* Nifi Light mode. Use these variables when applying colors to elements */
+-    --nf-success-default: #31975b; /* The success color  */
++    --nf-success-default: #16a34a; /* The success color (Stackable green)  */
+     --nf-success-default-background: #bdf8e9;
+-    --nf-success-variant: #1390ca; /* The success variant color  */
++    --nf-success-variant: #1680bd; /* The success variant color (Stackable blue)  */
+     --nf-success-contrast: #ffffff; /* The success contrast color */
+-    --nf-caution-default: #cf9338; /* The caution color  */
++    --nf-caution-default: #d97706; /* The caution color (Stackable amber)  */
+     --nf-caution-contrast: #ffffff; /* The caution contrast color */
+     --nf-neutral: #666666; /* The neutral color  */
+     --nf-disabled: #d8d8d8; /* The color to use for disabled */
+-    --nf-error-variant: #eb7071; /* The stopped run status color  */
++    --nf-error-variant: #dc2626; /* The stopped run status color (Stackable red)  */
+     --nf-new-canvas-item-grip: #ffffff; /* The new canvas item grip color */
+     --nf-new-canvas-item-hover: #ffffff; /* The new canvas item hover color */
+     --nf-resizable-triangle: rgba(18, 18, 18, 0.2); /* The color of the resize handle */
+@@ -522,69 +526,73 @@ html {
+ /* Dark Theme */
+ .darkMode {
+     /* Material Design color palettes and typography for dark mode. These are used by Angular Material SASS api's to define the theme for all Angular Material components. These variable should NOT be referenced outside of the theme file. */
++    /* Stackable theme: Tailwind/Stackable red ramp (#dc2626 / #ef4444) */
+     --md-ref-palette-error-0: #000000; /* Error 0 */
+     --md-ref-palette-error-10: #000000; /* Error 10 */
+     --md-ref-palette-error-20: #000000; /* Error 20 */
+-    --md-ref-palette-error-25: #a8372a; /* Error 25 */
+-    --md-ref-palette-error-30: #ba554a; /* Error 30 */
+-    --md-ref-palette-error-35: #ba554a; /* Error 35 */
+-    --md-ref-palette-error-40: #ba554a; /* Error 40 */
+-    --md-ref-palette-error-50: #eb7071; /* Error 50 */
+-    --md-ref-palette-error-60: #eb7071; /* Error 60 */
+-    --md-ref-palette-error-70: #eb7071; /* Error 70 */
+-    --md-ref-palette-error-80: #eb7071; /* Error 80 */
+-    --md-ref-palette-error-90: #f49999; /* Error 90 */
+-    --md-ref-palette-error-95: #f49999; /* Error 95 */
+-    --md-ref-palette-error-98: #ffccd2; /* Error 98 */
+-    --md-ref-palette-error-99: #ffccd2; /* Error 99 */
++    --md-ref-palette-error-25: #7f1d1d; /* Error 25 */
++    --md-ref-palette-error-30: #991b1b; /* Error 30 */
++    --md-ref-palette-error-35: #b91c1c; /* Error 35 */
++    --md-ref-palette-error-40: #dc2626; /* Error 40 */
++    --md-ref-palette-error-50: #ef4444; /* Error 50 */
++    --md-ref-palette-error-60: #ef4444; /* Error 60 */
++    --md-ref-palette-error-70: #f87171; /* Error 70 */
++    --md-ref-palette-error-80: #f87171; /* Error 80 */
++    --md-ref-palette-error-90: #fca5a5; /* Error 90 */
++    --md-ref-palette-error-95: #fecaca; /* Error 95 */
++    --md-ref-palette-error-98: #fee2e2; /* Error 98 */
++    --md-ref-palette-error-99: #fef2f2; /* Error 99 */
+     --md-ref-palette-error-100: #ffffff; /* Error 100 */
++    /* Stackable theme: accent blue ramp (#7ca8d3) used for the tertiary role */
+     --md-ref-palette-tertiary-0: #000000; /* Tertiary 0 */
+-    --md-ref-palette-tertiary-10: #3e2723; /* Tertiary 10 */
+-    --md-ref-palette-tertiary-20: #4e342e; /* Tertiary 20 */
+-    --md-ref-palette-tertiary-25: #4e342e; /* Tertiary 25 */
+-    --md-ref-palette-tertiary-30: #5d4037; /* Tertiary 30 */
+-    --md-ref-palette-tertiary-35: #6d4c41; /* Tertiary 35 */
+-    --md-ref-palette-tertiary-40: #795548; /* Tertiary 40 */
+-    --md-ref-palette-tertiary-50: #8d6e63; /* Tertiary 50 */
+-    --md-ref-palette-tertiary-60: #a1887f; /* Tertiary 60 */
+-    --md-ref-palette-tertiary-70: #bcaaa4; /* Tertiary 70 */
+-    --md-ref-palette-tertiary-80: #d7ccc8; /* Tertiary 80 */
+-    --md-ref-palette-tertiary-90: #d7ccc8; /* Tertiary 90 */
+-    --md-ref-palette-tertiary-95: #efebe9; /* Tertiary 95 */
+-    --md-ref-palette-tertiary-98: #efebe9; /* Tertiary 98 */
+-    --md-ref-palette-tertiary-99: #efebe9; /* Tertiary 99 */
++    --md-ref-palette-tertiary-10: #0d1f30; /* Tertiary 10 */
++    --md-ref-palette-tertiary-20: #1f3a52; /* Tertiary 20 */
++    --md-ref-palette-tertiary-25: #284763; /* Tertiary 25 */
++    --md-ref-palette-tertiary-30: #315473; /* Tertiary 30 */
++    --md-ref-palette-tertiary-35: #3a6184; /* Tertiary 35 */
++    --md-ref-palette-tertiary-40: #436f96; /* Tertiary 40 */
++    --md-ref-palette-tertiary-50: #5d88af; /* Tertiary 50 */
++    --md-ref-palette-tertiary-60: #7ca8d3; /* Tertiary 60 */
++    --md-ref-palette-tertiary-70: #9cc0e0; /* Tertiary 70 */
++    --md-ref-palette-tertiary-80: #bdd6ec; /* Tertiary 80 */
++    --md-ref-palette-tertiary-90: #deeaf7; /* Tertiary 90 */
++    --md-ref-palette-tertiary-95: #eef4fb; /* Tertiary 95 */
++    --md-ref-palette-tertiary-98: #f8fbfe; /* Tertiary 98 */
++    --md-ref-palette-tertiary-99: #fcfdff; /* Tertiary 99 */
+     --md-ref-palette-tertiary-100: #ffffff; /* Tertiary 100 */
++    /* Stackable theme: secondary magenta ramp (#b80068 / #d4107d) */
+     --md-ref-palette-secondary-0: #000000; /* Secondary 0 */
+-    --md-ref-palette-secondary-10: #000000; /* Secondary 10 */
+-    --md-ref-palette-secondary-20: #000000; /* Secondary 20 */
+-    --md-ref-palette-secondary-25: #4e6c79; /* Secondary 25 */
+-    --md-ref-palette-secondary-30: #597b8a; /* Secondary 30 */
+-    --md-ref-palette-secondary-35: #728e9b; /* Secondary 35 */
+-    --md-ref-palette-secondary-40: #8aa2ad; /* Secondary 40 */
+-    --md-ref-palette-secondary-50: #abbdc5; /* Secondary 50 */
+-    --md-ref-palette-secondary-60: #abbdc5; /* Secondary 60 */
+-    --md-ref-palette-secondary-70: #abbdc5; /* Secondary 70 */
+-    --md-ref-palette-secondary-80: #cbd8dd; /* Secondary 80 */
+-    --md-ref-palette-secondary-90: #cbd8dd; /* Secondary 90 */
+-    --md-ref-palette-secondary-95: #cbd8dd; /* Secondary 95 */
+-    --md-ref-palette-secondary-98: #cbd8dd; /* Secondary 98 */
+-    --md-ref-palette-secondary-99: #cbd8dd; /* Secondary 99 */
++    --md-ref-palette-secondary-10: #3d0021; /* Secondary 10 */
++    --md-ref-palette-secondary-20: #650038; /* Secondary 20 */
++    --md-ref-palette-secondary-25: #790043; /* Secondary 25 */
++    --md-ref-palette-secondary-30: #8e004e; /* Secondary 30 */
++    --md-ref-palette-secondary-35: #a3005a; /* Secondary 35 */
++    --md-ref-palette-secondary-40: #b80068; /* Secondary 40 */
++    --md-ref-palette-secondary-50: #d4107d; /* Secondary 50 */
++    --md-ref-palette-secondary-60: #e2569f; /* Secondary 60 */
++    --md-ref-palette-secondary-70: #ee85bc; /* Secondary 70 */
++    --md-ref-palette-secondary-80: #f7b3d6; /* Secondary 80 */
++    --md-ref-palette-secondary-90: #ffd9e9; /* Secondary 90 */
++    --md-ref-palette-secondary-95: #ffecf2; /* Secondary 95 */
++    --md-ref-palette-secondary-98: #fff8fa; /* Secondary 98 */
++    --md-ref-palette-secondary-99: #fffbfc; /* Secondary 99 */
+     --md-ref-palette-secondary-100: #ffffff; /* Secondary 100 */
++    /* Stackable theme: primary blue ramp (#1680bd) */
+     --md-ref-palette-primary-0: #000000; /* Primary 0 */
+-    --md-ref-palette-primary-10: #000000; /* Primary 10 */
+-    --md-ref-palette-primary-20: #000000; /* Primary 20 */
+-    --md-ref-palette-primary-25: #4e6c79; /* Primary 25 */
+-    --md-ref-palette-primary-30: #597b8a; /* Primary 30 */
+-    --md-ref-palette-primary-35: #728e9b; /* Primary 35 */
+-    --md-ref-palette-primary-40: #8aa2ad; /* Primary 40 */
+-    --md-ref-palette-primary-50: #abbdc5; /* Primary 50 */
+-    --md-ref-palette-primary-60: #abbdc5; /* Primary 60 */
+-    --md-ref-palette-primary-70: #abbdc5; /* Primary 70 */
+-    --md-ref-palette-primary-80: #cbd8dd; /* Primary 80 */
+-    --md-ref-palette-primary-90: #cbd8dd; /* Primary 90 */
+-    --md-ref-palette-primary-95: #cbd8dd; /* Primary 95 */
+-    --md-ref-palette-primary-98: #cbd8dd; /* Primary 98 */
+-    --md-ref-palette-primary-99: #cbd8dd; /* Primary 99 */
++    --md-ref-palette-primary-10: #001e30; /* Primary 10 */
++    --md-ref-palette-primary-20: #00344f; /* Primary 20 */
++    --md-ref-palette-primary-25: #003f5f; /* Primary 25 */
++    --md-ref-palette-primary-30: #004b70; /* Primary 30 */
++    --md-ref-palette-primary-35: #005a86; /* Primary 35 */
++    --md-ref-palette-primary-40: #1680bd; /* Primary 40 */
++    --md-ref-palette-primary-50: #2f93cf; /* Primary 50 */
++    --md-ref-palette-primary-60: #5aa9da; /* Primary 60 */
++    --md-ref-palette-primary-70: #82c0ea; /* Primary 70 */
++    --md-ref-palette-primary-80: #a6d3f3; /* Primary 80 */
++    --md-ref-palette-primary-90: #cfe7fa; /* Primary 90 */
++    --md-ref-palette-primary-95: #e7f3fd; /* Primary 95 */
++    --md-ref-palette-primary-98: #f4faff; /* Primary 98 */
++    --md-ref-palette-primary-99: #fafdff; /* Primary 99 */
+     --md-ref-palette-primary-100: #ffffff; /* Primary 100 */
+     --md-ref-palette-neutral-variant-0: #000000; /* Neutral Variant 0 */
+     --md-ref-palette-neutral-variant-10: #303030; /* Neutral Variant 10 */
+@@ -602,17 +610,19 @@ html {
+     --md-ref-palette-neutral-variant-98: #fafafa; /* Neutral Variant 98 */
+     --md-ref-palette-neutral-variant-99: #fafafa; /* Neutral Variant 99 */
+     --md-ref-palette-neutral-variant-100: #ffffff; /* Neutral Variant 100 */
++    /* Stackable theme: dark-mode surfaces use the Stackable navy ladder
++       (#0e1822 -> #3a5876). Tones 35+ stay neutral gray for text/icon contrast. */
+     --md-ref-palette-neutral-0: #0000001f; /* Neutral 0 */
+-    --md-ref-palette-neutral-4: #303030; /* Neutral 4 */
+-    --md-ref-palette-neutral-6: #303030; /* Neutral 6 */
+-    --md-ref-palette-neutral-10: #303030; /* Neutral 10 */
+-    --md-ref-palette-neutral-12: #444444; /* Neutral 12 */
+-    --md-ref-palette-neutral-17: #444444; /* Neutral 17 */
+-    --md-ref-palette-neutral-20: #444444; /* Neutral 20 */
+-    --md-ref-palette-neutral-22: #444444; /* Neutral 22 */
+-    --md-ref-palette-neutral-24: #444444; /* Neutral 24 */
+-    --md-ref-palette-neutral-25: #666666; /* Neutral 25 */
+-    --md-ref-palette-neutral-30: #666666; /* Neutral 30 */
++    --md-ref-palette-neutral-4: #0e1822; /* Neutral 4 */
++    --md-ref-palette-neutral-6: #122230; /* Neutral 6 */
++    --md-ref-palette-neutral-10: #182c3d; /* Neutral 10 */
++    --md-ref-palette-neutral-12: #1e3548; /* Neutral 12 */
++    --md-ref-palette-neutral-17: #243f54; /* Neutral 17 */
++    --md-ref-palette-neutral-20: #2a4562; /* Neutral 20 */
++    --md-ref-palette-neutral-22: #2a4562; /* Neutral 22 */
++    --md-ref-palette-neutral-24: #2f4a68; /* Neutral 24 */
++    --md-ref-palette-neutral-25: #3a5876; /* Neutral 25 */
++    --md-ref-palette-neutral-30: #3a5876; /* Neutral 30 */
+     --md-ref-palette-neutral-35: #666666; /* Neutral 35 */
+     --md-ref-palette-neutral-40: #acacac; /* Neutral 40 */
+     --md-ref-palette-neutral-50: #acacac; /* Neutral 50 */
+@@ -635,25 +645,25 @@ html {
+     --md-ref-typeface-weight-regular: 400; /* Regular weight */
+
+     /* Nifi Dark mode. Use these variables when applying colors to elements */
+-    --nf-success-default: #31975b; /* The success color  */
++    --nf-success-default: #22c55e; /* The success color (Stackable green)  */
+     --nf-success-default-background: #bdf8e9;
+-    --nf-success-variant: #1390ca; /* The success variant color  */
++    --nf-success-variant: #1680bd; /* The success variant color (Stackable blue)  */
+     --nf-success-contrast: #ffffff; /* The success contrast color */
+-    --nf-caution-default: #cf9338; /* The caution color  */
++    --nf-caution-default: #f59e0b; /* The caution color (Stackable amber)  */
+     --nf-caution-contrast: #ffffff; /* The caution contrast color */
+     --nf-neutral: #acacac; /* The neutral color  */
+     --nf-disabled: #cccccc; /* The color to use for disabled */
+-    --nf-error-variant: #f49999; /* The stopped run status color  */
++    --nf-error-variant: #ef4444; /* The stopped run status color (Stackable red)  */
+     --nf-new-canvas-item-grip: #000000; /* The new canvas item grip color  */
+     --nf-new-canvas-item-hover: #ffffff; /* The new canvas item hover color  */
+     --nf-resizable-triangle: rgba(18, 18, 18, 0.2); /* The color of the resize handle */
+     --nf-banner: #f4f4f414; /* The banner row color */
+     --nf-odd: #f4f4f406; /* The odd background color */
+-    --nf-even: #303030; /* The even background color */
++    --nf-even: #1e3548; /* The even background color (Stackable navy surface)  */
+     --nf-text-shadow: 0 0 4px rgba(0, 0, 0, 1); /* The text shadow color */
+     --nf-zero-opactiy: 0.5; /* The zero opacity color */
+     --nf-connection-drop-shadow: black; /* The connection drop shadow color */
+-    --nf-canvas-background: #0d1411; /* The canvas background color */
++    --nf-canvas-background: #122435; /* The canvas background color (Stackable navy)  */
+     --nf-canvas-border-stroke-width: 2; /* The canvas border stroke width */
+
+     // Codemirror syntax highlighting


### PR DESCRIPTION
Very rough colour selection:

<img width="1919" height="764" alt="image" src="https://github.com/user-attachments/assets/90f9dd04-7921-4bd7-b76c-1a6a220096d1" />

<img width="1919" height="716" alt="image" src="https://github.com/user-attachments/assets/4a81ec0a-fb13-4ffb-8ece-28df966bbb66" />


To test quicker:

<details><summary>stackable-theme.css</summary>

```css
/*
 * Stackable Data Platform theme overrides for the NiFi 2.x web UI.
 *
 * These re-assign the CSS custom properties that NiFi's Angular Material theme
 * is built on. They are resolved live (same mechanism as NiFi's dark-mode
 * toggle), so appending this file to the already-compiled styles-<hash>.css
 * re-themes the UI without recompiling the frontend.
 *
 * Mirrors patch 0008-Apply-Stackable-Data-Platform-theme-to-web-UI.patch.
 */

/* ----- Light mode ----- */
:root {
    /* primary -> Stackable blue (#1680bd) */
    --md-ref-palette-primary-0: #000000;
    --md-ref-palette-primary-10: #001e30;
    --md-ref-palette-primary-20: #00344f;
    --md-ref-palette-primary-25: #003f5f;
    --md-ref-palette-primary-30: #004b70;
    --md-ref-palette-primary-35: #005a86;
    --md-ref-palette-primary-40: #1680bd;
    --md-ref-palette-primary-50: #2f93cf;
    --md-ref-palette-primary-60: #5aa9da;
    --md-ref-palette-primary-70: #82c0ea;
    --md-ref-palette-primary-80: #a6d3f3;
    --md-ref-palette-primary-90: #cfe7fa;
    --md-ref-palette-primary-95: #e7f3fd;
    --md-ref-palette-primary-98: #f4faff;
    --md-ref-palette-primary-99: #fafdff;
    --md-ref-palette-primary-100: #ffffff;
    /* secondary -> Stackable magenta (#b80068 / #d4107d) */
    --md-ref-palette-secondary-0: #000000;
    --md-ref-palette-secondary-10: #3d0021;
    --md-ref-palette-secondary-20: #650038;
    --md-ref-palette-secondary-25: #790043;
    --md-ref-palette-secondary-30: #8e004e;
    --md-ref-palette-secondary-35: #a3005a;
    --md-ref-palette-secondary-40: #b80068;
    --md-ref-palette-secondary-50: #d4107d;
    --md-ref-palette-secondary-60: #e2569f;
    --md-ref-palette-secondary-70: #ee85bc;
    --md-ref-palette-secondary-80: #f7b3d6;
    --md-ref-palette-secondary-90: #ffd9e9;
    --md-ref-palette-secondary-95: #ffecf2;
    --md-ref-palette-secondary-98: #fff8fa;
    --md-ref-palette-secondary-99: #fffbfc;
    --md-ref-palette-secondary-100: #ffffff;
    /* tertiary -> Stackable accent blue (#7ca8d3) */
    --md-ref-palette-tertiary-0: #000000;
    --md-ref-palette-tertiary-10: #0d1f30;
    --md-ref-palette-tertiary-20: #1f3a52;
    --md-ref-palette-tertiary-25: #284763;
    --md-ref-palette-tertiary-30: #315473;
    --md-ref-palette-tertiary-35: #3a6184;
    --md-ref-palette-tertiary-40: #436f96;
    --md-ref-palette-tertiary-50: #5d88af;
    --md-ref-palette-tertiary-60: #7ca8d3;
    --md-ref-palette-tertiary-70: #9cc0e0;
    --md-ref-palette-tertiary-80: #bdd6ec;
    --md-ref-palette-tertiary-90: #deeaf7;
    --md-ref-palette-tertiary-95: #eef4fb;
    --md-ref-palette-tertiary-98: #f8fbfe;
    --md-ref-palette-tertiary-99: #fcfdff;
    --md-ref-palette-tertiary-100: #ffffff;
    /* error -> Stackable red (#dc2626 / #ef4444) */
    --md-ref-palette-error-25: #7f1d1d;
    --md-ref-palette-error-30: #991b1b;
    --md-ref-palette-error-35: #b91c1c;
    --md-ref-palette-error-40: #dc2626;
    --md-ref-palette-error-50: #ef4444;
    --md-ref-palette-error-60: #ef4444;
    --md-ref-palette-error-70: #f87171;
    --md-ref-palette-error-80: #f87171;
    --md-ref-palette-error-90: #fca5a5;
    --md-ref-palette-error-95: #fecaca;
    --md-ref-palette-error-98: #fee2e2;
    --md-ref-palette-error-99: #fef2f2;
    /* NiFi status colors */
    --nf-success-default: #16a34a;
    --nf-success-variant: #1680bd;
    --nf-caution-default: #d97706;
    --nf-error-variant: #dc2626;
}

/* ----- Dark mode ----- */
.darkMode {
    /* primary -> Stackable blue (#1680bd) */
    --md-ref-palette-primary-0: #000000;
    --md-ref-palette-primary-10: #001e30;
    --md-ref-palette-primary-20: #00344f;
    --md-ref-palette-primary-25: #003f5f;
    --md-ref-palette-primary-30: #004b70;
    --md-ref-palette-primary-35: #005a86;
    --md-ref-palette-primary-40: #1680bd;
    --md-ref-palette-primary-50: #2f93cf;
    --md-ref-palette-primary-60: #5aa9da;
    --md-ref-palette-primary-70: #82c0ea;
    --md-ref-palette-primary-80: #a6d3f3;
    --md-ref-palette-primary-90: #cfe7fa;
    --md-ref-palette-primary-95: #e7f3fd;
    --md-ref-palette-primary-98: #f4faff;
    --md-ref-palette-primary-99: #fafdff;
    --md-ref-palette-primary-100: #ffffff;
    /* secondary -> Stackable magenta (#b80068 / #d4107d) */
    --md-ref-palette-secondary-0: #000000;
    --md-ref-palette-secondary-10: #3d0021;
    --md-ref-palette-secondary-20: #650038;
    --md-ref-palette-secondary-25: #790043;
    --md-ref-palette-secondary-30: #8e004e;
    --md-ref-palette-secondary-35: #a3005a;
    --md-ref-palette-secondary-40: #b80068;
    --md-ref-palette-secondary-50: #d4107d;
    --md-ref-palette-secondary-60: #e2569f;
    --md-ref-palette-secondary-70: #ee85bc;
    --md-ref-palette-secondary-80: #f7b3d6;
    --md-ref-palette-secondary-90: #ffd9e9;
    --md-ref-palette-secondary-95: #ffecf2;
    --md-ref-palette-secondary-98: #fff8fa;
    --md-ref-palette-secondary-99: #fffbfc;
    --md-ref-palette-secondary-100: #ffffff;
    /* tertiary -> Stackable accent blue (#7ca8d3) */
    --md-ref-palette-tertiary-0: #000000;
    --md-ref-palette-tertiary-10: #0d1f30;
    --md-ref-palette-tertiary-20: #1f3a52;
    --md-ref-palette-tertiary-25: #284763;
    --md-ref-palette-tertiary-30: #315473;
    --md-ref-palette-tertiary-35: #3a6184;
    --md-ref-palette-tertiary-40: #436f96;
    --md-ref-palette-tertiary-50: #5d88af;
    --md-ref-palette-tertiary-60: #7ca8d3;
    --md-ref-palette-tertiary-70: #9cc0e0;
    --md-ref-palette-tertiary-80: #bdd6ec;
    --md-ref-palette-tertiary-90: #deeaf7;
    --md-ref-palette-tertiary-95: #eef4fb;
    --md-ref-palette-tertiary-98: #f8fbfe;
    --md-ref-palette-tertiary-99: #fcfdff;
    --md-ref-palette-tertiary-100: #ffffff;
    /* error -> Stackable red (#dc2626 / #ef4444) */
    --md-ref-palette-error-25: #7f1d1d;
    --md-ref-palette-error-30: #991b1b;
    --md-ref-palette-error-35: #b91c1c;
    --md-ref-palette-error-40: #dc2626;
    --md-ref-palette-error-50: #ef4444;
    --md-ref-palette-error-60: #ef4444;
    --md-ref-palette-error-70: #f87171;
    --md-ref-palette-error-80: #f87171;
    --md-ref-palette-error-90: #fca5a5;
    --md-ref-palette-error-95: #fecaca;
    --md-ref-palette-error-98: #fee2e2;
    --md-ref-palette-error-99: #fef2f2;
    /* dark-mode surfaces -> Stackable navy ladder (#0e1822 -> #3a5876) */
    --md-ref-palette-neutral-4: #0e1822;
    --md-ref-palette-neutral-6: #122230;
    --md-ref-palette-neutral-10: #182c3d;
    --md-ref-palette-neutral-12: #1e3548;
    --md-ref-palette-neutral-17: #243f54;
    --md-ref-palette-neutral-20: #2a4562;
    --md-ref-palette-neutral-22: #2a4562;
    --md-ref-palette-neutral-24: #2f4a68;
    --md-ref-palette-neutral-25: #3a5876;
    --md-ref-palette-neutral-30: #3a5876;
    /* NiFi status colors + navy surfaces */
    --nf-success-default: #22c55e;
    --nf-success-variant: #1680bd;
    --nf-caution-default: #f59e0b;
    --nf-error-variant: #ef4444;
    --nf-even: #1e3548;
    --nf-canvas-background: #122435;
}

```

</details>

<details><summary>Dockerfile</summary>

```Dockerfile
# Throwaway preview image: applies the Stackable theme to an already-built NiFi
# image by appending CSS-variable overrides to the compiled stylesheet, instead
# of recompiling the Angular frontend.
#
# The stylesheet lives at:
#   /stackable/nifi/lib/nifi-server-nar-<v>.nar
#     -> META-INF/bundled-dependencies/nifi-ui-<v>.war
#       -> styles-<hash>.css
# The NiFi runtime image ships only a JRE, so a small JDK stage does the
# (un)zipping with `jar`.
#
# Build (run from this directory):
#   docker build -t nifi:2.9.0-stackable-theme .
# Run, then hard-refresh the browser (Ctrl/Cmd+Shift+R) to bypass cached CSS.

ARG NIFI_IMAGE=oci.stackable.tech/sdp/nifi:2.9.0-stackable0.0.0-dev

FROM ${NIFI_IMAGE} AS nifi

# --- Patcher: repackage the NAR/WAR with the themed stylesheet ---
FROM docker.io/library/eclipse-temurin:21-jdk AS patcher
WORKDIR /patch
COPY stackable-theme.css ./stackable-theme.css
COPY --from=nifi /stackable/nifi/lib/ ./lib/
RUN set -eux; \
    nar="$(ls lib/nifi-server-nar-*.nar)"; \
    mkdir nar; (cd nar && jar xf "/patch/${nar}"); \
    war="$(cd nar && ls META-INF/bundled-dependencies/nifi-ui-*.war)"; \
    mkdir nar/war; (cd nar/war && jar xf "/patch/nar/${war}"); \
    styles="$(cd nar/war && ls styles-*.css)"; \
    echo ">>> appending Stackable overrides to ${styles} in ${war}"; \
    cat stackable-theme.css >> "nar/war/${styles}"; \
    (cd nar/war && jar uf "/patch/nar/${war}" "${styles}"); \
    (cd nar && jar uf "/patch/${nar}" "${war}")
# /patch/lib/nifi-server-nar-*.nar now holds the themed stylesheet.

# --- Final: same NiFi image, themed NAR swapped in ---
FROM ${NIFI_IMAGE}
USER 0
COPY --from=patcher --chown=1000:0 /patch/lib/ /stackable/nifi/lib/
# Ensure the modified NAR is re-exploded on first start (work dir is normally
# empty in a freshly built image; this is just belt-and-braces).
RUN rm -rf /stackable/nifi/work/* 2>/dev/null || true
USER 1000

```

</details>

<details><summary>docker build</summary>

```sh
docker build -t nifi:2.9.0-stackable-theme . 
```

</details>