### PR TITLE
ci: Bump actions

### DIFF
--- a/.github/workflows/boil_pr.yaml
+++ b/.github/workflows/boil_pr.yaml
@@ -29,12 +29,12 @@ jobs:
           - bans licenses sources
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Run cargo-deny
-        uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2.0.15
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           command: check ${{ matrix.checks }}
 
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.targets.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/boil_release.yaml
+++ b/.github/workflows/boil_release.yaml
@@ -22,14 +22,14 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: Generate Changelog
         id: changelog
-        uses: orhun/git-cliff-action@e16f179f0be49ecdfe63753837f20b9531642772 # v4.7.0
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
         with:
           config: rust/boil/cliff.toml
           args: --latest --strip header
@@ -58,7 +58,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -95,7 +95,7 @@ jobs:
     steps:
       # This checkout is only here so that a .git directory is present because the gh CLI needs it.
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Publish Container Image on oci.stackable.tech/sdp
         if: inputs.destination-project == 'sdp'
-        uses: stackabletech/actions/publish-image@d0a8db3ba80e974b872c09cb5311f04e0e78582e # v0.16.1
+        uses: stackabletech/actions/publish-image@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -85,7 +85,7 @@ jobs:
 
       - name: Publish Container Image on oci.stackable.tech/stackable
         if: inputs.destination-project == 'stackable'
-        uses: stackabletech/actions/publish-image@d0a8db3ba80e974b872c09cb5311f04e0e78582e # v0.16.1
+        uses: stackabletech/actions/publish-image@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$stackable+github-action-build
@@ -114,7 +114,7 @@ jobs:
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech/sdp
         if: inputs.destination-project == 'sdp'
-        uses: stackabletech/actions/publish-image-index-manifest@d0a8db3ba80e974b872c09cb5311f04e0e78582e # v0.16.1
+        uses: stackabletech/actions/publish-image-index-manifest@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -124,7 +124,7 @@ jobs:
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech/stackable
         if: inputs.destination-project == 'stackable'
-        uses: stackabletech/actions/publish-image-index-manifest@d0a8db3ba80e974b872c09cb5311f04e0e78582e # v0.16.1
+        uses: stackabletech/actions/publish-image-index-manifest@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$stackable+github-action-build

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -52,7 +52,7 @@ jobs:
           - amd64
           - arm64
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -102,7 +102,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -80,8 +80,8 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: ${{ format('sdp/{0}', env.IMAGE_REPOSITORY) }}
-          image-manifest-tag: ${{ format('{0}-{1}', inputs.image-index-manifest-tag, matrix.arch) }}
-          source-image-uri: ${{ format('{0}:{1}', inputs.image-repository-uri, inputs.image-index-manifest-tag) }}
+          canonical-image-manifest-tag: ${{ format('{0}-{1}', inputs.image-index-manifest-tag, matrix.arch) }}
+          canonical-source-image-uri: ${{ format('{0}:{1}', inputs.image-repository-uri, inputs.image-index-manifest-tag) }}
 
       - name: Publish Container Image on oci.stackable.tech/stackable
         if: inputs.destination-project == 'stackable'
@@ -91,8 +91,8 @@ jobs:
           image-registry-username: robot$stackable+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_STACKABLE_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: ${{ format('stackable/{0}', env.IMAGE_REPOSITORY) }}
-          image-manifest-tag: ${{ format('{0}-{1}', inputs.image-index-manifest-tag, matrix.arch) }}
-          source-image-uri: ${{ format('{0}:{1}', inputs.image-repository-uri, inputs.image-index-manifest-tag) }}
+          canonical-image-manifest-tag: ${{ format('{0}-{1}', inputs.image-index-manifest-tag, matrix.arch) }}
+          canonical-source-image-uri: ${{ format('{0}:{1}', inputs.image-repository-uri, inputs.image-index-manifest-tag) }}
 
   publish_manifests:
     name: Build/Publish Image Index Manifest
@@ -120,7 +120,7 @@ jobs:
           image-registry-username: robot$sdp+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: ${{ format('sdp/{0}', env.IMAGE_REPOSITORY) }}
-          image-index-manifest-tag: ${{ inputs.image-index-manifest-tag }}
+          canonical-image-index-manifest-tag: ${{ inputs.image-index-manifest-tag }}
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech/stackable
         if: inputs.destination-project == 'stackable'
@@ -130,7 +130,7 @@ jobs:
           image-registry-username: robot$stackable+github-action-build
           image-registry-password: ${{ secrets.HARBOR_ROBOT_STACKABLE_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: ${{ format('stackable/{0}', env.IMAGE_REPOSITORY) }}
-          image-index-manifest-tag: ${{ inputs.image-index-manifest-tag }}
+          canonical-image-index-manifest-tag: ${{ inputs.image-index-manifest-tag }}
 
   # NOTE (@Techassi) It is currently not possible to use our own action here, because the inputs
   # assume it is used to report on image build results, not mirror results. The action needs to be

--- a/.github/workflows/patchable_pr.yaml
+++ b/.github/workflows/patchable_pr.yaml
@@ -29,12 +29,12 @@ jobs:
           - bans licenses sources
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Run cargo-deny
-        uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2.0.15
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           command: check ${{ matrix.checks }}
 
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.targets.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/pr_prek.yaml
+++ b/.github/workflows/pr_prek.yaml
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - uses: stackabletech/actions/run-prek@0fe048f952bee522474903a925ea48dc706a0bb4 # v0.17.5
+      - uses: stackabletech/actions/run-prek@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
         with:
           rust: ${{ env.RUST_TOOLCHAIN_VERSION }}
           hadolint: ${{ env.HADOLINT_VERSION }}

--- a/.github/workflows/pr_prek.yaml
+++ b/.github/workflows/pr_prek.yaml
@@ -16,7 +16,7 @@ jobs:
   prek:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/preflight.yaml
+++ b/.github/workflows/preflight.yaml
@@ -81,7 +81,7 @@ jobs:
     env:
       GITHUB_REF_NAME: ${{ github.ref_name }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/reusable_build_image.yaml
+++ b/.github/workflows/reusable_build_image.yaml
@@ -88,10 +88,9 @@ jobs:
           persist-credentials: false
 
       - id: shard
-        uses: stackabletech/actions/shard@d0a8db3ba80e974b872c09cb5311f04e0e78582e # v0.16.1
+        uses: stackabletech/actions/shard@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
         with:
           product-name: ${{ inputs.product-name }}
-          boil-version: 0.2.2
     outputs:
       versions: ${{ steps.shard.outputs.versions }}
 
@@ -116,21 +115,20 @@ jobs:
           persist-credentials: false
 
       - name: Free Disk Space
-        uses: stackabletech/actions/free-disk-space@d0a8db3ba80e974b872c09cb5311f04e0e78582e # v0.16.1
+        uses: stackabletech/actions/free-disk-space@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@d0a8db3ba80e974b872c09cb5311f04e0e78582e # v0.16.1
+        uses: stackabletech/actions/build-product-image@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
         with:
           registry-namespace: ${{ inputs.registry-namespace }}
           product-name: ${{ inputs.product-name }}
           product-version: ${{ matrix.versions }}
           sdp-version: ${{ inputs.sdp-version }}
-          boil-version: 0.2.2
 
       - name: Publish Container Image on oci.stackable.tech
         if: inputs.publish
-        uses: stackabletech/actions/publish-image@d0a8db3ba80e974b872c09cb5311f04e0e78582e # v0.16.1
+        uses: stackabletech/actions/publish-image@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$${{ inputs.registry-namespace }}+github-action-build
@@ -146,7 +144,7 @@ jobs:
 
       - name: Publish Container Image on quay.io
         if: inputs.publish && inputs.publish-to-quay
-        uses: stackabletech/actions/publish-image@d0a8db3ba80e974b872c09cb5311f04e0e78582e # v0.16.1
+        uses: stackabletech/actions/publish-image@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
         with:
           image-registry-uri: quay.io
           image-registry-username: stackable+robot_${{ inputs.registry-namespace }}_github_action_build
@@ -180,7 +178,7 @@ jobs:
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         id: publish-oci
         if: inputs.publish
-        uses: stackabletech/actions/publish-image-index-manifest@d0a8db3ba80e974b872c09cb5311f04e0e78582e # v0.16.1
+        uses: stackabletech/actions/publish-image-index-manifest@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$${{ inputs.registry-namespace }}+github-action-build
@@ -196,7 +194,7 @@ jobs:
       - name: Publish and Sign Image Index Manifest to quay.io
         id: publish-quay
         if: inputs.publish && inputs.publish-to-quay
-        uses: stackabletech/actions/publish-image-index-manifest@d0a8db3ba80e974b872c09cb5311f04e0e78582e # v0.16.1
+        uses: stackabletech/actions/publish-image-index-manifest@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
         with:
           image-registry-uri: quay.io
           image-registry-username: stackable+robot_${{ inputs.registry-namespace }}_github_action_build
@@ -218,7 +216,7 @@ jobs:
     if: failure() || (github.run_attempt > 1 && !cancelled())
     steps:
       - name: Send Notification
-        uses: stackabletech/actions/send-slack-notification@d0a8db3ba80e974b872c09cb5311f04e0e78582e # v0.16.1
+        uses: stackabletech/actions/send-slack-notification@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
         with:
           publish-manifests-result: ${{ needs.publish_manifests.result }}
           build-result: ${{ needs.build.result }}

--- a/.github/workflows/reusable_build_image.yaml
+++ b/.github/workflows/reusable_build_image.yaml
@@ -139,8 +139,8 @@ jobs:
           # In future, we probably want to encode this information in the boil config metadata per
           # registry so we don't have to do such gymnastics in the workflow.
           image-repository: ${{ inputs.registry-namespace }}/${{ inputs.image-name || inputs.product-name }}
-          image-manifest-tag: ${{ steps.build.outputs.image-manifest-tag }}
-          source-image-uri: localhost/${{ inputs.registry-namespace }}/${{ inputs.product-name }}:${{ steps.build.outputs.image-manifest-tag }}
+          canonical-image-manifest-tag: ${{ steps.build.outputs.canonical-image-manifest-tag }}
+          canonical-source-image-uri: localhost/${{ inputs.registry-namespace }}/${{ inputs.product-name }}:${{ steps.build.outputs.canonical-image-manifest-tag }}
 
       - name: Publish Container Image on quay.io
         if: inputs.publish && inputs.publish-to-quay
@@ -155,8 +155,8 @@ jobs:
           # In future, we probably want to encode this information in the boil config metadata per
           # registry so we don't have to do such gymnastics in the workflow.
           image-repository: stackable/${{ inputs.registry-namespace }}/${{ inputs.image-name || inputs.product-name }}
-          image-manifest-tag: ${{ steps.build.outputs.image-manifest-tag }}
-          source-image-uri: localhost/${{ inputs.registry-namespace }}/${{ inputs.product-name }}:${{ steps.build.outputs.image-manifest-tag }}
+          canonical-image-manifest-tag: ${{ steps.build.outputs.canonical-image-manifest-tag }}
+          canonical-source-image-uri: localhost/${{ inputs.registry-namespace }}/${{ inputs.product-name }}:${{ steps.build.outputs.canonical-image-manifest-tag }}
 
   publish_manifests:
     name: Build/Publish ${{ matrix.versions }} Manifests
@@ -189,7 +189,7 @@ jobs:
           # In future, we probably want to encode this information in the boil config metadata per
           # registry so we don't have to do such gymnastics in the workflow.
           image-repository: ${{ inputs.registry-namespace }}/${{ inputs.image-name || inputs.product-name }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ inputs.sdp-version }}
+          canonical-image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ inputs.sdp-version }}
 
       - name: Publish and Sign Image Index Manifest to quay.io
         id: publish-quay
@@ -205,7 +205,7 @@ jobs:
           # In future, we probably want to encode this information in the boil config metadata per
           # registry so we don't have to do such gymnastics in the workflow.
           image-repository: stackable/${{ inputs.registry-namespace }}/${{ inputs.image-name || inputs.product-name }}
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ inputs.sdp-version }}
+          canonical-image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ inputs.sdp-version }}
 
   notify:
     name: Failure Notification

--- a/.github/workflows/reusable_build_image.yaml
+++ b/.github/workflows/reusable_build_image.yaml
@@ -55,7 +55,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -83,7 +83,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -111,7 +111,7 @@ jobs:
         runner: ${{ fromJson(needs.generate_runner_dimension.outputs.runners) }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -173,7 +173,7 @@ jobs:
         versions: ${{ fromJson(needs.generate_version_dimension.outputs.versions) }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/ubi-rust-builder.yml
+++ b/.github/workflows/ubi-rust-builder.yml
@@ -35,32 +35,33 @@ jobs:
           - ubi9
           - ubi10
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Login to Stackable Harbor
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: oci.stackable.tech
           username: robot$sdp+github-action-build
           password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
 
       - name: Set up Cosign
-        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Determine Architecture
+        id: tag
         run: |
-          echo "TAG=$(git rev-parse --short HEAD)-$(arch)" >> "$GITHUB_ENV"
+          echo "TAG=$(git rev-parse --short HEAD)-$(arch)" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         id: build-and-push
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./${{ matrix.ubi-version }}-rust-builder/Dockerfile
           push: true
-          tags: oci.stackable.tech/sdp/${{ matrix.ubi-version }}-rust-builder:${{ env.TAG }}
+          tags: oci.stackable.tech/sdp/${{ matrix.ubi-version }}-rust-builder:${{ steps.tag.outputs.TAG }}
           provenance: false
 
       - name: Sign the published builder image
@@ -87,19 +88,19 @@ jobs:
           - ubi9
           - ubi10
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Login to Stackable Harbor
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: oci.stackable.tech
           username: robot$sdp+github-action-build
           password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
 
       - name: Set up Cosign
-        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Create and Push Image Index Manifest
         shell: bash

--- a/.github/workflows/ubi-rust-builder.yml
+++ b/.github/workflows/ubi-rust-builder.yml
@@ -124,7 +124,7 @@ jobs:
     if: failure() || (github.run_attempt > 1 && !cancelled())
     steps:
       - name: Send Notification
-        uses: stackabletech/actions/send-slack-notification@d0a8db3ba80e974b872c09cb5311f04e0e78582e # v0.16.1
+        uses: stackabletech/actions/send-slack-notification@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
         with:
           publish-manifests-result: ${{ needs.publish_manifests.result }}
           build-result: ${{ needs.build.result }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -64,7 +64,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -166,7 +166,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
  "winx",
 ]
 
@@ -468,7 +468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -623,17 +623,14 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags",
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe 0.1.6",
- "openssl-sys",
- "url",
 ]
 
 [[package]]
@@ -1060,9 +1057,7 @@ checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
 ]
 
@@ -1071,20 +1066,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "libz-sys"
@@ -1166,7 +1147,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1206,27 +1187,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "patchable"
@@ -1570,7 +1533,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1603,7 +1566,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -1637,7 +1600,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1853,7 +1816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1975,7 +1938,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2505,7 +2468,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,6 +631,8 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
+ "openssl-probe 0.1.6",
+ "openssl-sys",
  "url",
 ]
 
@@ -1058,7 +1060,9 @@ checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",
+ "libssh2-sys",
  "libz-sys",
+ "openssl-sys",
  "pkg-config",
 ]
 
@@ -1067,6 +1071,20 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c04141a07bb0c0bc461cb657808764de571702a59bc5c726c400ac9a7625e3ab"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "libz-sys"
@@ -1188,9 +1206,27 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "patchable"
@@ -1567,7 +1603,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
  "security-framework",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,6 +631,7 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ cap-std = "4.0.2"
 clap = { version = "4.5.41", features = ["derive"] }
 clap_complete = "4.5.55"
 clap_complete_nushell = "4.5.8"
-git2 = "0.21.0"
+git2 = { version = "0.21.0", features = ["cred"] }
 glob = "0.3.2"
 humansize = "2.1.3"
 oci-spec = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ cap-std = "4.0.2"
 clap = { version = "4.5.41", features = ["derive"] }
 clap_complete = "4.5.55"
 clap_complete_nushell = "4.5.8"
-git2 = { version = "0.21.0", features = ["cred"] }
+git2 = { version = "0.21.0", features = ["cred", "ssh", "https"] }
 glob = "0.3.2"
 humansize = "2.1.3"
 oci-spec = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ cap-std = "4.0.2"
 clap = { version = "4.5.41", features = ["derive"] }
 clap_complete = "4.5.55"
 clap_complete_nushell = "4.5.8"
-git2 = "0.20.1"
+git2 = "0.21.0"
 glob = "0.3.2"
 humansize = "2.1.3"
 oci-spec = "0.9.0"

--- a/rust/patchable/src/patch.rs
+++ b/rust/patchable/src/patch.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use git2::{Oid, Repository};
-use snafu::{OptionExt, ResultExt as _, Snafu};
+use snafu::{ResultExt as _, Snafu};
 use tracing_indicatif::suspend_tracing_indicatif;
 
 #[cfg(doc)]
@@ -113,7 +113,10 @@ pub enum Error {
         original_commit: error::CommitId,
     },
     #[snafu(display("commit {commit}'s commit message is invalid UTF-8"))]
-    NonUtf8CommitMessage { commit: CommitId },
+    NonUtf8CommitMessage {
+        source: git2::Error,
+        commit: CommitId,
+    },
 
     #[snafu(display("failed to delete old patch file {path:?}"))]
     DeleteOldPatch {

--- a/rust/patchable/src/repo.rs
+++ b/rust/patchable/src/repo.rs
@@ -91,6 +91,9 @@ pub enum Error {
         url: String,
         refs: Vec<String>,
     },
+
+    #[snafu(display("worktree head reference name is invalid UTF-8"))]
+    NonUtf8WorktreeHeadReferenceName { source: git2::Error },
 }
 type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -223,7 +226,9 @@ pub fn ensure_worktree_is_at(
                 .context(FindCommitSnafu { repo, commit })?;
             // We can't reset the branch if it's already checked out, so detach to the commit instead for the meantime
             if let Ok(head) = worktree.head() {
-                tracing::info!(head.old = head.name(), "detaching worktree head");
+                let head_name = head.name().context(NonUtf8WorktreeHeadReferenceNameSnafu)?;
+                tracing::info!(head.old = head_name, "detaching worktree head");
+
                 let head_commit = head
                     .peel_to_commit()
                     .context(FindCommitSnafu {


### PR DESCRIPTION
> [!NOTE]
> The required action changes are tested here:
>
> - https://github.com/stackabletech/docker-images/actions/runs/33158737983
> - https://github.com/stackabletech/docker-images/actions/runs/33162548043
> - https://github.com/stackabletech/docker-images/actions/runs/33164245294
> - https://github.com/stackabletech/docker-images/actions/runs/33402847226 (Mirror)
>
>This PR **does not** add support to produce floating tags. This will be done in a later PR.

This PR bumps the following actions:

- Bump actions/checkout to v7.0.1
- Bump EmbarkStudios/cargo-deny-action to v2.1.1
- Bump orhun/git-cliff-action to v4.8.0
- Bump docker/login-action to v4.6.0
- Bump sigstore/cosign-installer to v4.1.2
- Bump docker/build-push-action to v7.3.0
- Bump stackabletech/actions to v0.18.0