### PR TITLE
fix: Grant permissions for SLSA provenance job

### DIFF
--- a/.github/workflows/build_airflow.yaml
+++ b/.github/workflows/build_airflow.yaml
@@ -41,6 +41,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: airflow
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_druid.yaml
+++ b/.github/workflows/build_druid.yaml
@@ -43,6 +43,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: druid
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_hadoop.yaml
+++ b/.github/workflows/build_hadoop.yaml
@@ -43,6 +43,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: hadoop
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_hbase.yaml
+++ b/.github/workflows/build_hbase.yaml
@@ -44,6 +44,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: hbase
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_hive.yaml
+++ b/.github/workflows/build_hive.yaml
@@ -44,6 +44,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: hive
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_java-base.yaml
+++ b/.github/workflows/build_java-base.yaml
@@ -39,6 +39,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: java-base
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_java-devel.yaml
+++ b/.github/workflows/build_java-devel.yaml
@@ -39,6 +39,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: java-devel
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_kafka-testing-tools.yaml
+++ b/.github/workflows/build_kafka-testing-tools.yaml
@@ -43,6 +43,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: kafka-testing-tools
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_kafka.yaml
+++ b/.github/workflows/build_kafka.yaml
@@ -44,6 +44,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: kafka
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_krb5.yaml
+++ b/.github/workflows/build_krb5.yaml
@@ -39,6 +39,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: krb5
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_nifi.yaml
+++ b/.github/workflows/build_nifi.yaml
@@ -43,6 +43,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: nifi
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_omid.yaml
+++ b/.github/workflows/build_omid.yaml
@@ -43,6 +43,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: omid
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_opa.yaml
+++ b/.github/workflows/build_opa.yaml
@@ -41,6 +41,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: opa
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_opensearch.yaml
+++ b/.github/workflows/build_opensearch.yaml
@@ -44,6 +44,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: opensearch
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_opensearch_dashboards.yaml
+++ b/.github/workflows/build_opensearch_dashboards.yaml
@@ -42,6 +42,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: opensearch-dashboards
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_spark-connect-client.yaml
+++ b/.github/workflows/build_spark-connect-client.yaml
@@ -41,6 +41,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: spark-connect-client
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_spark-k8s.yaml
+++ b/.github/workflows/build_spark-k8s.yaml
@@ -44,6 +44,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: spark-k8s
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_stackable-base.yaml
+++ b/.github/workflows/build_stackable-base.yaml
@@ -40,6 +40,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: stackable-base
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_superset.yaml
+++ b/.github/workflows/build_superset.yaml
@@ -41,6 +41,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: superset
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_testing-tools.yaml
+++ b/.github/workflows/build_testing-tools.yaml
@@ -47,6 +47,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: ${{ matrix.product-name }}
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_tools.yaml
+++ b/.github/workflows/build_tools.yaml
@@ -40,6 +40,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: tools
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_trino-cli.yaml
+++ b/.github/workflows/build_trino-cli.yaml
@@ -42,6 +42,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: trino-cli
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_trino.yaml
+++ b/.github/workflows/build_trino.yaml
@@ -43,6 +43,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: trino
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_vector.yaml
+++ b/.github/workflows/build_vector.yaml
@@ -39,6 +39,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: vector
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/build_zookeeper.yaml
+++ b/.github/workflows/build_zookeeper.yaml
@@ -43,6 +43,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: zookeeper
       sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}

--- a/.github/workflows/precompile_hadoop.yaml
+++ b/.github/workflows/precompile_hadoop.yaml
@@ -45,6 +45,10 @@ jobs:
       id-token: write
       # Needed for checkout
       contents: read
+      # Both needed by the nested SLSA provenance job (see reusable_build_image.yaml);
+      # packages: write is required until slsa-github-generator#1257 is resolved.
+      actions: read
+      packages: write
     with:
       product-name: precompiled/hadoop
       registry-namespace: precompiled


### PR DESCRIPTION
# Description

The SLSA provenance job added to reusable_build_image.yaml requests `actions: read` and `packages: write`. GitHub caps a nested reusable workflow's permissions at what the top-level caller grants, so every caller must grant these or the nested `provenance` job fails validation with "requesting 'actions: read, packages: write', but is only allowed 'actions: none, packages: none'".

Add both to all workflows that call reusable_build_image.yaml. `packages: write` is required by slsa-github-generator until https://github.com/slsa-framework/slsa-github-generator/issues/1257 is resolved.

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
