### PR TITLE
feat(boil): Add floating-tag tool

### DIFF
--- a/rust/boil/src/cli/mod.rs
+++ b/rust/boil/src/cli/mod.rs
@@ -3,15 +3,17 @@ use std::{path::PathBuf, sync::LazyLock};
 use clap::{Parser, Subcommand};
 use regex::Regex;
 use snafu::Snafu;
+use url::Host;
 
 mod build;
 mod completions;
 mod image;
+mod tools;
 
 pub use build::*;
 pub use completions::*;
 pub use image::*;
-use url::Host;
+pub use tools::*;
 
 // This is derived from the general rule where the length of the tag can be up to 128 chars
 // See: https://github.com/opencontainers/distribution-spec/blob/main/spec.md
@@ -75,6 +77,9 @@ pub enum Command {
 
     /// Alias for `image list`.
     Images(ImageListArguments),
+
+    /// Various small tools for working with images and versions.
+    Tools(ToolsArguments),
 
     /// Generate shell completions.
     Completions(CompletionsArguments),

--- a/rust/boil/src/cli/tools.rs
+++ b/rust/boil/src/cli/tools.rs
@@ -1,0 +1,23 @@
+use clap::{Args, Parser, Subcommand};
+
+#[derive(Debug, Parser)]
+pub struct ToolsArguments {
+    #[command(subcommand)]
+    pub command: ToolsCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ToolsCommand {
+    /// Turn the provided version tag into a floating tag according to boil's rules.
+    //
+    // The main user of this command is stackabletech/actions to be able to construct the floating
+    // tag for the image index manifest tag. This command serves as a stepping stone for a more
+    // robust solution using structured data output directly from boil.
+    FloatingTag(FloatingTagArguments),
+}
+
+#[derive(Debug, Args)]
+pub struct FloatingTagArguments {
+    /// The source version tag which should be converted into a floating version tag.
+    pub version: semver::Version,
+}

--- a/rust/boil/src/cmd/mod.rs
+++ b/rust/boil/src/cmd/mod.rs
@@ -1,3 +1,4 @@
 pub mod build;
 pub mod completions;
 pub mod image;
+pub mod tools;

--- a/rust/boil/src/cmd/tools.rs
+++ b/rust/boil/src/cmd/tools.rs
@@ -1,0 +1,6 @@
+use crate::{cli::FloatingTagArguments, utils::VersionExt};
+
+pub fn floating_tag(args: FloatingTagArguments) {
+    let floating_tag = args.version.floating();
+    println!("{floating_tag}");
+}

--- a/rust/boil/src/main.rs
+++ b/rust/boil/src/main.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use snafu::{ResultExt, Snafu};
 
 use crate::{
-    cli::{Cli, Command, ImageCommand},
+    cli::{Cli, Command, ImageCommand, ToolsCommand},
     config::Config,
 };
 
@@ -83,6 +83,12 @@ async fn main() -> Result<(), Error> {
             }
         },
         Command::Images(arguments) => cmd::image::list_images(arguments).context(ImageSnafu),
+        Command::Tools(arguments) => match arguments.command {
+            ToolsCommand::FloatingTag(arguments) => {
+                cmd::tools::floating_tag(arguments);
+                Ok(())
+            }
+        },
         Command::Completions(arguments) => {
             cmd::completions::run_command(arguments);
             Ok(())


### PR DESCRIPTION
This PR adds a new command: `boil tools floating-tag` which takes and SemVer compatible input and turns it into a floating tag based on boil's rules. The main consumer will be `stackabletech/actions`.

```shell
$ boil tools floating-tag 1.2.3-rc.1
1.2-rc.1

$ boil tools floating-tag 1.2.3
1.2

$ boil tools floating-tag 0.0.0-dev
0.0.0-dev
```

This command only serves as a stepping stone to a more robust solution using structured data in `boil-target-tags.json`.

<details>
<summary>Initial sketch</summary>

```jsonc
{
  "krb": {
    // Always there
    "canonical": {
      "manifest": "",
      "index-manifest": ""
    },
    // Optional, only there with --floating-tag
    "floating": {
      "manifest": "",
      "index-manifest": ""
    },
    // Others, currently empty then. Probably will support something like --tag
    "others": [
      {
        "manifest": "",
        "index-manifest": ""
      }
    ]
  }
}
```

</details>