### PR TITLE
chore(java-devel): Tweak Maven transport settings [skip ci]

### DIFF
--- a/java-devel/stackable/settings.xml
+++ b/java-devel/stackable/settings.xml
@@ -55,6 +55,24 @@
 
         <!-- New name: maven-resolver 2.x, as of Maven 4.x -->
         <aether.transport.http.connectionMaxTtl>25</aether.transport.http.connectionMaxTtl>
+
+        <!--
+        By default, requests are retried 3 times. We increase the count slightly to hopefully get less failing
+        builds in CI.
+        -->
+        <aether.transport.http.retryHandler.count>5</aether.transport.http.retryHandler.count>
+
+        <!--
+        By default, retries wait for 5000l milliseconds (5 seconds). We increase this to 10000l milliseonds
+        (10 seconds) to spam the Nexus instance a little less.
+        -->
+        <aether.transport.http.retryHandler.interval>10000l</aether.transport.http.retryHandler.interval>
+
+        <!--
+        Servers can respond with `Retry-After` headers. By default, the value is capped at 300000l milliseconds (300
+        seconds). We reduce this to 60000l (60 seconds) to avoid super long retry intervals.
+        -->
+        <aether.transport.http.retryHandler.intervalMax>60000l</aether.transport.http.retryHandler.intervalMax>
       </properties>
     </profile>
   </profiles>

--- a/java-devel/stackable/settings.xml
+++ b/java-devel/stackable/settings.xml
@@ -51,10 +51,10 @@
         -->
 
         <!-- Old name: maven-resolver 1.x, Maven 3.x -->
-        <aether.connector.http.connectionMaxTtl>30</aether.connector.http.connectionMaxTtl>
+        <aether.connector.http.connectionMaxTtl>25</aether.connector.http.connectionMaxTtl>
 
         <!-- New name: maven-resolver 2.x, as of Maven 4.x -->
-        <aether.transport.http.connectionMaxTtl>30</aether.transport.http.connectionMaxTtl>
+        <aether.transport.http.connectionMaxTtl>25</aether.transport.http.connectionMaxTtl>
       </properties>
     </profile>
   </profiles>

--- a/java-devel/stackable/settings.xml
+++ b/java-devel/stackable/settings.xml
@@ -40,6 +40,8 @@
 
       <properties>
         <!--
+        Resolver specific configuration keys can be found here: https://maven.apache.org/resolver/configuration.html
+
         This is to work around an issue where Maven builds in Github Actions would randomly fail.
         There is some evidence that points at Azure networking as the root cause where it closes idle connections (silently) after 4 minutes.
         Maven would then sometimes reuse an "old" connection from its connection pool and would encounter issues due to these connection closures.

--- a/java-devel/stackable/settings.xml
+++ b/java-devel/stackable/settings.xml
@@ -65,7 +65,7 @@
         <aether.transport.http.retryHandler.count>5</aether.transport.http.retryHandler.count>
 
         <!--
-        By default, retries wait for 5000l milliseconds (5 seconds). We increase this to 10000l milliseonds
+        By default, retries wait for 5000l milliseconds (5 seconds). We increase this to 10000l milliseconds
         (10 seconds) to spam the Nexus instance a little less.
         -->
         <aether.transport.http.retryHandler.interval>10000</aether.transport.http.retryHandler.interval>

--- a/java-devel/stackable/settings.xml
+++ b/java-devel/stackable/settings.xml
@@ -68,13 +68,13 @@
         By default, retries wait for 5000l milliseconds (5 seconds). We increase this to 10000l milliseonds
         (10 seconds) to spam the Nexus instance a little less.
         -->
-        <aether.transport.http.retryHandler.interval>10000l</aether.transport.http.retryHandler.interval>
+        <aether.transport.http.retryHandler.interval>10000</aether.transport.http.retryHandler.interval>
 
         <!--
         Servers can respond with `Retry-After` headers. By default, the value is capped at 300000l milliseconds (300
         seconds). We reduce this to 60000l (60 seconds) to avoid super long retry intervals.
         -->
-        <aether.transport.http.retryHandler.intervalMax>60000l</aether.transport.http.retryHandler.intervalMax>
+        <aether.transport.http.retryHandler.intervalMax>60000</aether.transport.http.retryHandler.intervalMax>
 
         <!--
         This is an option we can experiment with in the future. Settings this to false will result in no connection

--- a/java-devel/stackable/settings.xml
+++ b/java-devel/stackable/settings.xml
@@ -65,14 +65,14 @@
         <aether.transport.http.retryHandler.count>5</aether.transport.http.retryHandler.count>
 
         <!--
-        By default, retries wait for 5000l milliseconds (5 seconds). We increase this to 10000l milliseconds
+        By default, retries wait for 5000 milliseconds (5 seconds). We increase this to 10000 milliseconds
         (10 seconds) to spam the Nexus instance a little less.
         -->
         <aether.transport.http.retryHandler.interval>10000</aether.transport.http.retryHandler.interval>
 
         <!--
-        Servers can respond with `Retry-After` headers. By default, the value is capped at 300000l milliseconds (300
-        seconds). We reduce this to 60000l (60 seconds) to avoid super long retry intervals.
+        Servers can respond with `Retry-After` headers. By default, the value is capped at 300000 milliseconds (300
+        seconds). We reduce this to 60000 (60 seconds) to avoid super long retry intervals.
         -->
         <aether.transport.http.retryHandler.intervalMax>60000</aether.transport.http.retryHandler.intervalMax>
 

--- a/java-devel/stackable/settings.xml
+++ b/java-devel/stackable/settings.xml
@@ -73,6 +73,13 @@
         seconds). We reduce this to 60000l (60 seconds) to avoid super long retry intervals.
         -->
         <aether.transport.http.retryHandler.intervalMax>60000l</aether.transport.http.retryHandler.intervalMax>
+
+        <!--
+        This is an option we can experiment with in the future. Settings this to false will result in no connection
+        pooling, which should help to avoid stale/long-lasting connections which can become inactive and be killed by
+        the Azure networking.
+        -->
+        <!-- <aether.transport.http.reuseConnections>false</aether.transport.http.reuseConnections> -->
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
> [!NOTE]
> This might get cherry-picked onto the `release-26.7` branch to potentially help with failing builds in CI.

This PR tweaks various Maven transport/resolver settings to be a little more network failure resistant in the future. These network issues seem to be known by the Java/Maven community and are related to Azure's network setup.