### PR TITLE
fix: File system permissions for libjvmkill.so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to this project will be documented in this file.
 - opensearch: Add `3.6.0` ([#1549]).
 - opensearch-dashboards: Add `3.6.0` ([#1551]).
 - spark: Add hbase-connector protobuf classes ([#1573]).
-- java-base: Add `jvmkill` ([#1579], [#XXXX]).
+- java-base: Add `jvmkill` ([#1579], [#1580]).
 
 ### Changed
 
@@ -103,7 +103,7 @@ All notable changes to this project will be documented in this file.
 [#1561]: https://github.com/stackabletech/docker-images/pull/1561
 [#1564]: https://github.com/stackabletech/docker-images/pull/1564
 [#1579]: https://github.com/stackabletech/docker-images/pull/1579
-[#XXXX]: https://github.com/stackabletech/docker-images/pull/XXXX
+[#1580]: https://github.com/stackabletech/docker-images/pull/1580
 
 ## [26.3.0] - 2026-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to this project will be documented in this file.
 - opensearch: Add `3.6.0` ([#1549]).
 - opensearch-dashboards: Add `3.6.0` ([#1551]).
 - spark: Add hbase-connector protobuf classes ([#1573]).
-- java-base: Add `jvmkill` ([#1579]).
+- java-base: Add `jvmkill` ([#1579], [#XXXX]).
 
 ### Changed
 
@@ -103,6 +103,7 @@ All notable changes to this project will be documented in this file.
 [#1561]: https://github.com/stackabletech/docker-images/pull/1561
 [#1564]: https://github.com/stackabletech/docker-images/pull/1564
 [#1579]: https://github.com/stackabletech/docker-images/pull/1579
+[#XXXX]: https://github.com/stackabletech/docker-images/pull/XXXX
 
 ## [26.3.0] - 2026-03-16
 

--- a/java-base/Dockerfile
+++ b/java-base/Dockerfile
@@ -63,3 +63,4 @@ ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true
 # We are adding jvmkill, as it improves shutdown of the JVM in case it runs out of native threads.
 # See https://github.com/stackabletech/docker-images/issues/1578 for motivation/details.
 COPY --chown=${STACKABLE_USER_UID}:0 --from=jvmkill-builder /stackable/libjvmkill.so /stackable/libjvmkill.so
+RUN chmod g=u /stackable/libjvmkill.so


### PR DESCRIPTION
# Description

For some reason this build fine for Trino, but not for other Java products.

```
RUN <<EOF (/bin/check-permissions-ownership.sh /stackable 1000 0):
Permission mismatch: /stackable/libjvmkill.so (Owner: rw-, Group: r--, Expected: owner=group)
Permission and Ownership checks failed for /stackable!
```

I confirmed Zookeeper and Kafka (which were affected) now build

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
