### PR TITLE
chore: bump the Rust toolchain to 1.97.1

### DIFF
--- a/.github/workflows/boil_pr.yaml
+++ b/.github/workflows/boil_pr.yaml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 env:
-  RUST_TOOLCHAIN_VERSION: 1.95.0
+  RUST_TOOLCHAIN_VERSION: 1.97.1
 
 jobs:
   # This job is always run to ensure we don't miss any new upstream advisories

--- a/.github/workflows/boil_release.yaml
+++ b/.github/workflows/boil_release.yaml
@@ -9,7 +9,7 @@ on:
 permissions: {}
 
 env:
-  RUST_TOOLCHAIN_VERSION: 1.95.0
+  RUST_TOOLCHAIN_VERSION: 1.97.1
   RELEASE_TAG: ${{ github.ref_name }}
 
 jobs:

--- a/.github/workflows/patchable_pr.yaml
+++ b/.github/workflows/patchable_pr.yaml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 env:
-  RUST_TOOLCHAIN_VERSION: 1.95.0
+  RUST_TOOLCHAIN_VERSION: 1.97.1
 
 jobs:
   # This job is always run to ensure we don't miss any new upstream advisories

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.97.1"
 profile = "default"

--- a/rust/boil/src/cmd/image.rs
+++ b/rust/boil/src/cmd/image.rs
@@ -128,7 +128,7 @@ pub async fn check_images(arguments: ImageCheckArguments, config: Config) -> Res
                 .await
                 .context(DeserializeResponseSnafu)?;
 
-            for (image_version, _) in image_config.versions.iter() {
+            for image_version in image_config.versions.keys() {
                 let index_manifest_tag = format_image_index_manifest_tag(
                     image_version,
                     &config.metadata.vendor_tag_prefix,
@@ -195,7 +195,7 @@ pub async fn calculate_size(arguments: ImageSizeArguments, config: Config) -> Re
                 std::env::var(name).ok().map(SecretString::from)
             });
 
-            for (image_version, _) in image_config.versions.iter() {
+            for image_version in image_config.versions.keys() {
                 let image_index_manifest_tag = format_image_index_manifest_tag(
                     image_version,
                     &config.metadata.vendor_tag_prefix,

--- a/stackable-devel/Dockerfile
+++ b/stackable-devel/Dockerfile
@@ -45,7 +45,7 @@ COPY stackable-base/stackable/curlrc /root/.curlrc
 # Find the latest version here: https://doc.rust-lang.org/stable/releases.html
 # TODO (@NickLarsenNZ): Move the version into boil-config.toml once renovate can look there
 # renovate: datasource=github-releases packageName=rust-lang/rust
-ARG RUST_DEFAULT_TOOLCHAIN_VERSION=1.95.0
+ARG RUST_DEFAULT_TOOLCHAIN_VERSION=1.97.1
 ENV RUST_DEFAULT_TOOLCHAIN_VERSION=${RUST_DEFAULT_TOOLCHAIN_VERSION}
 # Find the latest version here: https://crates.io/crates/cargo-cyclonedx
 # renovate: datasource=crate packageName=cargo-cyclonedx

--- a/ubi10-rust-builder/Dockerfile
+++ b/ubi10-rust-builder/Dockerfile
@@ -17,7 +17,7 @@ ENV RUSTUP_VERSION=1.28.2
 # This SHOULD be kept in sync with operator-templating and other tools to reduce build times
 # Find the latest version here: https://doc.rust-lang.org/stable/releases.html
 # renovate: datasource=github-releases packageName=rust-lang/rust
-ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.95.0
+ENV RUST_DEFAULT_TOOLCHAIN_VERSION=1.97.1
 # Find the latest version here: https://crates.io/crates/cargo-cyclonedx
 # renovate: datasource=crate packageName=cargo-cyclonedx
 ENV CARGO_CYCLONEDX_CRATE_VERSION=0.5.9


### PR DESCRIPTION
# Description

* Fixes this clippy lint: https://rust-lang.github.io/rust-clippy/master/#for_kv_map

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
