### PR TITLE
chore(stackable-devel): Tweak npm+yarn transport settings

### DIFF
--- a/stackable-devel/stackable/.npmrc
+++ b/stackable-devel/stackable/.npmrc
@@ -1,1 +1,22 @@
+# See https://docs.npmjs.com/cli/v12/using-npm/config#registry
 registry=https://build-repo.stackable.tech/repository/npm-public/
+
+# By default, fetches are retried 2 times. We increase the count slightly to hopefully get less
+# failing builds in CI. See https://docs.npmjs.com/cli/v12/using-npm/config#fetch-retries
+fetch-retries=5
+
+# 10000 milliseconds (10 seconds) is the default of npm, but we explicitly set it here if this needs
+# to be tweaked in the future. See https://docs.npmjs.com/cli/v12/using-npm/config#fetch-retry-mintimeout
+fetch-retry-mintimeout=10000
+
+# By default, this factor is 10. The value below is tweaked to result in 5 retries over the span of
+# 5 minutes with an initial timeout of 10 seconds. See:
+# - https://docs.npmjs.com/cli/v12/using-npm/config#fetch-retry-factor
+# - https://github.com/tim-kos/node-retry/blob/master/README.md#retrytimeoutsoptions
+# - https://www.wolframalpha.com/input?i=Sum%5B10000*x%5Ek%2C+%7Bk%2C+0%2C+4%7D%5D+%3D+5+*+60+*+1000
+fetch-retry-factor=1.97
+
+# 3000000 milliseconds (300 seconds, 5 minutes) is the default of npm, but we explicitly set it here
+# if this needs to be tweaked in the future. This value is also used in the factor tweaking above.
+# See https://docs.npmjs.com/cli/v12/using-npm/config#fetch-timeout
+fetch-timeout=300000

--- a/stackable-devel/stackable/.yarnrc.yml
+++ b/stackable-devel/stackable/.yarnrc.yml
@@ -1,1 +1,10 @@
 npmRegistryServer: "https://build-repo.stackable.tech/repository/npm-public/"
+
+# By default, yarn retries failed HTTP requests after 3 seconds. We increase this to 50 seconds
+# to spam the Nexus instance a little less. In combination with the timeout configured below, this
+# should result in roughly 5 retries. See https://yarnpkg.com/configuration/yarnrc#httpRetry
+httpRetry: 50
+
+# By default, yarn times out after 1 minute. We increase this to 5 minutes to hopefully get less
+# failing builds in CI. See https://yarnpkg.com/configuration/yarnrc#httpTimeout
+httpTimeout: 5m


### PR DESCRIPTION
> [!NOTE]
> This might get cherry-picked onto the `release-26.7` branch to potentially help with failing builds in CI.

This PR tweaks the transport settings of `npm` and `yarn`.