### PR TITLE
chore(java-devel): Disable Maven connection pooling

### DIFF
--- a/java-devel/stackable/settings.xml
+++ b/java-devel/stackable/settings.xml
@@ -89,9 +89,10 @@
         <aether.transport.http.retryHandler.intervalMax>60000</aether.transport.http.retryHandler.intervalMax>
 
         <!--
-        This is an option we can experiment with in the future. Settings this to false will result in no connection
-        pooling, which should help to avoid stale/long-lasting connections which can become inactive and be killed by
-        the Azure networking.
+        Disable connection pooling entirely (which makes the connectionMaxTtl settings redundant for now) to rule out
+        failures we're seeing where connections between the IONOS and Azure network seem to be dropped without us
+        noticing. The downside is that Maven uses a fresh connection for everything we download. This can be disabled
+        again, if it doesn't have the desired effects or causes other issues.
         -->
         <aether.connector.http.reuseConnections>false</aether.connector.http.reuseConnections>
         <aether.transport.http.reuseConnections>false</aether.transport.http.reuseConnections>

--- a/java-devel/stackable/settings.xml
+++ b/java-devel/stackable/settings.xml
@@ -93,7 +93,8 @@
         pooling, which should help to avoid stale/long-lasting connections which can become inactive and be killed by
         the Azure networking.
         -->
-        <!-- <aether.transport.http.reuseConnections>false</aether.transport.http.reuseConnections> -->
+        <aether.connector.http.reuseConnections>false</aether.connector.http.reuseConnections>
+        <aether.transport.http.reuseConnections>false</aether.transport.http.reuseConnections>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
This hopefully reduces the number of network issues between the GitHub Action runners (Azure) and our Maven repo (IONOS). This is pretty much one of the last stop we can pull before we would need to investigate moving our Maven repo off of IONOS which hopefully has better networking to Azure or try out Pulp afterall and see if it improves the situation.