### PR TITLE
fix(superset): Remove NodeJS from final image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - spark: Propagate the entrypoint's exit code so failed applications are no longer reported as successful ([#1595]).
 - superset: Fix the broken builds by excluding the `cypress-base` end-to-end test project from the frontend SBOM ([#1616]).
 - superset: Fix the broken 4.1.4 build by also excluding `packages/superset-ui-switchboard` from the frontend SBOM ([#1620]).
+- superset: Install nvm into `/opt/nvm` so that Node and npm, which are only needed to build the frontend, are no longer shipped in the final image (about 161 MB) ([#1623]).
 
 ### Removed
 
@@ -34,6 +35,7 @@ All notable changes to this project will be documented in this file.
 [#1611]: https://github.com/stackabletech/docker-images/pull/1611
 [#1616]: https://github.com/stackabletech/docker-images/pull/1616
 [#1620]: https://github.com/stackabletech/docker-images/pull/1620
+[#1623]: https://github.com/stackabletech/docker-images/pull/1623
 
 ## [26.7.0] - 2026-07-21
 

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -88,10 +88,16 @@ COPY --chown=${STACKABLE_USER_UID}:0 superset/stackable/patches/${PRODUCT_VERSIO
 
 WORKDIR /stackable
 
+# nvm derives its installation directory from the location of nvm.sh if NVM_DIR is not set.
+# It must not end up anywhere below /stackable, because the final image copies that directory
+# as a whole and would then ship Node and npm, which are only needed to build the frontend.
+ENV NVM_DIR=/opt/nvm
+
 RUN <<EOF
 # Download nvm to manage Node and npm installation
-curl "https://repo.stackable.tech/repository/packages/nvm/nvm-${NVM_VERSION}.sh" -o /stackable/nvm.sh
-. /stackable/nvm.sh
+mkdir -p "${NVM_DIR}"
+curl "https://repo.stackable.tech/repository/packages/nvm/nvm-${NVM_VERSION}.sh" -o "${NVM_DIR}/nvm.sh"
+. "${NVM_DIR}/nvm.sh"
 
 # Install the specified version of Node (including the latest compatible version of npm)
 nvm install "$NODEJS_VERSION" --latest-npm
@@ -119,7 +125,7 @@ EOF
 # hadolint ignore=DL3042
 RUN <<EOF
 # This makes node and npm available in the path
-. /stackable/nvm.sh
+. "${NVM_DIR}/nvm.sh"
 
 python${PYTHON_VERSION} -m venv --system-site-packages /stackable/app
 


### PR DESCRIPTION
# Description

The Superset image ships a full Node and npm installation that is only needed to build the frontend.

The reason is the download location: `nvm.sh` was written to `/stackable/nvm.sh`, and nvm derives its installation directory from the location of that script when `NVM_DIR` is unset. Node therefore ends up in `/stackable/versions`, and the final image copies `/stackable/` from the builder as a whole.

Setting `NVM_DIR=/opt/nvm` and downloading `nvm.sh` there keeps the whole nvm tree outside the copied directory. This mirrors what the cdxgen Node installation in `/opt/node-cdxgen` already does.

Besides the smaller image, this also removes a Node runtime that is never executed but is picked up by the vulnerability scans.

Other images were checked and are not affected: Airflow, NiFi, Kafka, Trino and OPA ship no Node at all, and OpenSearch Dashboards needs it at runtime.

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [x] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
