### PR TITLE
chore: bump the rustfmt nightly in the pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
       - id: cargo-rustfmt
         name: cargo-rustfmt
         language: system
-        entry: cargo +nightly-2026-07-01 fmt --all -- --check
+        entry: cargo +nightly-2026-08-23 fmt --all -- --check
         stages: [pre-commit, pre-merge-commit]
         pass_filenames: false
         files: \.rs$


### PR DESCRIPTION
# Description

While looking at operator-rs I saw that there is another reference to the nightly version.
We already updated one in https://github.com/stackabletech/docker-images/pull/1617
