### PR TITLE
ci: Enable floating tags

### DIFF
--- a/.github/workflows/build_airflow.yaml
+++ b/.github/workflows/build_airflow.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -31,8 +36,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
@@ -43,7 +91,9 @@ jobs:
       contents: read
     with:
       product-name: airflow
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}

--- a/.github/workflows/build_druid.yaml
+++ b/.github/workflows/build_druid.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -33,8 +38,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
@@ -45,7 +93,9 @@ jobs:
       contents: read
     with:
       product-name: druid
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}

--- a/.github/workflows/build_hadoop.yaml
+++ b/.github/workflows/build_hadoop.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -33,8 +38,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
@@ -45,7 +93,9 @@ jobs:
       contents: read
     with:
       product-name: hadoop
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}

--- a/.github/workflows/build_hbase.yaml
+++ b/.github/workflows/build_hbase.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -34,8 +39,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
@@ -46,7 +94,9 @@ jobs:
       contents: read
     with:
       product-name: hbase
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}

--- a/.github/workflows/build_hive.yaml
+++ b/.github/workflows/build_hive.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -34,8 +39,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
@@ -46,8 +94,10 @@ jobs:
       contents: read
     with:
       product-name: hive
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}
       runners: ubicloud

--- a/.github/workflows/build_java-base.yaml
+++ b/.github/workflows/build_java-base.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -29,8 +34,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
@@ -41,7 +89,9 @@ jobs:
       contents: read
     with:
       product-name: java-base
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}

--- a/.github/workflows/build_java-devel.yaml
+++ b/.github/workflows/build_java-devel.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -29,8 +34,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
@@ -41,7 +89,9 @@ jobs:
       contents: read
     with:
       product-name: java-devel
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}

--- a/.github/workflows/build_kafka-testing-tools.yaml
+++ b/.github/workflows/build_kafka-testing-tools.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -33,8 +38,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
@@ -45,7 +93,9 @@ jobs:
       contents: read
     with:
       product-name: kafka-testing-tools
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}

--- a/.github/workflows/build_kafka.yaml
+++ b/.github/workflows/build_kafka.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -34,8 +39,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
@@ -46,7 +94,9 @@ jobs:
       contents: read
     with:
       product-name: kafka
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}

--- a/.github/workflows/build_krb5.yaml
+++ b/.github/workflows/build_krb5.yaml
@@ -53,6 +53,6 @@ jobs:
       sdp-version: 1.2.3
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ case(inputs.publish, true, true) }}
+      publish: ${{ case(inputs.publish, inputs.publish, false) }}
       # Default to false if not set/empty (if not triggered by workflow_dispatch)
-      floating-tag: ${{ case(inputs.floating-tag, true, false) }}
+      floating-tag: ${{ case(inputs.floating-tag, inputs.floating-tag, false) }}

--- a/.github/workflows/build_krb5.yaml
+++ b/.github/workflows/build_krb5.yaml
@@ -59,6 +59,6 @@ jobs:
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
       # TODO (@Techassi): Set the default back to true
-      publish: ${{ case(inputs.publish, inputs.publish, false) }}
+      publish: ${{ inputs.publish || false}}
       # Default to false if not set/empty (if not triggered by workflow_dispatch)
-      floating-tag: ${{ case(inputs.floating-tag, inputs.floating-tag, false) }}
+      floating-tag: ${{ inputs.floating-tag || false }}

--- a/.github/workflows/build_krb5.yaml
+++ b/.github/workflows/build_krb5.yaml
@@ -34,8 +34,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
@@ -50,7 +93,5 @@ jobs:
       # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
       sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ inputs.publish || true }}
-      # Default to false if not set/empty (if not triggered by workflow_dispatch)
-      floating-tag: ${{ inputs.floating-tag || false }}
+      publish: ${{ needs.defaults.outputs.publish }}
+      floating-tag: ${{ needs.defaults.outputs.floating-tag }}

--- a/.github/workflows/build_krb5.yaml
+++ b/.github/workflows/build_krb5.yaml
@@ -18,6 +18,11 @@ on:
         default: false
   schedule:
     - cron: 0 2 2/2 * * # https://crontab.guru/#0_2_2/2_*_*
+  # NOTE (@Techassi): Temporarily enable builds on PR to test if the workflow works when triggered
+  # without inputs.
+  pull_request:
+    paths:
+      - .github/workflows/build_krb5.yaml
   push:
     branches: [main]
     tags:
@@ -53,6 +58,7 @@ jobs:
       sdp-version: 1.2.3
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      # TODO (@Techassi): Set the default back to true
       publish: ${{ case(inputs.publish, inputs.publish, false) }}
       # Default to false if not set/empty (if not triggered by workflow_dispatch)
       floating-tag: ${{ case(inputs.floating-tag, inputs.floating-tag, false) }}

--- a/.github/workflows/build_krb5.yaml
+++ b/.github/workflows/build_krb5.yaml
@@ -6,11 +6,11 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
         type: boolean
         required: true
-        default: false
+        default: true
       floating-tag:
         description: Produce floating tag
         type: boolean
@@ -53,5 +53,6 @@ jobs:
       sdp-version: 1.2.3
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
+      publish: ${{ case(inputs.publish, true, true) }}
       # Default to false if not set/empty (if not triggered by workflow_dispatch)
       floating-tag: ${{ case(inputs.floating-tag, true, false) }}

--- a/.github/workflows/build_krb5.yaml
+++ b/.github/workflows/build_krb5.yaml
@@ -91,10 +91,7 @@ jobs:
       product-name: krb5
       # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
       # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
-      # sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
-      # TODO (@Techassi): Temporarily use hard-coded version to produce floating tag- Remove again.
-      sdp-version: 1.2.3
-      publish-to-quay: false # Cleanup is easier if we only push to Harbor for e2e testing.
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
       publish: ${{ fromJson(needs.defaults.outputs.publish) }}
       floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}

--- a/.github/workflows/build_krb5.yaml
+++ b/.github/workflows/build_krb5.yaml
@@ -11,6 +11,11 @@ on:
         type: boolean
         required: true
         default: false
+      floating-tag:
+        description: Produce floating tag
+        type: boolean
+        required: true
+        default: false
   schedule:
     - cron: 0 2 2/2 * * # https://crontab.guru/#0_2_2/2_*_*
   push:
@@ -40,8 +45,13 @@ jobs:
       id-token: write
       contents: read
     with:
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
       product-name: krb5
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
+      # NOTE (@Techassi): Temporarily hard-code the SDP version
+      sdp-version: 1.2.3
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      # Default to false if not set/empty (if not triggered by workflow_dispatch)
+      floating-tag: ${{ case(inputs.floating-tag, true, false) }}

--- a/.github/workflows/build_krb5.yaml
+++ b/.github/workflows/build_krb5.yaml
@@ -93,5 +93,5 @@ jobs:
       # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
       sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      publish: ${{ needs.defaults.outputs.publish }}
-      floating-tag: ${{ needs.defaults.outputs.floating-tag }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}

--- a/.github/workflows/build_krb5.yaml
+++ b/.github/workflows/build_krb5.yaml
@@ -18,11 +18,6 @@ on:
         default: false
   schedule:
     - cron: 0 2 2/2 * * # https://crontab.guru/#0_2_2/2_*_*
-  # NOTE (@Techassi): Temporarily enable builds on PR to test if the workflow works when triggered
-  # without inputs.
-  pull_request:
-    paths:
-      - .github/workflows/build_krb5.yaml
   push:
     branches: [main]
     tags:
@@ -30,7 +25,7 @@ on:
       - "[0-9][0-9].[0-9]+.[0-9]+-rc[0-9]+"
     paths:
       # To check dependencies, run this ( you will need to consider transitive dependencies)
-      # bake --product PRODUCT -d | grep -v 'docker buildx bake' | jq '.target | keys[]'
+      # boil build PRODUCT -d | jq '.target | keys[]' | grep -v 'common--target'
       - krb5/**
       - .github/actions/**
       - .github/workflows/build_krb5.yaml
@@ -50,15 +45,12 @@ jobs:
       id-token: write
       contents: read
     with:
+      product-name: krb5
       # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
       # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
-      product-name: krb5
-      # sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
-      # NOTE (@Techassi): Temporarily hard-code the SDP version
-      sdp-version: 1.2.3
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
       # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      # TODO (@Techassi): Set the default back to true
-      publish: ${{ inputs.publish || false}}
+      publish: ${{ inputs.publish || true }}
       # Default to false if not set/empty (if not triggered by workflow_dispatch)
       floating-tag: ${{ inputs.floating-tag || false }}

--- a/.github/workflows/build_krb5.yaml
+++ b/.github/workflows/build_krb5.yaml
@@ -91,7 +91,10 @@ jobs:
       product-name: krb5
       # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
       # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
-      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
+      # sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
+      # TODO (@Techassi): Temporarily use hard-coded version to produce floating tag- Remove again.
+      sdp-version: 1.2.3
+      publish-to-quay: false # Cleanup is easier if we only push to Harbor for e2e testing.
       registry-namespace: sdp
       publish: ${{ fromJson(needs.defaults.outputs.publish) }}
       floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}

--- a/.github/workflows/build_nifi.yaml
+++ b/.github/workflows/build_nifi.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -33,8 +38,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
@@ -45,10 +93,12 @@ jobs:
       contents: read
     with:
       product-name: nifi
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}
       # Since building Vector from source, this build runs out of disk space.
       # As such, we use the Ubicloud runners which provide bigger disks.
       runners: ubicloud

--- a/.github/workflows/build_omid.yaml
+++ b/.github/workflows/build_omid.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -33,8 +38,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
@@ -45,7 +93,9 @@ jobs:
       contents: read
     with:
       product-name: omid
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}

--- a/.github/workflows/build_opa.yaml
+++ b/.github/workflows/build_opa.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -31,8 +36,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
@@ -43,7 +91,9 @@ jobs:
       contents: read
     with:
       product-name: opa
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}

--- a/.github/workflows/build_opensearch.yaml
+++ b/.github/workflows/build_opensearch.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -34,8 +39,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
@@ -46,8 +94,10 @@ jobs:
       contents: read
     with:
       product-name: opensearch
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}
       runners: ubicloud

--- a/.github/workflows/build_opensearch_dashboards.yaml
+++ b/.github/workflows/build_opensearch_dashboards.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -32,8 +37,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
@@ -44,8 +92,10 @@ jobs:
       contents: read
     with:
       product-name: opensearch-dashboards
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}
       runners: ubicloud

--- a/.github/workflows/build_spark-connect-client.yaml
+++ b/.github/workflows/build_spark-connect-client.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -32,8 +37,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_STACKABLE_GITHUB_ACTION_BUILD_SECRET }}
@@ -43,11 +91,13 @@ jobs:
       contents: read
     with:
       product-name: spark-connect-client
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: stackable
       # Since building Vector from source, this build runs out of disk space.
       # As such, we use the Ubicloud runners which provide bigger disks.
       runners: ubicloud
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}
       publish-to-quay: false

--- a/.github/workflows/build_spark-k8s.yaml
+++ b/.github/workflows/build_spark-k8s.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -34,8 +39,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
@@ -46,8 +94,10 @@ jobs:
       contents: read
     with:
       product-name: spark-k8s
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}
       runners: ubicloud

--- a/.github/workflows/build_stackable-base.yaml
+++ b/.github/workflows/build_stackable-base.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -30,8 +35,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
@@ -42,7 +90,9 @@ jobs:
       contents: read
     with:
       product-name: stackable-base
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}

--- a/.github/workflows/build_superset.yaml
+++ b/.github/workflows/build_superset.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -31,8 +36,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
@@ -43,7 +91,9 @@ jobs:
       contents: read
     with:
       product-name: superset
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}

--- a/.github/workflows/build_testing-tools.yaml
+++ b/.github/workflows/build_testing-tools.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -29,8 +34,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow (${{ matrix.product-name }})
+    name: Build Image(s) (${{ matrix.product-name }})
+    needs: [defaults]
     strategy:
       fail-fast: false
       matrix:
@@ -49,7 +97,9 @@ jobs:
       contents: read
     with:
       product-name: ${{ matrix.product-name }}
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}

--- a/.github/workflows/build_tools.yaml
+++ b/.github/workflows/build_tools.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -30,8 +35,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
@@ -42,7 +90,9 @@ jobs:
       contents: read
     with:
       product-name: tools
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}

--- a/.github/workflows/build_trino-cli.yaml
+++ b/.github/workflows/build_trino-cli.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -32,8 +37,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
@@ -44,7 +92,9 @@ jobs:
       contents: read
     with:
       product-name: trino-cli
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}

--- a/.github/workflows/build_trino.yaml
+++ b/.github/workflows/build_trino.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -33,8 +38,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
@@ -45,10 +93,12 @@ jobs:
       contents: read
     with:
       product-name: trino
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}
       # Since building Vector from source, this build runs out of disk space.
       # As such, we use the Ubicloud runners which provide bigger disks.
       runners: ubicloud

--- a/.github/workflows/build_vector.yaml
+++ b/.github/workflows/build_vector.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -29,8 +34,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
@@ -41,7 +89,9 @@ jobs:
       contents: read
     with:
       product-name: vector
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}

--- a/.github/workflows/build_zookeeper.yaml
+++ b/.github/workflows/build_zookeeper.yaml
@@ -6,8 +6,13 @@ run-name: |
 on:
   workflow_dispatch:
     inputs:
-      skip-publish:
-        description: Skip publishing and signing images
+      publish:
+        description: Publish and sign images
+        type: boolean
+        required: true
+        default: true
+      floating-tag:
+        description: Produce floating tag
         type: boolean
         required: true
         default: false
@@ -33,8 +38,51 @@ on:
 permissions: {}
 
 jobs:
+  # This whole dance is only needed because GitHub Actions has no straight forward way of setting
+  # default values for inputs which are not present due to the workflow being triggered by a
+  # different event (workflow_dispatch vs push). Approaches tried (and used) in the past:
+  #
+  # - Negate the input (publish -> skip-publish) and use ${{ !inputs.skip-publish }} for the reusable
+  #   workflow. This works, but only by luck and it is cumbersome to wrap your head around.
+  #   We generally prefer non-negated terms for inputs.
+  # - Use ${{ inputs.publish || true }}, but that results in 'true' even when the workflow is
+  #   dispatched with 'false' via the UI.
+  # - Use ${{ case(inputs.publish, inputs.publish, true) }}, but that fails as well, because the
+  #   predicate must evaluate to a boolean value and apparently doesn't if the input is not present.
+  defaults:
+    name: Determine Defaults
+    runs-on: ubuntu-latest
+    outputs:
+      floating-tag: ${{ steps.defaults.outputs.FLOATING_TAG }}
+      publish: ${{ steps.defaults.outputs.PUBLISH }}
+    steps:
+      - id: defaults
+        shell: bash
+        env:
+          INPUT_FLOATING_TAG: ${{ inputs.floating-tag }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          # Default to false if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_FLOATING_TAG:-}" ]; then
+            echo "FLOATING_TAG=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=${INPUT_FLOATING_TAG}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+          # Default to true if not set/empty (if not triggered by workflow_dispatch)
+          # Keep this default value in sync with the default value specified for workflow_dispatch!
+          if [ -z "${INPUT_PUBLISH:-}" ]; then
+            echo "PUBLISH=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "PUBLISH=${INPUT_PUBLISH}" | tee -a "$GITHUB_OUTPUT"
+          fi
+
   build_image:
-    name: Reusable Workflow
+    name: Build Image(s)
+    needs: [defaults]
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
@@ -45,7 +93,9 @@ jobs:
       contents: read
     with:
       product-name: zookeeper
-      sdp-version: ${{ github.ref_type == 'tag' && github.ref_name || '0.0.0-dev' }}
+      # Syntax for case(): predicate, value if predicate is true, (more predicate+value pairs), default value
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case
+      sdp-version: ${{ case(github.ref_type == 'tag', github.ref_name, '0.0.0-dev') }}
       registry-namespace: sdp
-      # Default to true if not set/empty (if not triggered by workflow_dispatch)
-      publish: ${{ !inputs.skip-publish }}
+      publish: ${{ fromJson(needs.defaults.outputs.publish) }}
+      floating-tag: ${{ fromJson(needs.defaults.outputs.floating-tag) }}

--- a/.github/workflows/reusable_build_image.yaml
+++ b/.github/workflows/reusable_build_image.yaml
@@ -188,7 +188,7 @@ jobs:
       # this should only be a stepping stone towards a more robust solution.
       - name: Install boil
         if: inputs.floating-tag
-        uses: stackabletech/actions/install-tools@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
+        uses: stackabletech/actions/setup-tools@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
         with:
           boil-version: latest
 

--- a/.github/workflows/reusable_build_image.yaml
+++ b/.github/workflows/reusable_build_image.yaml
@@ -36,6 +36,11 @@ on:
           provided.
         type: boolean
         default: true
+      floating-tag:
+        description: Whether to produce a floating tag
+        type: boolean
+        # NOTE (@Techassi): Default to false for now, but eventually we want to default to true here
+        default: false
     secrets:
       harbor-robot-secret:
         description: The secret for the Harbor robot user used to push images and manifest
@@ -125,6 +130,8 @@ jobs:
           product-name: ${{ inputs.product-name }}
           product-version: ${{ matrix.versions }}
           sdp-version: ${{ inputs.sdp-version }}
+          # Map the boolean to a string, because actions cannot use boolean inputs.
+          floating-tag: ${{ case(inputs.floating-tag, 'true', 'false') }}
 
       - name: Publish Container Image on oci.stackable.tech
         if: inputs.publish
@@ -141,6 +148,7 @@ jobs:
           image-repository: ${{ inputs.registry-namespace }}/${{ inputs.image-name || inputs.product-name }}
           canonical-image-manifest-tag: ${{ steps.build.outputs.canonical-image-manifest-tag }}
           canonical-source-image-uri: localhost/${{ inputs.registry-namespace }}/${{ inputs.product-name }}:${{ steps.build.outputs.canonical-image-manifest-tag }}
+          other-image-manifest-tags: ${{ steps.build.outputs.other-image-manifest-tags }}
 
       - name: Publish Container Image on quay.io
         if: inputs.publish && inputs.publish-to-quay
@@ -157,6 +165,7 @@ jobs:
           image-repository: stackable/${{ inputs.registry-namespace }}/${{ inputs.image-name || inputs.product-name }}
           canonical-image-manifest-tag: ${{ steps.build.outputs.canonical-image-manifest-tag }}
           canonical-source-image-uri: localhost/${{ inputs.registry-namespace }}/${{ inputs.product-name }}:${{ steps.build.outputs.canonical-image-manifest-tag }}
+          other-image-manifest-tags: ${{ steps.build.outputs.other-image-manifest-tags }}
 
   publish_manifests:
     name: Build/Publish ${{ matrix.versions }} Manifests
@@ -175,6 +184,29 @@ jobs:
         with:
           persist-credentials: false
 
+      # NOTE (@Techassi): I'm not super happy about how this looks/works, but as already mentioned,
+      # this should only be a stepping stone towards a more robust solution.
+      - name: Install boil
+        if: inputs.floating-tag
+        uses: stackabletech/actions/install-tools@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
+        with:
+          boil-version: latest
+
+      - name: Extract floating image index manifest tag
+        id: extract-floating-tag
+        if: inputs.floating-tag
+        env:
+          SDP_VERSION: ${{ inputs.sdp-version }}
+          IMAGE_VERSION: ${{ matrix.versions }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          FLOATING_IMAGE_INDEX_MANIFEST_TAG=$(boil tools floating-tag "${SDP_VERSION}")
+          FLOATING_IMAGE_INDEX_MANIFEST_TAG="${IMAGE_VERSION}-stackable${FLOATING_IMAGE_INDEX_MANIFEST_TAG}"
+
+          echo "FLOATING_IMAGE_INDEX_MANIFEST_TAG=[\"$FLOATING_IMAGE_INDEX_MANIFEST_TAG\"]" | tee -a "$GITHUB_OUTPUT"
+
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         id: publish-oci
         if: inputs.publish
@@ -190,6 +222,7 @@ jobs:
           # registry so we don't have to do such gymnastics in the workflow.
           image-repository: ${{ inputs.registry-namespace }}/${{ inputs.image-name || inputs.product-name }}
           canonical-image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ inputs.sdp-version }}
+          other-image-index-manifest-tags: ${{ case(inputs.floating-tag, steps.extract-floating-tag.outputs.FLOATING_IMAGE_INDEX_MANIFEST_TAG, '[]') }}
 
       - name: Publish and Sign Image Index Manifest to quay.io
         id: publish-quay
@@ -206,6 +239,7 @@ jobs:
           # registry so we don't have to do such gymnastics in the workflow.
           image-repository: stackable/${{ inputs.registry-namespace }}/${{ inputs.image-name || inputs.product-name }}
           canonical-image-index-manifest-tag: ${{ matrix.versions }}-stackable${{ inputs.sdp-version }}
+          other-image-index-manifest-tags: ${{ case(inputs.floating-tag, steps.extract-floating-tag.outputs.FLOATING_IMAGE_INDEX_MANIFEST_TAG, '[]') }}
 
   notify:
     name: Failure Notification

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/rhysd/actionlint
-    rev: e7d448ef7507c20fc4c88a95d0c448b848cd6127 # 1.7.8
+    rev: 914e7df21a07ef503a81201c76d2b11c789d3fca # 1.7.12
     hooks:
       - id: actionlint
 


### PR DESCRIPTION
Part of https://github.com/stackabletech/internal-issues/issues/169.

> [!NOTE]
> These changes were tested as best as they could here:
>
> - https://github.com/stackabletech/docker-images/actions/runs/33633919558 (no push/signing)
> - https://github.com/stackabletech/docker-images/actions/runs/33636217543
> - https://github.com/stackabletech/docker-images/actions/runs/33636408316
>
> It should be noted, that 0.0.0-dev is already considered floating and as such **no** extra tag is produced. Testing with a version which will produce a second tag will be done later.
>
> - https://github.com/stackabletech/docker-images/actions/runs/33638912230 (1.2.3 hard-coded, with push/sign to Harbor, artifacts were deleted after testing)

This PR wires up floating tag support for all product images. We currently still default to false to make sure everything continues to work as expected (and without changing behaviour).
