### PR TITLE
nifi: Backport NIFI-16294 to guard against a null controller status in  SiteToSiteStatusReportingTask` during startup, for `2.6.0`, `2.7.2`, and `2.9.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - airflow, superset, druid, nifi: Add SBOMs for the frontend (npm) dependencies ([#1600]).
 - nifi: Backport NIFI-15958 to log periodic progress while waiting for the content archive scan and provenance re-index, for `2.6.0`, `2.7.2`, and `2.9.0` ([#1611]).
+- nifi: Backport [NIFI-16294](https://issues.apache.org/jira/browse/NIFI-16294) to guard against a null controller status in `SiteToSiteStatusReportingTask` during startup, for `2.6.0`, `2.7.2`, and `2.9.0` ([#XXXX]).
 - hbase: Add an SBOM for the web UI (npm) dependencies, which are unpacked from webjars and therefore not covered by the CycloneDX Maven plugin ([#1620]).
 - trino: Add SBOMs for the web UI, both for the two npm projects behind it and for the pre-built JavaScript vendored into the source tree ([#1620]).
 - hadoop, spark: Add SBOMs for the pre-built JavaScript that is vendored into the source tree for the HDFS and Spark web UIs ([#1620]).
@@ -36,6 +37,7 @@ All notable changes to this project will be documented in this file.
 [#1616]: https://github.com/stackabletech/docker-images/pull/1616
 [#1620]: https://github.com/stackabletech/docker-images/pull/1620
 [#1623]: https://github.com/stackabletech/docker-images/pull/1623
+[#XXXX]: https://github.com/stackabletech/docker-images/pull/XXXX
 
 ## [26.7.0] - 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - airflow, superset, druid, nifi: Add SBOMs for the frontend (npm) dependencies ([#1600]).
 - nifi: Backport NIFI-15958 to log periodic progress while waiting for the content archive scan and provenance re-index, for `2.6.0`, `2.7.2`, and `2.9.0` ([#1611]).
-- nifi: Backport [NIFI-16294](https://issues.apache.org/jira/browse/NIFI-16294) to guard against a null controller status in `SiteToSiteStatusReportingTask` during startup, for `2.6.0`, `2.7.2`, and `2.9.0` ([#XXXX]).
+- nifi: Backport [NIFI-16294](https://issues.apache.org/jira/browse/NIFI-16294) to guard against a null controller status in `SiteToSiteStatusReportingTask` during startup, for `2.6.0`, `2.7.2`, and `2.9.0` ([#1629]).
 - hbase: Add an SBOM for the web UI (npm) dependencies, which are unpacked from webjars and therefore not covered by the CycloneDX Maven plugin ([#1620]).
 - trino: Add SBOMs for the web UI, both for the two npm projects behind it and for the pre-built JavaScript vendored into the source tree ([#1620]).
 - hadoop, spark: Add SBOMs for the pre-built JavaScript that is vendored into the source tree for the HDFS and Spark web UIs ([#1620]).
@@ -37,7 +37,7 @@ All notable changes to this project will be documented in this file.
 [#1616]: https://github.com/stackabletech/docker-images/pull/1616
 [#1620]: https://github.com/stackabletech/docker-images/pull/1620
 [#1623]: https://github.com/stackabletech/docker-images/pull/1623
-[#XXXX]: https://github.com/stackabletech/docker-images/pull/XXXX
+[#1629]: https://github.com/stackabletech/docker-images/pull/1629
 
 ## [26.7.0] - 2026-07-21
 

--- a/nifi/stackable/patches/2.6.0/0011-NIFI-16294-Guard-against-null-controller-status-in-S.patch
+++ b/nifi/stackable/patches/2.6.0/0011-NIFI-16294-Guard-against-null-controller-status-in-S.patch
@@ -1,0 +1,59 @@
+From 5c24a2332409b5c599a8bbe0e850a9080112f880 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?S=C3=B6nke=20Liebau?= <soenke.liebau@stackable.tech>
+Date: Fri, 4 Sep 2026 11:04:21 +0000
+Subject: NIFI-16294 Guard against null controller status in
+ SiteToSiteStatusReportingTask
+
+Return early when getControllerStatus() is null (flow not yet
+initialized) instead of passing it unguarded into serialization.
+
+Log at debug level, this is a transient error that'll correct itself when the cluster is stable again and should arguably not clutter the logs.
+
+This differs from the null guard in SiteToSiteMetricsReportingTask.java:227 which chose to log at the error level, but I'd argue that debug is more appropriate here.
+---
+ .../reporting/SiteToSiteStatusReportingTask.java   |  6 +++++-
+ .../TestSiteToSiteStatusReportingTask.java         | 14 ++++++++++++++
+ 2 files changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteStatusReportingTask.java b/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteStatusReportingTask.java
+index 732a1a9617..58891ee0db 100644
+--- a/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteStatusReportingTask.java
++++ b/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteStatusReportingTask.java
+@@ -125,7 +125,11 @@ public class SiteToSiteStatusReportingTask extends AbstractSiteToSiteReportingTa
+         processGroupIDToPath = new HashMap<>();
+ 
+         final ProcessGroupStatus procGroupStatus = context.getEventAccess().getControllerStatus();
+-        final String rootGroupName = procGroupStatus == null ? null : procGroupStatus.getName();
++        if (procGroupStatus == null) {
++            getLogger().debug("Controller status is not yet available; will report status on a subsequent trigger.");
++            return;
++        }
++        final String rootGroupName = procGroupStatus.getName();
+ 
+         final String nifiUrl = context.getProperty(SiteToSiteUtils.INSTANCE_URL).evaluateAttributeExpressions().getValue();
+         URL url;
+diff --git a/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/test/java/org/apache/nifi/reporting/TestSiteToSiteStatusReportingTask.java b/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/test/java/org/apache/nifi/reporting/TestSiteToSiteStatusReportingTask.java
+index b3bc0c819e..b049247959 100644
+--- a/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/test/java/org/apache/nifi/reporting/TestSiteToSiteStatusReportingTask.java
++++ b/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/test/java/org/apache/nifi/reporting/TestSiteToSiteStatusReportingTask.java
+@@ -123,6 +123,20 @@ public class TestSiteToSiteStatusReportingTask {
+         assertEquals("UP_TO_DATE", versionedFlowState.getString());
+     }
+ 
++    @Test
++    public void testNullControllerStatus() throws IOException, InitializationException {
++        final Map<PropertyDescriptor, String> properties = new HashMap<>();
++        properties.put(SiteToSiteUtils.BATCH_SIZE, "4");
++        properties.put(SiteToSiteStatusReportingTask.COMPONENT_NAME_FILTER_REGEX, "Awesome.*");
++        properties.put(SiteToSiteStatusReportingTask.COMPONENT_TYPE_FILTER_REGEX, ".*");
++
++        // The controller status is not yet available (e.g. during startup before the flow is initialized)
++        MockSiteToSiteStatusReportingTask task = initTask(properties, null);
++        assertDoesNotThrow(() -> task.onTrigger(context));
++
++        assertTrue(task.dataSent.isEmpty());
++    }
++
+     @Test
+     public void testComponentTypeFilter() throws IOException, InitializationException {
+         final ProcessGroupStatus pgStatus = generateProcessGroupStatus("root", "Awesome", 1, 0);

--- a/nifi/stackable/patches/2.7.2/0011-NIFI-16294-Guard-against-null-controller-status-in-S.patch
+++ b/nifi/stackable/patches/2.7.2/0011-NIFI-16294-Guard-against-null-controller-status-in-S.patch
@@ -1,0 +1,59 @@
+From a8e9672fdbcfbccde3610f6447dc6b7d10417dac Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?S=C3=B6nke=20Liebau?= <soenke.liebau@stackable.tech>
+Date: Fri, 4 Sep 2026 11:04:21 +0000
+Subject: NIFI-16294 Guard against null controller status in
+ SiteToSiteStatusReportingTask
+
+Return early when getControllerStatus() is null (flow not yet
+initialized) instead of passing it unguarded into serialization.
+
+Log at debug level, this is a transient error that'll correct itself when the cluster is stable again and should arguably not clutter the logs.
+
+This differs from the null guard in SiteToSiteMetricsReportingTask.java:227 which chose to log at the error level, but I'd argue that debug is more appropriate here.
+---
+ .../reporting/SiteToSiteStatusReportingTask.java   |  6 +++++-
+ .../TestSiteToSiteStatusReportingTask.java         | 14 ++++++++++++++
+ 2 files changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteStatusReportingTask.java b/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteStatusReportingTask.java
+index 88dc035b0d..891c9f2571 100644
+--- a/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteStatusReportingTask.java
++++ b/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteStatusReportingTask.java
+@@ -125,7 +125,11 @@ public class SiteToSiteStatusReportingTask extends AbstractSiteToSiteReportingTa
+         processGroupIDToPath = new HashMap<>();
+ 
+         final ProcessGroupStatus procGroupStatus = context.getEventAccess().getControllerStatus();
+-        final String rootGroupName = procGroupStatus == null ? null : procGroupStatus.getName();
++        if (procGroupStatus == null) {
++            getLogger().debug("Controller status is not yet available; will report status on a subsequent trigger.");
++            return;
++        }
++        final String rootGroupName = procGroupStatus.getName();
+ 
+         final String nifiUrl = context.getProperty(SiteToSiteUtils.INSTANCE_URL).evaluateAttributeExpressions().getValue();
+         URL url;
+diff --git a/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/test/java/org/apache/nifi/reporting/TestSiteToSiteStatusReportingTask.java b/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/test/java/org/apache/nifi/reporting/TestSiteToSiteStatusReportingTask.java
+index 288c7a5cce..dd26c23f6c 100644
+--- a/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/test/java/org/apache/nifi/reporting/TestSiteToSiteStatusReportingTask.java
++++ b/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/test/java/org/apache/nifi/reporting/TestSiteToSiteStatusReportingTask.java
+@@ -123,6 +123,20 @@ public class TestSiteToSiteStatusReportingTask {
+         assertEquals("UP_TO_DATE", versionedFlowState.getString());
+     }
+ 
++    @Test
++    public void testNullControllerStatus() throws IOException, InitializationException {
++        final Map<PropertyDescriptor, String> properties = new HashMap<>();
++        properties.put(SiteToSiteUtils.BATCH_SIZE, "4");
++        properties.put(SiteToSiteStatusReportingTask.COMPONENT_NAME_FILTER_REGEX, "Awesome.*");
++        properties.put(SiteToSiteStatusReportingTask.COMPONENT_TYPE_FILTER_REGEX, ".*");
++
++        // The controller status is not yet available (e.g. during startup before the flow is initialized)
++        MockSiteToSiteStatusReportingTask task = initTask(properties, null);
++        assertDoesNotThrow(() -> task.onTrigger(context));
++
++        assertTrue(task.dataSent.isEmpty());
++    }
++
+     @Test
+     public void testComponentTypeFilter() throws IOException, InitializationException {
+         final ProcessGroupStatus pgStatus = generateProcessGroupStatus("root", "Awesome", 1, 0);

--- a/nifi/stackable/patches/2.9.0/0011-NIFI-16294-Guard-against-null-controller-status-in-S.patch
+++ b/nifi/stackable/patches/2.9.0/0011-NIFI-16294-Guard-against-null-controller-status-in-S.patch
@@ -1,0 +1,59 @@
+From 4315e5c7e8bb3d655fd152b661e06856c541f76d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?S=C3=B6nke=20Liebau?= <soenke.liebau@stackable.tech>
+Date: Fri, 4 Sep 2026 11:04:21 +0000
+Subject: NIFI-16294 Guard against null controller status in
+ SiteToSiteStatusReportingTask
+
+Return early when getControllerStatus() is null (flow not yet
+initialized) instead of passing it unguarded into serialization.
+
+Log at debug level, this is a transient error that'll correct itself when the cluster is stable again and should arguably not clutter the logs.
+
+This differs from the null guard in SiteToSiteMetricsReportingTask.java:227 which chose to log at the error level, but I'd argue that debug is more appropriate here.
+---
+ .../reporting/SiteToSiteStatusReportingTask.java   |  6 +++++-
+ .../TestSiteToSiteStatusReportingTask.java         | 14 ++++++++++++++
+ 2 files changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteStatusReportingTask.java b/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteStatusReportingTask.java
+index 1bc0495130..c9d4c4f42c 100644
+--- a/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteStatusReportingTask.java
++++ b/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteStatusReportingTask.java
+@@ -124,7 +124,11 @@ public class SiteToSiteStatusReportingTask extends AbstractSiteToSiteReportingTa
+         processGroupIDToPath = new HashMap<>();
+ 
+         final ProcessGroupStatus procGroupStatus = context.getEventAccess().getControllerStatus();
+-        final String rootGroupName = procGroupStatus == null ? null : procGroupStatus.getName();
++        if (procGroupStatus == null) {
++            getLogger().debug("Controller status is not yet available; will report status on a subsequent trigger.");
++            return;
++        }
++        final String rootGroupName = procGroupStatus.getName();
+ 
+         final String nifiUrl = context.getProperty(SiteToSiteUtils.INSTANCE_URL).evaluateAttributeExpressions().getValue();
+         URL url;
+diff --git a/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/test/java/org/apache/nifi/reporting/TestSiteToSiteStatusReportingTask.java b/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/test/java/org/apache/nifi/reporting/TestSiteToSiteStatusReportingTask.java
+index fdabe2aee7..dea32d1104 100644
+--- a/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/test/java/org/apache/nifi/reporting/TestSiteToSiteStatusReportingTask.java
++++ b/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/test/java/org/apache/nifi/reporting/TestSiteToSiteStatusReportingTask.java
+@@ -123,6 +123,20 @@ public class TestSiteToSiteStatusReportingTask {
+         assertEquals("UP_TO_DATE", versionedFlowState.getString());
+     }
+ 
++    @Test
++    public void testNullControllerStatus() throws IOException, InitializationException {
++        final Map<PropertyDescriptor, String> properties = new HashMap<>();
++        properties.put(SiteToSiteUtils.BATCH_SIZE, "4");
++        properties.put(SiteToSiteStatusReportingTask.COMPONENT_NAME_FILTER_REGEX, "Awesome.*");
++        properties.put(SiteToSiteStatusReportingTask.COMPONENT_TYPE_FILTER_REGEX, ".*");
++
++        // The controller status is not yet available (e.g. during startup before the flow is initialized)
++        MockSiteToSiteStatusReportingTask task = initTask(properties, null);
++        assertDoesNotThrow(() -> task.onTrigger(context));
++
++        assertTrue(task.dataSent.isEmpty());
++    }
++
+     @Test
+     public void testComponentTypeFilter() throws IOException, InitializationException {
+         final ProcessGroupStatus pgStatus = generateProcessGroupStatus("root", "Awesome", 1, 0);


### PR DESCRIPTION
# Description

nifi: Backport NIFI-16294 to guard against a null controller status in  SiteToSiteStatusReportingTask` during startup, for `2.6.0`, `2.7.2`, and `2.9.0`

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [x] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

