### PR TITLE
fix(superset): Exclude cypress-base from the frontend SBOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - spark: Propagate the entrypoint's exit code so failed applications are no longer reported as successful ([#1595]).
+- superset: Fix the broken builds by excluding the `cypress-base` end-to-end test project from the frontend SBOM ([#1616]).
 
 ### Removed
 
@@ -25,6 +26,7 @@ All notable changes to this project will be documented in this file.
 [#1595]: https://github.com/stackabletech/docker-images/pull/1595
 [#1596]: https://github.com/stackabletech/docker-images/pull/1596
 [#1600]: https://github.com/stackabletech/docker-images/pull/1600
+[#1616]: https://github.com/stackabletech/docker-images/pull/1616
 
 ## [26.7.0] - 2026-07-21
 

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -147,10 +147,17 @@ npm run build
 #   also drop all transitive runtime dependencies.
 # --project-version is passed because the frontends declare a placeholder version
 #   upstream.
+# --exclude skips cypress-base, which is an independent npm project (it has its own
+#   package-lock.json) for the end-to-end tests. Its dependencies are never installed
+#   or shipped in this image, so they have no place in the SBOM. Excluding it also
+#   avoids a cdxgen bug: for such nested projects it emits the `license` string from
+#   package.json verbatim instead of a CycloneDX `licenses` array, which makes cdxgen
+#   fail its own schema validation.
 PATH="/opt/node-cdxgen/bin:$PATH" cdxgen \
     --type js \
     --required-only \
     --no-babel \
+    --exclude "**/cypress-base/**" \
     --spec-version "${CDXGEN_SPEC_VERSION}" \
     --project-version "${PRODUCT_VERSION}" \
     --output "/stackable/app/superset-frontend-${PRODUCT_VERSION}.cdx.json"


### PR DESCRIPTION
# Description

All Superset builds have been failing since #1600, for every version and both architectures.

`cdxgen` treats `superset-frontend/cypress-base` as an independent npm project, because it has its own `package-lock.json`. The resulting component is then rejected by `cdxgen`'s own schema validation, which is a bug in `cdxgen`. It is already fixed in their master branch, but there is no new release yet.
We can work around it though: `cypress-base` only holds the end-to-end tests, so its dependencies are never installed and never shipped, so excluding it both fixes the build and keeps test-only dependencies out of the SBOM.

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
