### PR TITLE
fix: Remove non-shipped dependencies from the SBOMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ All notable changes to this project will be documented in this file.
 - superset: Fix the broken builds by excluding the `cypress-base` end-to-end test project from the frontend SBOM ([#1616]).
 - superset: Fix the broken 4.1.4 build by also excluding `packages/superset-ui-switchboard` from the frontend SBOM ([#1620]).
 - superset: Install nvm into `/opt/nvm` so that Node and npm, which are only needed to build the frontend, are no longer shipped in the final image (about 161 MB) ([#1623]).
+- vector: Generate the SBOM with the same feature set the binary is built with, so that the integrations that are not compiled in (AWS, Azure, GreptimeDB, ...) are no longer reported ([#1624]).
+- base images: Exclude the build-time dependencies from the Rust SBOMs ([#1624]).
+- kafka: Exclude the non-runtime configurations and the projects that are not shipped from the SBOM ([#1624]).
+- opensearch: Exclude the test framework, the test fixtures, the QA projects and the benchmarks from the SBOM of `3.1.0` and `3.4.0` ([#1624]).
+- opensearch: Restrict the SBOM of the Prometheus exporter to the runtime dependencies ([#1624]).
+- opensearch-dashboards: Exclude the devDependencies from the SBOM ([#1624]).
+- hbase: Exclude the optional npm dependencies from the web UI SBOM ([#1624]).
+- airflow, superset: Create the Python SBOM from a separate environment, so that neither cyclonedx-bom nor its dependencies end up in the SBOM and in the image ([#1624]).
 
 ### Removed
 
@@ -36,6 +44,7 @@ All notable changes to this project will be documented in this file.
 [#1616]: https://github.com/stackabletech/docker-images/pull/1616
 [#1620]: https://github.com/stackabletech/docker-images/pull/1620
 [#1623]: https://github.com/stackabletech/docker-images/pull/1623
+[#1624]: https://github.com/stackabletech/docker-images/pull/1624
 
 ## [26.7.0] - 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,14 +22,15 @@ All notable changes to this project will be documented in this file.
 - superset: Fix the broken builds by excluding the `cypress-base` end-to-end test project from the frontend SBOM ([#1616]).
 - superset: Fix the broken 4.1.4 build by also excluding `packages/superset-ui-switchboard` from the frontend SBOM ([#1620]).
 - superset: Install nvm into `/opt/nvm` so that Node and npm, which are only needed to build the frontend, are no longer shipped in the final image (about 161 MB) ([#1623]).
-- vector: Generate the SBOM with the same feature set the binary is built with, so that the integrations that are not compiled in (AWS, Azure, GreptimeDB, ...) are no longer reported ([#1624]).
-- base images: Exclude the build-time dependencies from the Rust SBOMs ([#1624]).
-- kafka: Exclude the non-runtime configurations and the projects that are not shipped from the SBOM ([#1624]).
-- opensearch: Exclude the test framework, the test fixtures, the QA projects and the benchmarks from the SBOM of `3.1.0` and `3.4.0` ([#1624]).
-- opensearch: Restrict the SBOM of the Prometheus exporter to the runtime dependencies ([#1624]).
-- opensearch-dashboards: Exclude the devDependencies from the SBOM ([#1624]).
-- hbase: Exclude the optional npm dependencies from the web UI SBOM ([#1624]).
-- airflow, superset: Create the Python SBOM from a separate environment, so that neither cyclonedx-bom nor its dependencies end up in the SBOM and in the image ([#1624]).
+- vector: Generate the SBOM with the same feature set the binary is built with, so that the integrations that are not compiled in are no longer reported ([#1630]).
+- base images: Exclude the build-time dependencies from the Rust SBOMs ([#1630]).
+- kafka: Exclude the non-runtime configurations and the projects that are not shipped from the SBOM ([#1630]).
+- opensearch: Exclude the test framework, the test fixtures, the QA projects and the benchmarks from the SBOM of `3.1.0` and `3.4.0` ([#1630]).
+- opensearch: Restrict the SBOM of the Prometheus exporter to the runtime dependencies ([#1630]).
+- opensearch-dashboards: Exclude the devDependencies from the SBOM ([#1630]).
+- hbase: Exclude the optional npm dependencies from the web UI SBOM ([#1630]).
+- airflow, superset: Create the Python SBOM from a separate environment, so that neither cyclonedx-bom nor its dependencies end up in the SBOM and in the image ([#1630]).
+- airflow, superset: Add the missing purl to the Airflow and Superset packages in the Python SBOM. They are installed from a locally built wheel, and without a purl they show up twice in the image SBOM ([#1630]).
 
 ### Removed
 
@@ -44,7 +45,7 @@ All notable changes to this project will be documented in this file.
 [#1616]: https://github.com/stackabletech/docker-images/pull/1616
 [#1620]: https://github.com/stackabletech/docker-images/pull/1620
 [#1623]: https://github.com/stackabletech/docker-images/pull/1623
-[#1624]: https://github.com/stackabletech/docker-images/pull/1624
+[#1630]: https://github.com/stackabletech/docker-images/pull/1630
 
 ## [26.7.0] - 2026-07-21
 

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -232,9 +232,17 @@ uv pip install --python /tmp/sbom-venv/bin/python cyclonedx-bom==${CYCLONEDX_BOM
 /tmp/sbom-venv/bin/cyclonedx-py environment --spec-version 1.5 --output-file /tmp/sbom.json "${VIRTUAL_ENV}"
 rm -rf /tmp/sbom-venv
 
-# Break circular dependencies by removing the apache-airflow dependency from the providers
+# Post-process the SBOM:
+#   * Break circular dependencies by removing the apache-airflow dependency from the providers.
+#   * Add the missing purl to the Airflow packages. They are installed from a locally built
+#     wheel, so cyclonedx-py records the file URL of that wheel instead of a purl.
 jq '.dependencies |= map(if .ref | test("^apache-airflow-providers-") then
     .dependsOn |= map(select(. != "apache-airflow=='${PRODUCT_VERSION}'"))
+else
+    .
+end)
+| .components |= map(if (.purl | not) and (.name | test("^apache[-_]airflow")) then
+    .purl = "pkg:pypi/" + (.name | ascii_downcase | gsub("[-_.]+"; "-")) + "@" + .version
 else
     .
 end)' /tmp/sbom.json > /stackable/app/airflow-${PRODUCT_VERSION}.cdx.json

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -216,7 +216,7 @@ fi
 
 # Needed for pandas S3 integration to e.g. write and read csv and parquet files to/from S3
 # TODO: s3fs may already be installed via the s3fs extra and constraints. Check if this explicit install is still needed.
-uv pip install --python ${VIRTUAL_ENV}/bin/python s3fs==${S3FS_VERSION} cyclonedx-bom==${CYCLONEDX_BOM_VERSION}
+uv pip install --python ${VIRTUAL_ENV}/bin/python s3fs==${S3FS_VERSION}
 # Needed for OIDC
 uv pip install --python ${VIRTUAL_ENV}/bin/python Flask_OIDC==2.2.0 Flask-OpenID==1.3.1
 
@@ -224,8 +224,13 @@ uv pip install --python ${VIRTUAL_ENV}/bin/python /tmp/opa_auth_manager-0.1.0-py
 
 # Create the SBOM for Airflow
 # Important: All `pip install` commands must be above this line, otherwise the SBOM will be incomplete
-${VIRTUAL_ENV}/bin/cyclonedx-py environment --spec-version 1.5 --output-file /tmp/sbom.json
-uv pip uninstall cyclonedx-bom
+# cyclonedx-bom is installed into a throw-away environment instead of the Airflow one. It would
+# otherwise be part of the SBOM itself, and uninstalling it afterwards leaves its dependencies
+# behind in the image.
+uv venv /tmp/sbom-venv
+uv pip install --python /tmp/sbom-venv/bin/python cyclonedx-bom==${CYCLONEDX_BOM_VERSION}
+/tmp/sbom-venv/bin/cyclonedx-py environment --spec-version 1.5 --output-file /tmp/sbom.json "${VIRTUAL_ENV}"
+rm -rf /tmp/sbom-venv
 
 # Break circular dependencies by removing the apache-airflow dependency from the providers
 jq '.dependencies |= map(if .ref | test("^apache-airflow-providers-") then

--- a/hbase/hbase/Dockerfile
+++ b/hbase/hbase/Dockerfile
@@ -112,6 +112,7 @@ mv hbase-assembly/target/bom.json /stackable/hbase-${NEW_VERSION}/hbase-${NEW_VE
   npm install --package-lock-only --no-audit --no-fund
   cdxgen \
     --type js \
+    --required-only \
     --spec-version "${CDXGEN_SPEC_VERSION}" \
     `# cdxgen would otherwise name the root component after the scratch directory` \
     --project-name hbase-webapps \

--- a/kafka/stackable/patches/3.9.1/0001-Add-CycloneDX-plugin.patch
+++ b/kafka/stackable/patches/3.9.1/0001-Add-CycloneDX-plugin.patch
@@ -1,17 +1,17 @@
-From 9f5ef4ff9f1868244326a56ea7c22c5c7c21253c Mon Sep 17 00:00:00 2001
+From 7e4a1e655312dd26f33bf0cb3a9e2d2b4b152f96 Mon Sep 17 00:00:00 2001
 From: Lukas Voetmand <lukas.voetmand@stackable.tech>
 Date: Thu, 17 Oct 2024 11:01:40 +0200
 Subject: Add CycloneDX plugin
 
 ---
- build.gradle | 42 ++++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 42 insertions(+)
+ build.gradle | 44 ++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 44 insertions(+)
 
 diff --git a/build.gradle b/build.gradle
-index 6b4725d542..f7894f379e 100644
+index 6b4725d542..f60df17046 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -48,6 +48,48 @@ plugins {
+@@ -48,6 +48,50 @@ plugins {
    //  We are going to drop JDK8 support. Hence, the spotless is upgrade to newest version and be applied only if the build env is compatible with JDK 11.
    //  spotless 6.15.0+ has issue in runtime with JDK8 even through we define it with `apply:false`. see https://github.com/diffplug/spotless/issues/2156 for more details
    id 'com.diffplug.spotless' version "6.14.0" apply false
@@ -32,7 +32,9 @@ index 6b4725d542..f7894f379e 100644
 +    includeConfigs = ["runtimeClasspath"]
 +    // Exclude test components. This list needs to be checked and, if it changed, updated for every new Kafka version.
 +    // The list can be obtained by running `gradle projects | grep upgrade-system-tests`
++    // The jmh-benchmarks project is not shipped either and pulls in JMH, JUnit and Mockito.
 +    skipProjects = [
++      'jmh-benchmarks',
 +      'upgrade-system-tests-0100',
 +      'upgrade-system-tests-0101',
 +      'upgrade-system-tests-0102',

--- a/kafka/stackable/patches/3.9.1/0002-Change-Gradle-to-use-the-Nexus-Build-Repo.patch
+++ b/kafka/stackable/patches/3.9.1/0002-Change-Gradle-to-use-the-Nexus-Build-Repo.patch
@@ -1,4 +1,4 @@
-From 4de60cd0100bffdd4b92133840ab25247187763d Mon Sep 17 00:00:00 2001
+From d750e93a81170a7f762618d31627507269002c0c Mon Sep 17 00:00:00 2001
 From: Lars Francke <git@lars-francke.de>
 Date: Thu, 12 Dec 2024 10:09:47 +0100
 Subject: Change Gradle to use the Nexus Build Repo
@@ -8,7 +8,7 @@ Subject: Change Gradle to use the Nexus Build Repo
  1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/build.gradle b/build.gradle
-index f7894f379e..a176efd936 100644
+index f60df17046..056088da5d 100644
 --- a/build.gradle
 +++ b/build.gradle
 @@ -20,7 +20,9 @@ import java.nio.charset.StandardCharsets
@@ -22,7 +22,7 @@ index f7894f379e..a176efd936 100644
    }
    apply from: "$rootDir/gradle/dependencies.gradle"
  
-@@ -168,7 +170,9 @@ ext {
+@@ -170,7 +172,9 @@ ext {
  allprojects {
  
    repositories {

--- a/kafka/stackable/patches/3.9.2/0001-Add-CycloneDX-plugin.patch
+++ b/kafka/stackable/patches/3.9.2/0001-Add-CycloneDX-plugin.patch
@@ -1,17 +1,17 @@
-From c19817ee82f7b90aac0a8be66e3efe17f268eb35 Mon Sep 17 00:00:00 2001
+From 6264a5a1c4115a92b1fe5b9a6ca9279abd02e59e Mon Sep 17 00:00:00 2001
 From: Lukas Voetmand <lukas.voetmand@stackable.tech>
 Date: Thu, 17 Oct 2024 11:01:40 +0200
 Subject: Add CycloneDX plugin
 
 ---
- build.gradle | 42 ++++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 42 insertions(+)
+ build.gradle | 44 ++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 44 insertions(+)
 
 diff --git a/build.gradle b/build.gradle
-index 381e964d13..f51f410858 100644
+index 381e964d13..38e0f7c215 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -48,6 +48,48 @@ plugins {
+@@ -48,6 +48,50 @@ plugins {
    //  We are going to drop JDK8 support. Hence, the spotless is upgrade to newest version and be applied only if the build env is compatible with JDK 11.
    //  spotless 6.15.0+ has issue in runtime with JDK8 even through we define it with `apply:false`. see https://github.com/diffplug/spotless/issues/2156 for more details
    id 'com.diffplug.spotless' version "6.14.0" apply false
@@ -32,7 +32,9 @@ index 381e964d13..f51f410858 100644
 +    includeConfigs = ["runtimeClasspath"]
 +    // Exclude test components. This list needs to be checked and, if it changed, updated for every new Kafka version.
 +    // The list can be obtained by running `gradle projects | grep upgrade-system-tests`
++    // The jmh-benchmarks project is not shipped either and pulls in JMH, JUnit and Mockito.
 +    skipProjects = [
++      'jmh-benchmarks',
 +      'upgrade-system-tests-0100',
 +      'upgrade-system-tests-0101',
 +      'upgrade-system-tests-0102',

--- a/kafka/stackable/patches/3.9.2/0002-Change-Gradle-to-use-the-Nexus-Build-Repo.patch
+++ b/kafka/stackable/patches/3.9.2/0002-Change-Gradle-to-use-the-Nexus-Build-Repo.patch
@@ -1,4 +1,4 @@
-From 343021661d7ed166a7555e6bce9da4805340f6cb Mon Sep 17 00:00:00 2001
+From 5981533c9e29ac164ac09f9821dd99be2f411c48 Mon Sep 17 00:00:00 2001
 From: Lars Francke <git@lars-francke.de>
 Date: Thu, 12 Dec 2024 10:09:47 +0100
 Subject: Change Gradle to use the Nexus Build Repo
@@ -8,7 +8,7 @@ Subject: Change Gradle to use the Nexus Build Repo
  1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/build.gradle b/build.gradle
-index f51f410858..5ccd99e024 100644
+index 38e0f7c215..099432834c 100644
 --- a/build.gradle
 +++ b/build.gradle
 @@ -20,7 +20,9 @@ import java.nio.charset.StandardCharsets
@@ -22,7 +22,7 @@ index f51f410858..5ccd99e024 100644
    }
    apply from: "$rootDir/gradle/dependencies.gradle"
  
-@@ -168,7 +170,9 @@ ext {
+@@ -170,7 +172,9 @@ ext {
  allprojects {
  
    repositories {

--- a/kafka/stackable/patches/4.1.1/0001-Add-CycloneDX-plugin.patch
+++ b/kafka/stackable/patches/4.1.1/0001-Add-CycloneDX-plugin.patch
@@ -1,17 +1,17 @@
-From c995ae95e5f725b19a7f4abdc28a86738aa59bf3 Mon Sep 17 00:00:00 2001
+From 0f9e14c6a625c20a80381cea71de855e4806fab0 Mon Sep 17 00:00:00 2001
 From: Malte Sander <malte.sander.it@gmail.com>
 Date: Thu, 25 Sep 2025 10:47:57 +0200
 Subject: Add CycloneDX plugin
 
 ---
- build.gradle | 41 +++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 41 insertions(+)
+ build.gradle | 47 +++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 47 insertions(+)
 
 diff --git a/build.gradle b/build.gradle
-index 97250637b7..732c6c2a18 100644
+index 97250637b7..49f691ca79 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -41,6 +41,47 @@ plugins {
+@@ -41,6 +41,53 @@ plugins {
    id 'org.scoverage' version '8.0.3' apply false
    id 'com.gradleup.shadow' version '8.3.6' apply false
    id 'com.diffplug.spotless' version "6.25.0"
@@ -32,7 +32,13 @@ index 97250637b7..732c6c2a18 100644
 +    includeConfigs = ["runtimeClasspath"]
 +    // Exclude test components. This list needs to be checked and, if it changed, updated for every new Kafka version.
 +    // The list can be obtained by running `gradle projects | grep upgrade-system-tests`
++    // The jmh-benchmarks project is not shipped either and pulls in JMH, JUnit and Mockito,
++    // and neither are the test-common projects, which pull in JUnit.
 +    skipProjects = [
++      'jmh-benchmarks',
++      'test-common-internal-api',
++      'test-common-runtime',
++      'test-common-util',
 +      'upgrade-system-tests-0110',
 +      'upgrade-system-tests-10',
 +      'upgrade-system-tests-11',

--- a/kafka/stackable/patches/4.1.1/0002-Change-Gradle-to-use-the-Nexus-Build-Repo.patch
+++ b/kafka/stackable/patches/4.1.1/0002-Change-Gradle-to-use-the-Nexus-Build-Repo.patch
@@ -1,4 +1,4 @@
-From 69d2bc1b5d6ab5232fcd93307426bb254b139d6e Mon Sep 17 00:00:00 2001
+From 55362f3ede127bf2a0a70ef07a01dca0ada37481 Mon Sep 17 00:00:00 2001
 From: Malte Sander <malte.sander.it@gmail.com>
 Date: Thu, 25 Sep 2025 10:50:07 +0200
 Subject: Change Gradle to use the Nexus Build Repo
@@ -8,7 +8,7 @@ Subject: Change Gradle to use the Nexus Build Repo
  1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/build.gradle b/build.gradle
-index 732c6c2a18..e6c0449952 100644
+index 49f691ca79..d0129928db 100644
 --- a/build.gradle
 +++ b/build.gradle
 @@ -18,7 +18,9 @@ import java.nio.charset.StandardCharsets
@@ -22,7 +22,7 @@ index 732c6c2a18..e6c0449952 100644
    }
    apply from: "$rootDir/gradle/dependencies.gradle"
  
-@@ -204,7 +206,9 @@ ext {
+@@ -210,7 +212,9 @@ ext {
  allprojects {
  
    repositories {

--- a/kafka/stackable/patches/4.1.1/0004-Include-jackson-dataformat-xml-dependency.patch
+++ b/kafka/stackable/patches/4.1.1/0004-Include-jackson-dataformat-xml-dependency.patch
@@ -1,4 +1,4 @@
-From e908b273dc6844f5cd4e6af5bc16622674457d9d Mon Sep 17 00:00:00 2001
+From 5d5829e4beb6454515eb7c7747aff508f9573028 Mon Sep 17 00:00:00 2001
 From: Malte Sander <malte.sander.it@gmail.com>
 Date: Thu, 25 Sep 2025 11:13:20 +0200
 Subject: Include jackson dataformat xml dependency
@@ -9,10 +9,10 @@ Subject: Include jackson dataformat xml dependency
  2 files changed, 15 insertions(+), 1 deletion(-)
 
 diff --git a/build.gradle b/build.gradle
-index e6c0449952..c1aa6e2f55 100644
+index d0129928db..518ab172d1 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -180,13 +180,15 @@ ext {
+@@ -186,13 +186,15 @@ ext {
      libs.slf4jLog4j2,
      libs.junitPlatformLanucher,
      libs.jacksonDatabindYaml,
@@ -29,7 +29,7 @@ index e6c0449952..c1aa6e2f55 100644
    ]
  
    log4j2Libs = [
-@@ -1066,6 +1068,7 @@ project(':core') {
+@@ -1072,6 +1074,7 @@ project(':core') {
      implementation libs.jacksonDataformatCsv
      implementation libs.jacksonJDK8Datatypes
      implementation libs.jacksonDatabindYaml
@@ -37,7 +37,7 @@ index e6c0449952..c1aa6e2f55 100644
      implementation libs.joptSimple
      implementation libs.jose4j
      implementation libs.metrics
-@@ -1484,6 +1487,7 @@ project(':group-coordinator') {
+@@ -1490,6 +1493,7 @@ project(':group-coordinator') {
      testImplementation project(':server-common').sourceSets.test.output
      testImplementation project(':coordinator-common').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -45,7 +45,7 @@ index e6c0449952..c1aa6e2f55 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoCore
      testImplementation testLog4j2Libs
-@@ -1606,6 +1610,7 @@ project(':test-common:test-common-runtime') {
+@@ -1612,6 +1616,7 @@ project(':test-common:test-common-runtime') {
      implementation libs.junitPlatformLanucher
      implementation libs.junitJupiter
      implementation libs.jacksonDatabindYaml
@@ -53,7 +53,7 @@ index e6c0449952..c1aa6e2f55 100644
      implementation libs.slf4jApi
  
      testImplementation libs.junitJupiter
-@@ -2079,6 +2084,7 @@ project(':raft') {
+@@ -2085,6 +2090,7 @@ project(':raft') {
      testImplementation project(':clients')
      testImplementation project(':clients').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -61,7 +61,7 @@ index e6c0449952..c1aa6e2f55 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoCore
      testImplementation libs.jqwik
-@@ -2176,6 +2182,7 @@ project(':server-common') {
+@@ -2182,6 +2188,7 @@ project(':server-common') {
      testImplementation project(':clients')
      testImplementation project(':clients').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -69,7 +69,7 @@ index e6c0449952..c1aa6e2f55 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoCore
      testImplementation testLog4j2Libs
-@@ -2317,6 +2324,7 @@ project(':storage') {
+@@ -2323,6 +2330,7 @@ project(':storage') {
      testImplementation project(':transaction-coordinator')
      testImplementation libs.hamcrest
      testImplementation libs.jacksonDatabindYaml
@@ -77,7 +77,7 @@ index e6c0449952..c1aa6e2f55 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoCore
      testImplementation libs.bcpkix
-@@ -2634,6 +2642,7 @@ project(':shell') {
+@@ -2640,6 +2648,7 @@ project(':shell') {
      testImplementation project(':server-common')
      testImplementation project(':server-common').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -85,7 +85,7 @@ index e6c0449952..c1aa6e2f55 100644
      testImplementation libs.junitJupiter
      testImplementation testLog4j2Libs
  
-@@ -2683,6 +2692,7 @@ project(':streams') {
+@@ -2689,6 +2698,7 @@ project(':streams') {
  
      testImplementation project(':clients').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -93,7 +93,7 @@ index e6c0449952..c1aa6e2f55 100644
      testImplementation libs.junitJupiter
      testImplementation libs.bcpkix
      testImplementation libs.hamcrest
-@@ -2828,6 +2838,7 @@ project(':streams:streams-scala') {
+@@ -2834,6 +2844,7 @@ project(':streams:streams-scala') {
      testImplementation project(':streams:test-utils')
  
      testImplementation libs.jacksonDatabindYaml
@@ -101,7 +101,7 @@ index e6c0449952..c1aa6e2f55 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoJunitJupiter // supports MockitoExtension
      testImplementation testLog4j2Libs
-@@ -2932,6 +2943,7 @@ project(':streams:test-utils') {
+@@ -2938,6 +2949,7 @@ project(':streams:test-utils') {
  
      testImplementation project(':clients').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -109,7 +109,7 @@ index e6c0449952..c1aa6e2f55 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoCore
      testImplementation libs.hamcrest
-@@ -3610,6 +3622,7 @@ project(':connect:runtime') {
+@@ -3616,6 +3628,7 @@ project(':connect:runtime') {
      testImplementation project(':server-common').sourceSets.test.output
  
      testImplementation libs.jacksonDatabindYaml

--- a/kafka/stackable/patches/4.2.1/0001-Add-CycloneDX-plugin.patch
+++ b/kafka/stackable/patches/4.2.1/0001-Add-CycloneDX-plugin.patch
@@ -1,17 +1,17 @@
-From 5ef351ca945bcaa8346ef066ba00fd9288a4f443 Mon Sep 17 00:00:00 2001
+From 3022c3cdb6f0b0240b73618a5fa1686256222aeb Mon Sep 17 00:00:00 2001
 From: Razvan-Daniel Mihai <84674+razvan@users.noreply.github.com>
 Date: Wed, 13 May 2026 16:30:33 +0300
 Subject: Add CycloneDX plugin
 
 ---
- build.gradle | 45 +++++++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 45 insertions(+)
+ build.gradle | 58 ++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 58 insertions(+)
 
 diff --git a/build.gradle b/build.gradle
-index c07cd3b047..effbe0f65d 100644
+index c07cd3b047..d3f7632f56 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -41,8 +41,53 @@ plugins {
+@@ -41,8 +41,66 @@ plugins {
    id 'org.scoverage' version '8.1' apply false
    id 'com.gradleup.shadow' version '8.3.9' apply false
    id 'com.diffplug.spotless' version "8.0.0"
@@ -27,9 +27,22 @@ index c07cd3b047..effbe0f65d 100644
 +    xmlOutput.unsetConvention()
 +}
 +
++// The SBOM must only describe what is shipped, so restrict it to the runtime dependencies.
++// Without this the SBOM also contains the test and build tooling (JUnit, Mockito, JaCoCo,
++// SpotBugs, Checkstyle, ...). It has to be configured on the per-project `cyclonedxDirectBom`
++// tasks, the `cyclonedxBom` extension above only configures the aggregation.
++allprojects {
++  tasks.matching { it.name == 'cyclonedxDirectBom' }.configureEach {
++    includeConfigs = ['runtimeClasspath']
++  }
++}
++
 +// Exclude test components. This list needs to be checked and, if it changed, updated for every new Kafka version.
 +// The list can be obtained by running `gradle projects | grep upgrade-system-tests`
++// The jmh-benchmarks project is not shipped either and pulls in JMH and the test fixtures.
++// The same is true for the test-common projects, which pull in JUnit.
 +def skipCyclonedxProjects = [
++  ':jmh-benchmarks',
 +  ':streams:upgrade-system-tests-0110',
 +  ':streams:upgrade-system-tests-10',
 +  ':streams:upgrade-system-tests-11',
@@ -56,7 +69,7 @@ index c07cd3b047..effbe0f65d 100644
 +  ':streams:upgrade-system-tests-41',
 +]
 +
-+configure(subprojects.findAll { skipCyclonedxProjects.contains(it.path) }) {
++configure(subprojects.findAll { skipCyclonedxProjects.contains(it.path) || it.path.startsWith(':test-common') }) {
 +  tasks.named('cyclonedxDirectBom') {
 +    enabled = false
 +  }

--- a/kafka/stackable/patches/4.2.1/0002-Change-Gradle-to-use-the-Nexus-Build-Repo.patch
+++ b/kafka/stackable/patches/4.2.1/0002-Change-Gradle-to-use-the-Nexus-Build-Repo.patch
@@ -1,4 +1,4 @@
-From e4e184668e99d71e2cbdebfd55ef4ba3322a6508 Mon Sep 17 00:00:00 2001
+From 2fa68a6a66b5a415c1d3e495d5991efb79fd2254 Mon Sep 17 00:00:00 2001
 From: Razvan-Daniel Mihai <84674+razvan@users.noreply.github.com>
 Date: Wed, 13 May 2026 16:31:44 +0300
 Subject: Change Gradle to use the Nexus Build Repo
@@ -8,7 +8,7 @@ Subject: Change Gradle to use the Nexus Build Repo
  1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/build.gradle b/build.gradle
-index effbe0f65d..bd840210bd 100644
+index d3f7632f56..64334779e9 100644
 --- a/build.gradle
 +++ b/build.gradle
 @@ -18,7 +18,9 @@ import java.nio.charset.StandardCharsets
@@ -22,7 +22,7 @@ index effbe0f65d..bd840210bd 100644
    }
    apply from: "$rootDir/gradle/dependencies.gradle"
  
-@@ -212,7 +214,9 @@ ext {
+@@ -225,7 +227,9 @@ ext {
  allprojects {
  
    repositories {

--- a/kafka/stackable/patches/4.2.1/0004-Include-jackson-dataformat-xml-dependency.patch
+++ b/kafka/stackable/patches/4.2.1/0004-Include-jackson-dataformat-xml-dependency.patch
@@ -1,4 +1,4 @@
-From 1f99c4cf15723be1ce1de65a7d5559b5bb29cb7a Mon Sep 17 00:00:00 2001
+From 8bb5e2b9bb18a19b92c1f6e45571f99a8c0642f2 Mon Sep 17 00:00:00 2001
 From: Razvan-Daniel Mihai <84674+razvan@users.noreply.github.com>
 Date: Fri, 29 May 2026 17:43:58 +0200
 Subject: Include jackson dataformat xml dependency
@@ -11,10 +11,10 @@ build.gradle
  2 files changed, 15 insertions(+), 1 deletion(-)
 
 diff --git a/build.gradle b/build.gradle
-index bd840210bd..487c2d06dd 100644
+index 64334779e9..bd4a2a1800 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -188,13 +188,15 @@ ext {
+@@ -201,13 +201,15 @@ ext {
      libs.slf4jLog4j2,
      libs.junitPlatformLanucher,
      libs.jacksonDatabindYaml,
@@ -31,7 +31,7 @@ index bd840210bd..487c2d06dd 100644
    ]
  
    log4j2Libs = [
-@@ -1122,6 +1124,7 @@ project(':core') {
+@@ -1135,6 +1137,7 @@ project(':core') {
      implementation libs.jacksonDataformatCsv
      implementation libs.jacksonJDK8Datatypes
      implementation libs.jacksonDatabindYaml
@@ -39,7 +39,7 @@ index bd840210bd..487c2d06dd 100644
      implementation libs.joptSimple
      implementation libs.jose4j
      implementation libs.metrics
-@@ -1537,6 +1540,7 @@ project(':group-coordinator') {
+@@ -1550,6 +1553,7 @@ project(':group-coordinator') {
      testImplementation project(':server-common').sourceSets.test.output
      testImplementation project(':coordinator-common').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -47,7 +47,7 @@ index bd840210bd..487c2d06dd 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoCore
      testImplementation testLog4j2Libs
-@@ -1659,6 +1663,7 @@ project(':test-common:test-common-runtime') {
+@@ -1672,6 +1676,7 @@ project(':test-common:test-common-runtime') {
      implementation libs.junitPlatformLanucher
      implementation libs.junitJupiter
      implementation libs.jacksonDatabindYaml
@@ -55,7 +55,7 @@ index bd840210bd..487c2d06dd 100644
      implementation libs.slf4jApi
  
      testImplementation libs.junitJupiter
-@@ -2133,6 +2138,7 @@ project(':raft') {
+@@ -2146,6 +2151,7 @@ project(':raft') {
      testImplementation project(':clients')
      testImplementation project(':clients').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -63,7 +63,7 @@ index bd840210bd..487c2d06dd 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoCore
      testImplementation libs.jqwik
-@@ -2230,6 +2236,7 @@ project(':server-common') {
+@@ -2243,6 +2249,7 @@ project(':server-common') {
      testImplementation project(':clients')
      testImplementation project(':clients').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -71,7 +71,7 @@ index bd840210bd..487c2d06dd 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoCore
      testImplementation testLog4j2Libs
-@@ -2371,6 +2378,7 @@ project(':storage') {
+@@ -2384,6 +2391,7 @@ project(':storage') {
      testImplementation project(':transaction-coordinator')
      testImplementation libs.hamcrest
      testImplementation libs.jacksonDatabindYaml
@@ -79,7 +79,7 @@ index bd840210bd..487c2d06dd 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoCore
      testImplementation libs.bcpkix
-@@ -2689,6 +2697,7 @@ project(':shell') {
+@@ -2702,6 +2710,7 @@ project(':shell') {
      testImplementation project(':server-common')
      testImplementation project(':server-common').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -87,7 +87,7 @@ index bd840210bd..487c2d06dd 100644
      testImplementation libs.junitJupiter
      testImplementation testLog4j2Libs
  
-@@ -2738,6 +2747,7 @@ project(':streams') {
+@@ -2751,6 +2760,7 @@ project(':streams') {
  
      testImplementation project(':clients').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -95,7 +95,7 @@ index bd840210bd..487c2d06dd 100644
      testImplementation libs.junitJupiter
      testImplementation libs.bcpkix
      testImplementation libs.hamcrest
-@@ -2883,6 +2893,7 @@ project(':streams:streams-scala') {
+@@ -2896,6 +2906,7 @@ project(':streams:streams-scala') {
      testImplementation project(':streams:test-utils')
  
      testImplementation libs.jacksonDatabindYaml
@@ -103,7 +103,7 @@ index bd840210bd..487c2d06dd 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoJunitJupiter // supports MockitoExtension
      testImplementation testLog4j2Libs
-@@ -2987,6 +2998,7 @@ project(':streams:test-utils') {
+@@ -3000,6 +3011,7 @@ project(':streams:test-utils') {
  
      testImplementation project(':clients').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -111,7 +111,7 @@ index bd840210bd..487c2d06dd 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoCore
      testImplementation libs.hamcrest
-@@ -3682,6 +3694,7 @@ project(':connect:runtime') {
+@@ -3695,6 +3707,7 @@ project(':connect:runtime') {
      testImplementation project(':server-common').sourceSets.test.output
  
      testImplementation libs.jacksonDatabindYaml

--- a/opensearch-dashboards/Dockerfile
+++ b/opensearch-dashboards/Dockerfile
@@ -197,7 +197,8 @@ EOF
 
 # --spec-version is passed explicitly because cdxgen changes its default between
 # releases. The value is a global build argument, see boil.toml.
-RUN PATH="/opt/node-cdxgen/bin:$PATH" cdxgen --target yarn --json-pretty --spec-version "${CDXGEN_SPEC_VERSION}"
+# --required-only restricts the SBOM to the runtime dependencies.
+RUN PATH="/opt/node-cdxgen/bin:$PATH" cdxgen --target yarn --required-only --json-pretty --spec-version "${CDXGEN_SPEC_VERSION}"
 
 RUN <<EOF
 # Change the group permissions already in the builder image to reduce

--- a/opensearch/opensearch-prometheus-exporter/stackable/patches/3.6.0.0/0001-Add-CycloneDX-plugin.patch
+++ b/opensearch/opensearch-prometheus-exporter/stackable/patches/3.6.0.0/0001-Add-CycloneDX-plugin.patch
@@ -1,17 +1,17 @@
-From 523bb67bd099d627bd787c66cdb2a9501cf214c7 Mon Sep 17 00:00:00 2001
+From e8e606c896c5fcb7006bdf02cb3a7a1f7bb2a55b Mon Sep 17 00:00:00 2001
 From: Razvan-Daniel Mihai <84674+razvan@users.noreply.github.com>
 Date: Fri, 19 Jun 2026 11:14:39 +0200
 Subject: Add CycloneDX plugin
 
 ---
- build.gradle | 13 +++++++++++--
- 1 file changed, 11 insertions(+), 2 deletions(-)
+ build.gradle | 22 ++++++++++++++++++++--
+ 1 file changed, 20 insertions(+), 2 deletions(-)
 
 diff --git a/build.gradle b/build.gradle
-index a0486c2..e6b1c3f 100644
+index a0486c2..35406db 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -30,8 +30,17 @@ buildscript {
+@@ -30,8 +30,26 @@ buildscript {
      }
  }
  
@@ -19,6 +19,15 @@ index a0486c2..e6b1c3f 100644
 -    zipArchive
 +plugins {
 +    id("org.cyclonedx.bom") version "3.2.4"
++}
++
++// The SBOM must only describe what is shipped, so restrict it to the runtime dependencies.
++// Without this it also contains the test and build tooling (JUnit, Mockito, JaCoCo,
++// Checkstyle, ...). This has to be configured on the `cyclonedxDirectBom` task, the
++// `cyclonedxBom` extension below only configures the aggregation.
++cyclonedxDirectBom {
++    includeConfigs = ["runtimeClasspath"]
++    skipConfigs = ["compileClasspath", "testCompileClasspath"]
 +}
 +
 +cyclonedxBom {

--- a/opensearch/stackable/patches/3.1.0/0005-Scope-CycloneDX-SBOM-to-shipped-components-only.patch
+++ b/opensearch/stackable/patches/3.1.0/0005-Scope-CycloneDX-SBOM-to-shipped-components-only.patch
@@ -1,4 +1,4 @@
-From e10e254da6a4fd0ee72accd4da6d4e93e8716bd9 Mon Sep 17 00:00:00 2001
+From b0fd24f0b5361718e5d479b692ba4e20e23082da Mon Sep 17 00:00:00 2001
 From: dervoeti <lukas.krug@stackable.tech>
 Date: Thu, 26 Mar 2026 20:51:26 +0000
 Subject: Scope CycloneDX SBOM to shipped components only
@@ -9,14 +9,14 @@ telemetry-otel are shipped from the local build. Other plugins like
 ingest-attachment (which pulls in tika-core) are not installed in the
 Stackable image and should not appear in the runtime SBOM.
 ---
- build.gradle | 10 ++++++++++
- 1 file changed, 10 insertions(+)
+ build.gradle | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
 
 diff --git a/build.gradle b/build.gradle
-index 78a15b418e7..505f9020830 100644
+index 78a15b418e7..b351ece8700 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -78,6 +78,16 @@ allprojects {
+@@ -78,6 +78,23 @@ allprojects {
  }
  
  cyclonedxBom {
@@ -25,10 +25,17 @@ index 78a15b418e7..505f9020830 100644
 +  // image (repository-s3 and telemetry-otel). This prevents build-only plugin
 +  // dependencies (e.g. tika-core from ingest-attachment) from appearing in the
 +  // runtime SBOM as false positives.
++  // The test framework, the test fixtures, the QA projects and the benchmarks are not
++  // shipped either and are the only source of JUnit, Mockito, Hamcrest, randomizedtesting
++  // and JMH in the SBOM.
 +  def shippedPlugins = ['repository-s3', 'telemetry-otel'] as Set
 +  skipProjects = subprojects.findAll { sub ->
 +    (sub.path.startsWith(':plugins:') && !(sub.name in shippedPlugins)) ||
-+    sub.path.startsWith(':example-plugins')
++    sub.path.startsWith(':example-plugins') ||
++    sub.path.startsWith(':test:') ||
++    sub.path.startsWith(':qa') ||
++    sub.path == ':benchmarks' ||
++    sub.path == ':client:test'
 +  }.collect { it.name }
    includeConfigs = ["runtimeClasspath"]
    includeLicenseText = false

--- a/opensearch/stackable/patches/3.4.0/0005-Scope-CycloneDX-SBOM-to-shipped-components-only.patch
+++ b/opensearch/stackable/patches/3.4.0/0005-Scope-CycloneDX-SBOM-to-shipped-components-only.patch
@@ -1,4 +1,4 @@
-From 180057545225e49cea09c74e454ee6bef30521b5 Mon Sep 17 00:00:00 2001
+From d855d718ce9ff7c31ea9e7e24f167b61128aecfe Mon Sep 17 00:00:00 2001
 From: dervoeti <lukas.krug@stackable.tech>
 Date: Thu, 26 Mar 2026 21:05:47 +0000
 Subject: Scope CycloneDX SBOM to shipped components only
@@ -9,14 +9,14 @@ telemetry-otel are shipped from the local build. Other plugins like
 ingest-attachment (which pulls in tika-core) are not installed in the
 Stackable image and should not appear in the runtime SBOM.
 ---
- build.gradle | 15 +++++++++++++++
- 1 file changed, 15 insertions(+)
+ build.gradle | 22 ++++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
 
 diff --git a/build.gradle b/build.gradle
-index 49d3b971efa..aa2638b6a60 100644
+index 49d3b971efa..6763cdfee48 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -82,6 +82,21 @@ allprojects {
+@@ -82,6 +82,28 @@ allprojects {
    version = VersionProperties.getOpenSearch()
    description = "OpenSearch subproject ${project.path}"
  
@@ -25,11 +25,18 @@ index 49d3b971efa..aa2638b6a60 100644
 +  // image (repository-s3 and telemetry-otel). This prevents build-only plugin
 +  // dependencies (e.g. tika-core from ingest-attachment) from appearing in the
 +  // runtime SBOM as false positives.
++  // The test framework, the test fixtures, the QA projects and the benchmarks are not
++  // shipped either and are the only source of JUnit, Mockito, Hamcrest, randomizedtesting
++  // and JMH in the SBOM.
 +  def shippedPlugins = ['repository-s3', 'telemetry-otel'] as Set
-+  def isUnshippedPlugin = (project.path.startsWith(':plugins:') && !(project.name in shippedPlugins)) ||
-+                          project.path.startsWith(':example-plugins')
++  def isUnshipped = (project.path.startsWith(':plugins:') && !(project.name in shippedPlugins)) ||
++                    project.path.startsWith(':example-plugins') ||
++                    project.path.startsWith(':test:') ||
++                    project.path.startsWith(':qa') ||
++                    project.path == ':benchmarks' ||
++                    project.path == ':client:test'
 +
-+  if (isUnshippedPlugin) {
++  if (isUnshipped) {
 +    tasks.matching { it.name == 'cyclonedxDirectBom' }.configureEach {
 +      enabled = false
 +    }

--- a/stackable-base/Dockerfile
+++ b/stackable-base/Dockerfile
@@ -21,11 +21,12 @@ git clone --depth 1 --branch "config-utils-${CONFIG_UTILS_VERSION}" https://gith
 git clone --depth 1 --branch "containerdebug-${CONTAINERDEBUG_VERSION}" https://github.com/stackabletech/operator-rs containerdebug
 git clone --depth 1 --branch "cert-tools-${CERT_TOOLS_VERSION}" https://github.com/stackabletech/secret-operator
 cd /config-utils
-cargo auditable --quiet build --package config-utils --release && cargo cyclonedx --all --spec-version 1.5 --describe binaries
+# --no-build-deps leaves out the build-time dependencies.
+cargo auditable --quiet build --package config-utils --release && cargo cyclonedx --all --spec-version 1.5 --describe binaries --no-build-deps
 cd /containerdebug
-cargo auditable --quiet build --package containerdebug --release && cargo cyclonedx --all --spec-version 1.5 --describe binaries
+cargo auditable --quiet build --package containerdebug --release && cargo cyclonedx --all --spec-version 1.5 --describe binaries --no-build-deps
 cd /secret-operator
-cargo auditable --quiet build --release --package cert-tools && cargo cyclonedx --all --spec-version 1.5 --describe binaries
+cargo auditable --quiet build --release --package cert-tools && cargo cyclonedx --all --spec-version 1.5 --describe binaries --no-build-deps
 EOF
 
 # Find the latest version:

--- a/stackable-devel/Dockerfile
+++ b/stackable-devel/Dockerfile
@@ -112,7 +112,8 @@ microdnf update
 microdnf install openssl-devel pkg-config
 cd /patchable
 . "$HOME/.cargo/env"
-cargo auditable --quiet build --release && cargo cyclonedx --all --spec-version 1.5 --describe binaries
+# --no-build-deps leaves out the build-time dependencies.
+cargo auditable --quiet build --release && cargo cyclonedx --all --spec-version 1.5 --describe binaries --no-build-deps
 mv /patchable/target/release/patchable /stackable/patchable
 microdnf clean all
 chown ${STACKABLE_USER_UID}:0 /stackable/patchable

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -210,9 +210,7 @@ if [[ "$PRODUCT_VERSION" =~ ^4\.0\..* ]]; then
     uv pip install gunicorn==22.0.0
 fi
 
-uv pip install --no-cache-dir \
-    python-json-logger \
-    cyclonedx-bom==${CYCLONEDX_BOM_VERSION}
+uv pip install --no-cache-dir python-json-logger
 
 if [ -n "$AUTHLIB_VERSION" ]; then
     uv pip install Authlib==${AUTHLIB_VERSION}
@@ -226,8 +224,16 @@ uv pip install --no-cache-dir /tmp/opa_authorizer-0.1.0-py3-none-any.whl
 # See https://setuptools.pypa.io/en/stable/history.html#v82-0-0
 uv pip install --no-cache-dir setuptools==75.2.0
 
-cyclonedx-py environment --schema-version 1.5 --outfile /stackable/app/superset-${PRODUCT_VERSION}.cdx.json
-uv pip uninstall cyclonedx-bom
+# Create the SBOM of the Python environment.
+# cyclonedx-bom is installed into a throw-away environment instead of the Superset one:
+# it would otherwise be part of the SBOM itself, and uninstalling it afterwards leaves its
+# dependencies (cyclonedx-python-lib, pip-requirements-parser, ...) behind in the image.
+uv venv /tmp/sbom-venv
+uv pip install --python /tmp/sbom-venv/bin/python --no-cache-dir cyclonedx-bom==${CYCLONEDX_BOM_VERSION}
+/tmp/sbom-venv/bin/cyclonedx-py environment --schema-version 1.5 \
+    --outfile /stackable/app/superset-${PRODUCT_VERSION}.cdx.json \
+    /stackable/app
+rm -rf /tmp/sbom-venv
 
 # Clean up build artifacts and temporary files to reduce image size
 cd /stackable

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -61,6 +61,8 @@ RUN microdnf update \
         make \
         gcc \
         gcc-c++ \
+        # Needed to modify the SBOM
+        jq \
         libffi-devel \
         openldap-devel \
         openssl-devel \
@@ -231,9 +233,17 @@ uv pip install --no-cache-dir setuptools==75.2.0
 uv venv /tmp/sbom-venv
 uv pip install --python /tmp/sbom-venv/bin/python --no-cache-dir cyclonedx-bom==${CYCLONEDX_BOM_VERSION}
 /tmp/sbom-venv/bin/cyclonedx-py environment --schema-version 1.5 \
-    --outfile /stackable/app/superset-${PRODUCT_VERSION}.cdx.json \
+    --outfile /tmp/sbom.json \
     /stackable/app
 rm -rf /tmp/sbom-venv
+
+# Add the missing purl to the Superset package. It is installed from a locally built wheel, so
+# cyclonedx-py records the file URL of that wheel instead of a purl.
+jq '.components |= map(if (.purl | not) and (.name | test("^apache[-_]superset")) then
+    .purl = "pkg:pypi/" + (.name | ascii_downcase | gsub("[-_.]+"; "-")) + "@" + .version
+else
+    .
+end)' /tmp/sbom.json > /stackable/app/superset-${PRODUCT_VERSION}.cdx.json
 
 # Clean up build artifacts and temporary files to reduce image size
 cd /stackable

--- a/ubi10-rust-builder/Dockerfile
+++ b/ubi10-rust-builder/Dockerfile
@@ -105,7 +105,8 @@ ONBUILD RUN <<EOF
 . "$HOME/.cargo/env"
 tar -czf /app/stackable-src.tar.gz .
 cargo auditable --quiet build --release --workspace
-cargo cyclonedx --all --spec-version 1.5 --describe binaries
+# --no-build-deps leaves out the build-time dependencies.
+cargo cyclonedx --all --spec-version 1.5 --describe binaries --no-build-deps
 
 # -maxdepth 1: The interesting binaries are all directly in ${BUILD_DIR}.
 # -regex filters out tests

--- a/ubi9-rust-builder/Dockerfile
+++ b/ubi9-rust-builder/Dockerfile
@@ -103,7 +103,8 @@ ONBUILD RUN <<EOF
 . "$HOME/.cargo/env"
 tar -czf /app/stackable-src.tar.gz .
 cargo auditable --quiet build --release --workspace
-cargo cyclonedx --all --spec-version 1.5 --describe binaries
+# --no-build-deps leaves out the build-time dependencies.
+cargo cyclonedx --all --spec-version 1.5 --describe binaries --no-build-deps
 
 # -maxdepth 1: The interesting binaries are all directly in ${BUILD_DIR}.
 # -regex filters out tests

--- a/vector/Dockerfile
+++ b/vector/Dockerfile
@@ -82,22 +82,18 @@ tar -czf /stackable/vector-${NEW_VERSION}-src.tar.gz .
 # Other:
 #   - api: Needed for /health checks (or /graphql queries)
 #   - unix: Enables jemalloc allocator on Linux for better performance
-cargo auditable --quiet build --release --no-default-features --features "
-  sources-file,
-  sources-internal_logs,
-  transforms-remap,
-  transforms-filter,
-  transforms-route,
-  sinks-vector,
-  sinks-opentelemetry,
-  sinks-console,
-  sinks-blackhole,
-  api,
-  unix
-"
+# cargo-cyclonedx does not split the feature list on newlines, so it has to be a single line
+# to be usable for both the build and the SBOM generation below.
+VECTOR_FEATURES="sources-file,sources-internal_logs,transforms-remap,transforms-filter,transforms-route,sinks-vector,sinks-opentelemetry,sinks-console,sinks-blackhole,api,unix"
+
+cargo auditable --quiet build --release --no-default-features --features "${VECTOR_FEATURES}"
 
 # Generate SBOMs and copy them to /app (via a script)
-cargo cyclonedx --all --spec-version 1.5 --describe binaries
+# The feature flags must be the same as for the build above. Without them cargo-cyclonedx
+# resolves the default feature set.
+# --no-build-deps drops build-time dependencies.
+cargo cyclonedx --all --spec-version 1.5 --describe binaries \
+  --no-default-features --features "${VECTOR_FEATURES}" --no-build-deps
 
 # -maxdepth 1: The interesting binaries are all directly in ${BUILD_DIR}.
 # -regex filters out tests


### PR DESCRIPTION
# Description

Our SBOMs report dependencies that are never shipped, like test frameworks, build tooling and integrations that are not compiled in. They show up as false positives in the vulnerability scans.

Vector: builds with an explicit, reduced feature set, but `cargo cyclonedx` resolved the default features and reported every integration (AWS, Azure, etc.).

Rust base images: now pass `--no-build-deps`, which drops the build-time dependencies.

Kafka: extended the list of skipped projects

OpenSearch (3.1.0 and 3.4.0): additionally skips the test framework, the test fixtures, the QA projects and the benchmarks. OpenSearch 3.6.0 was already fine since there an allow-list instead of a deny-list is used.
The Prometheus exporter 3.6.0.0 gets `includeConfigs = ["runtimeClasspath"]` on its `cyclonedxDirectBom` task, the `cyclonedxBom` extension only configures the aggregation there. 3.1.0.0 and 3.4.0.0 use plugin version 2.4.1, where the extension still applies to the project itself, so they are already correct.

OpenSearch Dashboards and the HBase web UI pass `--required-only` to cdxgen, which leaves out devDependencies and optional dependencies.

Airflow and Superset got two fixes:

  * `cyclonedx-bom` was installed into the product environment, so it was part of its own SBOM, and uninstalling it afterwards left its dependencies behind in the image. It is now installed into a throw-away venv that is removed after the SBOM is written.
  * The Airflow and Superset packages are installed from a locally built wheel, so `cyclonedx-py` records the file URL of that wheel instead of a purl. Without a purl they appear twice in the image SBOM (no deduplication possible). The purl is added in post-processing with `jq`.

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
