### PR TITLE
fix: Collect provenance digests regardless of artifact layout

### DIFF
--- a/.github/workflows/reusable_build_image.yaml
+++ b/.github/workflows/reusable_build_image.yaml
@@ -268,6 +268,18 @@ jobs:
           set -euo pipefail
           IMAGE="${IMAGE_NAME:-$PRODUCT_NAME}"
 
+          # Collect every digests.json regardless of the directory layout that
+          # download-artifact produces.
+          readarray -t DIGEST_FILES < <(find artifacts -type f -name digests.json)
+
+          # No digests recorded means nothing to attach provenance to. Guard here
+          # because jq with no file arguments would block reading from stdin.
+          if [ "${#DIGEST_FILES[@]}" -eq 0 ]; then
+            echo "matrix={\"include\":[]}" | tee -a "$GITHUB_OUTPUT"
+            echo "has_entries=false" | tee -a "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # Build a JSON matrix include array. Each version contributes one entry
           # for oci.stackable.tech and, if a quay digest was recorded, one for
           # quay.io. The slsa generator attaches provenance by digest, so no tag
@@ -286,7 +298,7 @@ jobs:
                          digest: .quay_digest,
                          username: ("stackable+robot_" + $ns + "_github_action_build") }
                   else empty end )
-            ]' artifacts/*/digests.json)
+            ]' "${DIGEST_FILES[@]}")
 
           echo "matrix={\"include\":$INCLUDE}" | tee -a "$GITHUB_OUTPUT"
           if [ "$INCLUDE" = "[]" ]; then


### PR DESCRIPTION
# Description

`download-artifact` only nests each artifact into its own subdirectory when more than one matches the pattern. Single-version products upload a single provenance-digests-* artifact, which gets flattened directly into the download path, so the hardcoded `artifacts/*/digests.json` glob found nothing and `jq` failed. Use `find` so both the flat and per-artifact subdirectory layouts work, and guard against zero digest files.

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
