### PR TITLE
fix: spark-k8s graceful shutdown on SIGTERM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 - spark: bump hadoop `3.4.2` to `3.4.3` ([#1533])
 - hive: Bump `4.2.0` to Hadoop `3.4.3` ([#1539]).
 - java-devel: Bump Maven to 3.9.16 ([#1548]).
+- spark: fix graceful shutdown at SIGTERM ([#1564])
 
 ### Fixed
 
@@ -95,6 +96,7 @@ All notable changes to this project will be documented in this file.
 [#1550]: https://github.com/stackabletech/docker-images/pull/1550
 [#1551]: https://github.com/stackabletech/docker-images/pull/1551
 [#1559]: https://github.com/stackabletech/docker-images/pull/1559
+[#1564]: https://github.com/stackabletech/docker-images/pull/1564
 
 ## [26.3.0] - 2026-03-16
 

--- a/spark-k8s/Dockerfile.3
+++ b/spark-k8s/Dockerfile.3
@@ -258,4 +258,4 @@ EOF
 USER ${STACKABLE_USER_UID}
 
 WORKDIR ${SPARK_HOME}
-ENTRYPOINT [ "/stackable/run-spark.sh" ]
+ENTRYPOINT [ "/usr/bin/tini", "-s", "--", "/stackable/run-spark.sh" ]

--- a/spark-k8s/Dockerfile.4
+++ b/spark-k8s/Dockerfile.4
@@ -230,4 +230,4 @@ EOF
 USER ${STACKABLE_USER_UID}
 
 WORKDIR ${SPARK_HOME}
-ENTRYPOINT [ "/stackable/run-spark.sh" ]
+ENTRYPOINT [ "/usr/bin/tini", "-s", "--", "/stackable/run-spark.sh" ]

--- a/spark-k8s/stackable/run-spark.sh
+++ b/spark-k8s/stackable/run-spark.sh
@@ -6,6 +6,7 @@ eval "$_STACKABLE_PRE_HOOK"
 /stackable/spark/kubernetes/dockerfiles/spark/entrypoint.sh "$@" &
 child_pid=$!
 
+  # shellcheck disable=SC2329
 _handle_term() {
   kill -TERM "$child_pid" 2>/dev/null || true
 }

--- a/spark-k8s/stackable/run-spark.sh
+++ b/spark-k8s/stackable/run-spark.sh
@@ -1,10 +1,23 @@
 #!/bin/bash
 
-eval "$_STACKABLE_PRE_HOOK"
+  eval "$_STACKABLE_PRE_HOOK"
 
-/stackable/spark/kubernetes/dockerfiles/spark/entrypoint.sh "$@"
-result=$?
+  # Forward SIGTERM to the Spark entrypoint to support spark JVM's gracefully shutdown.
+  /stackable/spark/kubernetes/dockerfiles/spark/entrypoint.sh "$@" &
+  child_pid=$!
 
-eval "$_STACKABLE_POST_HOOK"
+  _handle_term() {
+    kill -TERM "$child_pid" 2>/dev/null || true
+  }
+  trap _handle_term TERM INT
 
-exit $result
+  # `wait` returns immediately when the trap fires; loop until the child is actually gone.
+  wait "$child_pid"
+  while kill -0 "$child_pid" 2>/dev/null; do
+    wait "$child_pid" 2>/dev/null || true
+  done
+  result=$?
+
+  eval "$_STACKABLE_POST_HOOK"
+
+  exit $result

--- a/spark-k8s/stackable/run-spark.sh
+++ b/spark-k8s/stackable/run-spark.sh
@@ -6,7 +6,7 @@ eval "$_STACKABLE_PRE_HOOK"
 /stackable/spark/kubernetes/dockerfiles/spark/entrypoint.sh "$@" &
 child_pid=$!
 
-  # shellcheck disable=SC2329
+# shellcheck disable=SC2329
 _handle_term() {
   kill -TERM "$child_pid" 2>/dev/null || true
 }

--- a/spark-k8s/stackable/run-spark.sh
+++ b/spark-k8s/stackable/run-spark.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
 
-  eval "$_STACKABLE_PRE_HOOK"
+eval "$_STACKABLE_PRE_HOOK"
 
-  # Forward SIGTERM to the Spark entrypoint to support spark JVM's gracefully shutdown.
-  /stackable/spark/kubernetes/dockerfiles/spark/entrypoint.sh "$@" &
-  child_pid=$!
+# Forward SIGTERM to the Spark entrypoint to support spark JVM's gracefully shutdown.
+/stackable/spark/kubernetes/dockerfiles/spark/entrypoint.sh "$@" &
+child_pid=$!
 
-  _handle_term() {
-    kill -TERM "$child_pid" 2>/dev/null || true
-  }
-  trap _handle_term TERM INT
+_handle_term() {
+  kill -TERM "$child_pid" 2>/dev/null || true
+}
+trap _handle_term TERM INT
 
-  # `wait` returns immediately when the trap fires; loop until the child is actually gone.
-  wait "$child_pid"
-  while kill -0 "$child_pid" 2>/dev/null; do
-    wait "$child_pid" 2>/dev/null || true
-  done
-  result=$?
+# `wait` returns immediately when the trap fires; loop until the child is actually gone.
+wait "$child_pid"
+while kill -0 "$child_pid" 2>/dev/null; do
+  wait "$child_pid" 2>/dev/null || true
+done
+result=$?
 
-  eval "$_STACKABLE_POST_HOOK"
+eval "$_STACKABLE_POST_HOOK"
 
-  exit $result
+exit $result


### PR DESCRIPTION
# Description

Spark executer didn't receive `SIGTERM` when driver received. Resulted in waiting for graceperiod and then the executer received `SIGKILL` from k8s.

This fixes the issue by:
1. wrapping `Tini` around the `run-spark.sh` script.
2. Trapping SIGTERM signal and explicitly passing it to child process.