### PR TITLE
ci(boil): Checkout repo to fix gh command

### DIFF
--- a/.github/workflows/boil_release.yaml
+++ b/.github/workflows/boil_release.yaml
@@ -85,6 +85,7 @@ jobs:
         run: gh release upload "${RELEASE_TAG}" boil-${{ matrix.targets.target }}
 
   finish-release:
+    name: Finish Release
     needs: [build]
     runs-on: ubuntu-latest
     permissions:
@@ -92,6 +93,12 @@ jobs:
       # See https://github.com/softprops/action-gh-release/blob/153bb8e04406b158c6c84fc1615b65b24149a1fe/README.md?plain=1#L281
       contents: write
     steps:
+      # This checkout is only here so that a .git directory is present because the gh CLI needs it.
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
       - name: Finish Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `gh` command needs a `.git` directory apparently. So now we checkout the repo when finishing the release.