### PR TITLE
chore(nifi): Bump opa-plugin to 0.6.0

### DIFF
--- a/nifi/boil-config.toml
+++ b/nifi/boil-config.toml
@@ -10,7 +10,7 @@ java-devel = "21"
 git-sync-version = "v4.6.0"
 # Check for new versions at the upstream: https://github.com/stackabletech/nifi-opa-plugin/tags
 # Checkout a Patchable version (patch-series) for the new tag
-nifi-opa-authorizer-plugin-version = "0.5.0"
+nifi-opa-authorizer-plugin-version = "0.6.0"
 
 # Release a new version here: https://github.com/stackabletech/nifi-iceberg-bundle
 # Checkout a Patchable version (patch-series) for the new tag
@@ -26,7 +26,7 @@ java-devel = "21"
 git-sync-version = "v4.6.0"
 # Check for new versions at the upstream: https://github.com/stackabletech/nifi-opa-plugin/tags
 # Checkout a Patchable version (patch-series) for the new tag
-nifi-opa-authorizer-plugin-version = "0.5.0"
+nifi-opa-authorizer-plugin-version = "0.6.0"
 
 [versions."2.9.0".local-images]
 java-base = "21" # As stated in GitHub README
@@ -37,4 +37,4 @@ java-devel = "21"
 git-sync-version = "v4.6.0"
 # Check for new versions at the upstream: https://github.com/stackabletech/nifi-opa-plugin/tags
 # Checkout a Patchable version (patch-series) for the new tag
-nifi-opa-authorizer-plugin-version = "0.5.0"
+nifi-opa-authorizer-plugin-version = "0.6.0"

--- a/nifi/opa-plugin/stackable/patches/0.6.0/patchable.toml
+++ b/nifi/opa-plugin/stackable/patches/0.6.0/patchable.toml
@@ -1,0 +1,2 @@
+mirror = "https://github.com/stackabletech/nifi-opa-plugin.git"
+base = "2689a6010c29041fcdeff4d8d3b954e95f02d8c6"


### PR DESCRIPTION
> [!NOTE]
> This change also needs to be cherry-picked onto the `release-26.7` branch.

This bumps the NiFi OPA plugin to version 0.6.0, which includes this fix: https://github.com/stackabletech/nifi-opa-plugin/pull/31.

A local test build of NiFi 2.9.0 succeeded.