### PR TITLE
chore: Bump stackabletech/actions to v0.16.0 and add SLSA provenance

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Publish Container Image on oci.stackable.tech/sdp
         if: inputs.destination-project == 'sdp'
-        uses: stackabletech/actions/publish-image@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
+        uses: stackabletech/actions/publish-image@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -84,7 +84,7 @@ jobs:
 
       - name: Publish Container Image on oci.stackable.tech/stackable
         if: inputs.destination-project == 'stackable'
-        uses: stackabletech/actions/publish-image@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
+        uses: stackabletech/actions/publish-image@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$stackable+github-action-build
@@ -113,7 +113,7 @@ jobs:
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech/sdp
         if: inputs.destination-project == 'sdp'
-        uses: stackabletech/actions/publish-image-index-manifest@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
+        uses: stackabletech/actions/publish-image-index-manifest@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -123,7 +123,7 @@ jobs:
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech/stackable
         if: inputs.destination-project == 'stackable'
-        uses: stackabletech/actions/publish-image-index-manifest@8a8085be0a8cec3d24ad3970e602d65be487da6a # v0.14.1
+        uses: stackabletech/actions/publish-image-index-manifest@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$stackable+github-action-build

--- a/.github/workflows/pr_pre-commit.yaml
+++ b/.github/workflows/pr_pre-commit.yaml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - uses: stackabletech/actions/run-pre-commit@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
+      - uses: stackabletech/actions/run-pre-commit@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           rust: ${{ env.RUST_TOOLCHAIN_VERSION }}

--- a/.github/workflows/reusable_build_image.yaml
+++ b/.github/workflows/reusable_build_image.yaml
@@ -88,7 +88,7 @@ jobs:
           persist-credentials: false
 
       - id: shard
-        uses: stackabletech/actions/shard@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
+        uses: stackabletech/actions/shard@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           product-name: ${{ inputs.product-name }}
     outputs:
@@ -115,11 +115,11 @@ jobs:
           persist-credentials: false
 
       - name: Free Disk Space
-        uses: stackabletech/actions/free-disk-space@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
+        uses: stackabletech/actions/free-disk-space@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
+        uses: stackabletech/actions/build-product-image@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           registry-namespace: ${{ inputs.registry-namespace }}
           product-name: ${{ inputs.product-name }}
@@ -128,7 +128,7 @@ jobs:
 
       - name: Publish Container Image on oci.stackable.tech
         if: inputs.publish
-        uses: stackabletech/actions/publish-image@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
+        uses: stackabletech/actions/publish-image@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$${{ inputs.registry-namespace }}+github-action-build
@@ -144,7 +144,7 @@ jobs:
 
       - name: Publish Container Image on quay.io
         if: inputs.publish && inputs.publish-to-quay
-        uses: stackabletech/actions/publish-image@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
+        uses: stackabletech/actions/publish-image@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           image-registry-uri: quay.io
           image-registry-username: stackable+robot_${{ inputs.registry-namespace }}_github_action_build
@@ -177,7 +177,7 @@ jobs:
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         if: inputs.publish
-        uses: stackabletech/actions/publish-image-index-manifest@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
+        uses: stackabletech/actions/publish-image-index-manifest@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$${{ inputs.registry-namespace }}+github-action-build
@@ -192,7 +192,7 @@ jobs:
 
       - name: Publish and Sign Image Index Manifest to quay.io
         if: inputs.publish && inputs.publish-to-quay
-        uses: stackabletech/actions/publish-image-index-manifest@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
+        uses: stackabletech/actions/publish-image-index-manifest@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           image-registry-uri: quay.io
           image-registry-username: stackable+robot_${{ inputs.registry-namespace }}_github_action_build
@@ -214,7 +214,7 @@ jobs:
     if: failure() || (github.run_attempt > 1 && !cancelled())
     steps:
       - name: Send Notification
-        uses: stackabletech/actions/send-slack-notification@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
+        uses: stackabletech/actions/send-slack-notification@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           publish-manifests-result: ${{ needs.publish_manifests.result }}
           build-result: ${{ needs.build.result }}

--- a/.github/workflows/reusable_build_image.yaml
+++ b/.github/workflows/reusable_build_image.yaml
@@ -176,6 +176,7 @@ jobs:
           persist-credentials: false
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
+        id: publish-oci
         if: inputs.publish
         uses: stackabletech/actions/publish-image-index-manifest@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
@@ -191,6 +192,7 @@ jobs:
           image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ inputs.sdp-version }}
 
       - name: Publish and Sign Image Index Manifest to quay.io
+        id: publish-quay
         if: inputs.publish && inputs.publish-to-quay
         uses: stackabletech/actions/publish-image-index-manifest@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
@@ -205,9 +207,120 @@ jobs:
           image-repository: stackable/${{ inputs.registry-namespace }}/${{ inputs.image-name || inputs.product-name }}
           image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ inputs.sdp-version }}
 
+      # Record the pushed index manifest digest(s) for this matrix version so the
+      # provenance jobs can pick them up. Matrix jobs cannot expose per-version
+      # outputs (they overwrite each other), so we pass the digests through
+      # artifacts instead.
+      - name: Record image index digests for provenance
+        if: inputs.publish
+        shell: bash
+        env:
+          VERSION: ${{ matrix.versions }}
+          OCI_DIGEST: ${{ steps.publish-oci.outputs.image-index-manifest-digest }}
+          QUAY_DIGEST: ${{ steps.publish-quay.outputs.image-index-manifest-digest }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg version "$VERSION" \
+            --arg oci "$OCI_DIGEST" \
+            --arg quay "$QUAY_DIGEST" \
+            '{version: $version, oci_digest: $oci, quay_digest: $quay}' > digests.json
+
+      - name: Upload provenance digests
+        if: inputs.publish
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: provenance-digests-${{ matrix.versions }}
+          path: digests.json
+          retention-days: 1
+
+  # Collect the per-version index manifest digests uploaded by publish_manifests
+  # and turn them into a matrix (one entry per version and registry) for the
+  # provenance job. This is needed because a matrix job cannot expose per-leg
+  # outputs directly.
+  collect-provenance-matrix:
+    name: Collect Provenance Matrix
+    if: inputs.publish
+    needs: [publish_manifests]
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+      has-entries: ${{ steps.build-matrix.outputs.has_entries }}
+    steps:
+      - name: Download provenance digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: provenance-digests-*
+          path: artifacts
+
+      - name: Build provenance matrix
+        id: build-matrix
+        shell: bash
+        env:
+          REGISTRY_NAMESPACE: ${{ inputs.registry-namespace }}
+          PRODUCT_NAME: ${{ inputs.product-name }}
+          IMAGE_NAME: ${{ inputs.image-name }}
+        run: |
+          set -euo pipefail
+          IMAGE="${IMAGE_NAME:-$PRODUCT_NAME}"
+
+          # Build a JSON matrix include array. Each version contributes one entry
+          # for oci.stackable.tech and, if a quay digest was recorded, one for
+          # quay.io. The slsa generator attaches provenance by digest, so no tag
+          # is needed in the image reference.
+          INCLUDE=$(jq -c -s \
+            --arg ns "$REGISTRY_NAMESPACE" \
+            --arg img "$IMAGE" '
+            [ .[]
+              | ( { registry: "oci.stackable.tech",
+                    image: ("oci.stackable.tech/" + $ns + "/" + $img),
+                    digest: .oci_digest,
+                    username: ("robot$" + $ns + "+github-action-build") } ),
+                ( if (.quay_digest // "") != ""
+                  then { registry: "quay.io",
+                         image: ("quay.io/stackable/" + $ns + "/" + $img),
+                         digest: .quay_digest,
+                         username: ("stackable+robot_" + $ns + "_github_action_build") }
+                  else empty end )
+            ]' artifacts/*/digests.json)
+
+          echo "matrix={\"include\":$INCLUDE}" | tee -a "$GITHUB_OUTPUT"
+          if [ "$INCLUDE" = "[]" ]; then
+            echo "has_entries=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "has_entries=true" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+  # Generate SLSA build provenance for every published multi-arch image index
+  # (one matrix entry per version and registry) and attach it to the image. The
+  # reusable workflow signs the provenance with keyless signing (GitHub Actions
+  # as the OIDC identity) and pushes the attestation next to the image.
+  provenance:
+    name: Generate Provenance (${{ matrix.image }}@${{ matrix.digest }})
+    if: inputs.publish && needs.collect-provenance-matrix.outputs.has-entries == 'true'
+    needs: [collect-provenance-matrix]
+    permissions:
+      actions: read # detect the build workflow that generated the image
+      id-token: write # mint the OIDC token for keyless signing
+      packages: write # needed until https://github.com/slsa-framework/slsa-github-generator/issues/1257 is resolved
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.collect-provenance-matrix.outputs.matrix) }}
+    # MUST be referenced by a @vX.Y.Z tag (not a SHA), otherwise the reusable
+    # workflow cannot verify its own provenance.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    with:
+      image: ${{ matrix.image }}
+      digest: ${{ matrix.digest }}
+      registry-username: ${{ matrix.username }}
+    secrets:
+      registry-password: ${{ matrix.registry == 'quay.io' && secrets.quay-robot-secret || secrets.harbor-robot-secret }}
+
   notify:
     name: Failure Notification
-    needs: [generate_version_dimension, build, publish_manifests]
+    needs: [generate_version_dimension, build, publish_manifests, collect-provenance-matrix, provenance]
     runs-on: ubuntu-latest
     # TODO (@NickLarsenNZ): Allow a condition from input so that we can always
     # be notified of new builds for precompiled product images.

--- a/.github/workflows/ubi-rust-builder.yml
+++ b/.github/workflows/ubi-rust-builder.yml
@@ -123,7 +123,7 @@ jobs:
     if: failure() || (github.run_attempt > 1 && !cancelled())
     steps:
       - name: Send Notification
-        uses: stackabletech/actions/send-slack-notification@1b8db26b7406c66a7ab74e344a9e54edb2bc2690 # v0.14.3
+        uses: stackabletech/actions/send-slack-notification@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           publish-manifests-result: ${{ needs.publish_manifests.result }}
           build-result: ${{ needs.build.result }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- ci: Generate SLSA build provenance for published image indexes and attest it in each registry ([#1559]).
+
 - hadoop: Add precompiled hadoop for later reuse in dependent images ([#1466], [#1474]).
 - nifi: Add version `2.9.0` ([#1463]).
 - nifi: Backport NIFI-15801 to 2.x versions ([#1481]).
@@ -28,6 +30,7 @@ All notable changes to this project will be documented in this file.
 
 - airflow: Bump statsd_exporter to `0.30.0` ([#1524]).
 - ci: Bump `docker/login-action` from `v3.6.0` to `v4.1.0` and `stackabletech/actions` to `v0.14.3` to escape Node.js 20 deprecation ([#1507]).
+- ci: Bump `stackabletech/actions` to `v0.16.0` ([#1559]).
 - hbase: Update `hbase-opa-authorizer` from `0.1.0` to `0.2.0` and then `0.3.0` ([#1446], [#1454]).
 - stackable-base: Bump `containerdebug` to `0.4.0` and  `config-utils` to `0.4.0` ([#1521]).
 - statsd_exporter: Bump version from `0.28.0` to `0.30.0` ([#1524]).
@@ -91,6 +94,7 @@ All notable changes to this project will be documented in this file.
 [#1549]: https://github.com/stackabletech/docker-images/pull/1549
 [#1550]: https://github.com/stackabletech/docker-images/pull/1550
 [#1551]: https://github.com/stackabletech/docker-images/pull/1551
+[#1559]: https://github.com/stackabletech/docker-images/pull/1559
 
 ## [26.3.0] - 2026-03-16
 


### PR DESCRIPTION
# Description

Bumps all `stackabletech/actions` references to v0.16.0 and generates SLSA build provenance for every published multi-arch image index via `slsa-github-generator`, attested to the image in each registry (oci.stackable.tech and quay.io).

## How it works

`publish_manifests` is a version matrix, GitHub matrix jobs cannot expose per-leg outputs (they overwrite each other).
I had to do work around this using artifacts:

1. Each `publish_manifests` leg records its oci/quay index manifest digests as a `provenance-digests-<version>` artifact.
2. `collect-provenance-matrix` assembles the artifacts into a matrix (via [include](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/run-job-variations#expanding-or-adding-matrix-configurations), one entry per version and registry).
3. A matrixed `provenance` job feeds each entry to `slsa-github-generator`, selecting the registry password per entry.

Example:
Two `digests.json` artifacts collected:
```json
  {"version": "3.4.1", "oci_digest": "sha256:aaa...", "quay_digest": "sha256:bbb..."}
  {"version": "3.3.6", "oci_digest": "sha256:ccc...", "quay_digest": "sha256:ddd..."}
```

Results in this matrix:
```json
  {
    "include": [
      {
        "registry": "oci.stackable.tech",
        "image": "oci.stackable.tech/sdp/hadoop",
        "digest": "sha256:aaa...",
        "username": "robot$sdp+github-action-build"
      },
      {
        "registry": "quay.io",
        "image": "quay.io/stackable/sdp/hadoop",
        "digest": "sha256:bbb...",
        "username": "stackable+robot_sdp_github_action_build"
      },
      {
        "registry": "oci.stackable.tech",
        "image": "oci.stackable.tech/sdp/hadoop",
        "digest": "sha256:ccc...",
        "username": "robot$sdp+github-action-build"
      },
      {
        "registry": "quay.io",
        "image": "quay.io/stackable/sdp/hadoop",
        "digest": "sha256:ddd...",
        "username": "stackable+robot_sdp_github_action_build"
      }
    ]
  }
```

For more details on SLSA generation itself, see the description of https://github.com/stackabletech/operator-templating/pull/602

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
