### PR TITLE
Revert "chore(java-devel): Disable Maven connection pooling"

### DIFF
--- a/java-devel/stackable/settings.xml
+++ b/java-devel/stackable/settings.xml
@@ -89,13 +89,11 @@
         <aether.transport.http.retryHandler.intervalMax>60000</aether.transport.http.retryHandler.intervalMax>
 
         <!--
-        Disable connection pooling entirely (which makes the connectionMaxTtl settings redundant for now) to rule out
-        failures we're seeing where connections between the IONOS and Azure network seem to be dropped without us
-        noticing. The downside is that Maven uses a fresh connection for everything we download. This can be disabled
-        again, if it doesn't have the desired effects or causes other issues.
+        This is an option we can experiment with in the future. Settings this to false will result in no connection
+        pooling, which should help to avoid stale/long-lasting connections which can become inactive and be killed by
+        the Azure networking.
         -->
-        <aether.connector.http.reuseConnections>false</aether.connector.http.reuseConnections>
-        <aether.transport.http.reuseConnections>false</aether.transport.http.reuseConnections>
+        <!-- <aether.transport.http.reuseConnections>false</aether.transport.http.reuseConnections> -->
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
Reverts stackabletech/docker-images#1626

It did not have a positive effect in our tests.