### PR TITLE
chore(java-devel): Include run id+attempt in maven UA [skip ci]

### DIFF
--- a/.github/workflows/reusable_build_image.yaml
+++ b/.github/workflows/reusable_build_image.yaml
@@ -93,7 +93,7 @@ jobs:
           persist-credentials: false
 
       - id: shard
-        uses: stackabletech/actions/shard@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
+        uses: stackabletech/actions/shard@633678e4294785ad88ac706139e8691337eefab8 # v0.18.2
         with:
           product-name: ${{ inputs.product-name }}
     outputs:
@@ -120,11 +120,11 @@ jobs:
           persist-credentials: false
 
       - name: Free Disk Space
-        uses: stackabletech/actions/free-disk-space@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
+        uses: stackabletech/actions/free-disk-space@633678e4294785ad88ac706139e8691337eefab8 # v0.18.2
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
+        uses: stackabletech/actions/build-product-image@633678e4294785ad88ac706139e8691337eefab8 # v0.18.2
         with:
           registry-namespace: ${{ inputs.registry-namespace }}
           product-name: ${{ inputs.product-name }}
@@ -135,7 +135,7 @@ jobs:
 
       - name: Publish Container Image on oci.stackable.tech
         if: inputs.publish
-        uses: stackabletech/actions/publish-image@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
+        uses: stackabletech/actions/publish-image@633678e4294785ad88ac706139e8691337eefab8 # v0.18.2
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$${{ inputs.registry-namespace }}+github-action-build
@@ -152,7 +152,7 @@ jobs:
 
       - name: Publish Container Image on quay.io
         if: inputs.publish && inputs.publish-to-quay
-        uses: stackabletech/actions/publish-image@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
+        uses: stackabletech/actions/publish-image@633678e4294785ad88ac706139e8691337eefab8 # v0.18.2
         with:
           image-registry-uri: quay.io
           image-registry-username: stackable+robot_${{ inputs.registry-namespace }}_github_action_build
@@ -188,7 +188,7 @@ jobs:
       # this should only be a stepping stone towards a more robust solution.
       - name: Install boil
         if: inputs.floating-tag
-        uses: stackabletech/actions/setup-tools@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
+        uses: stackabletech/actions/setup-tools@633678e4294785ad88ac706139e8691337eefab8 # v0.18.2
         with:
           boil-version: latest
 
@@ -210,7 +210,7 @@ jobs:
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         id: publish-oci
         if: inputs.publish
-        uses: stackabletech/actions/publish-image-index-manifest@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
+        uses: stackabletech/actions/publish-image-index-manifest@633678e4294785ad88ac706139e8691337eefab8 # v0.18.2
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$${{ inputs.registry-namespace }}+github-action-build
@@ -227,7 +227,7 @@ jobs:
       - name: Publish and Sign Image Index Manifest to quay.io
         id: publish-quay
         if: inputs.publish && inputs.publish-to-quay
-        uses: stackabletech/actions/publish-image-index-manifest@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
+        uses: stackabletech/actions/publish-image-index-manifest@633678e4294785ad88ac706139e8691337eefab8 # v0.18.2
         with:
           image-registry-uri: quay.io
           image-registry-username: stackable+robot_${{ inputs.registry-namespace }}_github_action_build
@@ -250,7 +250,7 @@ jobs:
     if: failure() || (github.run_attempt > 1 && !cancelled())
     steps:
       - name: Send Notification
-        uses: stackabletech/actions/send-slack-notification@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
+        uses: stackabletech/actions/send-slack-notification@633678e4294785ad88ac706139e8691337eefab8 # v0.18.2
         with:
           publish-manifests-result: ${{ needs.publish_manifests.result }}
           build-result: ${{ needs.build.result }}

--- a/.github/workflows/reusable_build_image.yaml
+++ b/.github/workflows/reusable_build_image.yaml
@@ -93,7 +93,7 @@ jobs:
           persist-credentials: false
 
       - id: shard
-        uses: stackabletech/actions/shard@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
+        uses: stackabletech/actions/shard@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
         with:
           product-name: ${{ inputs.product-name }}
     outputs:
@@ -120,11 +120,11 @@ jobs:
           persist-credentials: false
 
       - name: Free Disk Space
-        uses: stackabletech/actions/free-disk-space@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
+        uses: stackabletech/actions/free-disk-space@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
 
       - name: Build Product Image
         id: build
-        uses: stackabletech/actions/build-product-image@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
+        uses: stackabletech/actions/build-product-image@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
         with:
           registry-namespace: ${{ inputs.registry-namespace }}
           product-name: ${{ inputs.product-name }}
@@ -135,7 +135,7 @@ jobs:
 
       - name: Publish Container Image on oci.stackable.tech
         if: inputs.publish
-        uses: stackabletech/actions/publish-image@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
+        uses: stackabletech/actions/publish-image@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$${{ inputs.registry-namespace }}+github-action-build
@@ -152,7 +152,7 @@ jobs:
 
       - name: Publish Container Image on quay.io
         if: inputs.publish && inputs.publish-to-quay
-        uses: stackabletech/actions/publish-image@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
+        uses: stackabletech/actions/publish-image@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
         with:
           image-registry-uri: quay.io
           image-registry-username: stackable+robot_${{ inputs.registry-namespace }}_github_action_build
@@ -188,7 +188,7 @@ jobs:
       # this should only be a stepping stone towards a more robust solution.
       - name: Install boil
         if: inputs.floating-tag
-        uses: stackabletech/actions/setup-tools@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
+        uses: stackabletech/actions/setup-tools@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
         with:
           boil-version: latest
 
@@ -210,7 +210,7 @@ jobs:
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         id: publish-oci
         if: inputs.publish
-        uses: stackabletech/actions/publish-image-index-manifest@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
+        uses: stackabletech/actions/publish-image-index-manifest@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$${{ inputs.registry-namespace }}+github-action-build
@@ -227,7 +227,7 @@ jobs:
       - name: Publish and Sign Image Index Manifest to quay.io
         id: publish-quay
         if: inputs.publish && inputs.publish-to-quay
-        uses: stackabletech/actions/publish-image-index-manifest@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
+        uses: stackabletech/actions/publish-image-index-manifest@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
         with:
           image-registry-uri: quay.io
           image-registry-username: stackable+robot_${{ inputs.registry-namespace }}_github_action_build
@@ -250,7 +250,7 @@ jobs:
     if: failure() || (github.run_attempt > 1 && !cancelled())
     steps:
       - name: Send Notification
-        uses: stackabletech/actions/send-slack-notification@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
+        uses: stackabletech/actions/send-slack-notification@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
         with:
           publish-manifests-result: ${{ needs.publish_manifests.result }}
           build-result: ${{ needs.build.result }}

--- a/java-devel/Dockerfile
+++ b/java-devel/Dockerfile
@@ -68,6 +68,12 @@ EOF
 ENV JAVA_HOME="/usr/lib/jvm/temurin-${PRODUCT_VERSION}-jdk"
 ENV MAVEN_ARGS="--batch-mode --no-transfer-progress"
 
+ARG GITHUB_RUN_ATTEMPT="<unknown>"
+ENV GITHUB_RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT}
+
+ARG GITHUB_RUN_ID="<unknown>"
+ENV GITHUB_RUN_ID=${GITHUB_RUN_ID}
+
 COPY --chown=${STACKABLE_USER_UID}:0 java-devel/stackable/settings.xml /stackable/.m2/settings.xml
 COPY --chown=${STACKABLE_USER_UID}:0 java-devel/stackable/settings.xml /root/.m2/settings.xml
 

--- a/java-devel/stackable/settings.xml
+++ b/java-devel/stackable/settings.xml
@@ -94,6 +94,9 @@
         the Azure networking.
         -->
         <!-- <aether.transport.http.reuseConnections>false</aether.transport.http.reuseConnections> -->
+
+        <aether.connector.userAgent>Maven (Workflow run id: ${env.GITHUB_RUN_ID}, Attempt: ${env.GITHUB_RUN_ATTEMPT})</aether.connector.userAgent>
+        <aether.transport.userAgent>Maven (Workflow run id: ${env.GITHUB_RUN_ID}, Attempt: ${env.GITHUB_RUN_ATTEMPT})</aether.transport.userAgent>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
Needs https://github.com/stackabletech/infrastructure/pull/270, bumped in 952ff8e1.

This UA shows up in our build-repo logs so that we can more easily correlate build failures with log messages on our servers.

> [!NOTE]
> Test builds:
>
> - https://github.com/stackabletech/docker-images/actions/runs/34207416565 (v0.18.1, succeeded, but run attempt was missing)
> - https://github.com/stackabletech/docker-images/actions/runs/34222990243 (v0.18.2, succeeded, run attempt is now there)
