### PR TITLE
feat(patchable): respect http proxy environment variables

### DIFF
--- a/rust/patchable/src/main.rs
+++ b/rust/patchable/src/main.rs
@@ -17,7 +17,7 @@ use snafu::{OptionExt, ResultExt as _, Snafu};
 use tracing_indicatif::IndicatifLayer;
 use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _};
 
-use crate::utils::setup_git_credentials;
+use crate::utils::{setup_git_credentials, setup_git_proxy};
 
 #[derive(clap::Parser)]
 struct ProductVersion {
@@ -622,6 +622,7 @@ fn main() -> Result<()> {
 
                 let mut push_options = git2::PushOptions::new();
                 push_options.remote_callbacks(callbacks);
+                push_options.proxy_options(setup_git_proxy());
 
                 // Always push the commit as a Git tag named like the value of `base`
                 let refspec = format!("{base_commit}:refs/tags/{base}");

--- a/rust/patchable/src/repo.rs
+++ b/rust/patchable/src/repo.rs
@@ -5,7 +5,7 @@ use snafu::{ResultExt, Snafu};
 
 use crate::{
     error::{self, CommitRef},
-    utils::{setup_git_credentials, setup_progress_tracking},
+    utils::{setup_git_credentials, setup_git_proxy, setup_progress_tracking},
 };
 
 #[derive(Debug, Snafu)]
@@ -177,6 +177,7 @@ pub fn resolve_and_fetch_commitish(
                         FetchOptions::new()
                             .update_fetchhead(true)
                             .remote_callbacks(callbacks)
+                            .proxy_options(setup_git_proxy())
                             // TODO: could be 1, CLI option maybe?
                             .depth(0),
                     ),

--- a/rust/patchable/src/utils.rs
+++ b/rust/patchable/src/utils.rs
@@ -132,3 +132,16 @@ pub fn setup_git_credentials<'a>() -> git2::RemoteCallbacks<'a> {
     });
     callbacks
 }
+
+/// Proxy configuration for Git operations.
+///
+/// Enables libgit2's automatic proxy detection, which honours the `http.proxy`
+/// Git config and the `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` environment variables
+/// (just like the `git` CLI). This is what lets patchable run inside sandboxes
+/// (e.g. nono) that force all traffic through an HTTP proxy; it is a no-op when no
+/// proxy is configured.
+pub fn setup_git_proxy<'a>() -> git2::ProxyOptions<'a> {
+    let mut proxy_options = git2::ProxyOptions::new();
+    proxy_options.auto();
+    proxy_options
+}


### PR DESCRIPTION
# Description

Allows `patchable` to run in `nono` sandboxes.
