### PR TITLE
ci: Bump stackabletech/actions to v0.18.2

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Publish Container Image on oci.stackable.tech/sdp
         if: inputs.destination-project == 'sdp'
-        uses: stackabletech/actions/publish-image@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
+        uses: stackabletech/actions/publish-image@633678e4294785ad88ac706139e8691337eefab8 # v0.18.2
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -85,7 +85,7 @@ jobs:
 
       - name: Publish Container Image on oci.stackable.tech/stackable
         if: inputs.destination-project == 'stackable'
-        uses: stackabletech/actions/publish-image@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
+        uses: stackabletech/actions/publish-image@633678e4294785ad88ac706139e8691337eefab8 # v0.18.2
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$stackable+github-action-build
@@ -114,7 +114,7 @@ jobs:
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech/sdp
         if: inputs.destination-project == 'sdp'
-        uses: stackabletech/actions/publish-image-index-manifest@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
+        uses: stackabletech/actions/publish-image-index-manifest@633678e4294785ad88ac706139e8691337eefab8 # v0.18.2
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -124,7 +124,7 @@ jobs:
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech/stackable
         if: inputs.destination-project == 'stackable'
-        uses: stackabletech/actions/publish-image-index-manifest@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
+        uses: stackabletech/actions/publish-image-index-manifest@633678e4294785ad88ac706139e8691337eefab8 # v0.18.2
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$stackable+github-action-build

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Publish Container Image on oci.stackable.tech/sdp
         if: inputs.destination-project == 'sdp'
-        uses: stackabletech/actions/publish-image@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
+        uses: stackabletech/actions/publish-image@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -85,7 +85,7 @@ jobs:
 
       - name: Publish Container Image on oci.stackable.tech/stackable
         if: inputs.destination-project == 'stackable'
-        uses: stackabletech/actions/publish-image@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
+        uses: stackabletech/actions/publish-image@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$stackable+github-action-build
@@ -114,7 +114,7 @@ jobs:
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech/sdp
         if: inputs.destination-project == 'sdp'
-        uses: stackabletech/actions/publish-image-index-manifest@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
+        uses: stackabletech/actions/publish-image-index-manifest@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -124,7 +124,7 @@ jobs:
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech/stackable
         if: inputs.destination-project == 'stackable'
-        uses: stackabletech/actions/publish-image-index-manifest@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
+        uses: stackabletech/actions/publish-image-index-manifest@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$stackable+github-action-build

--- a/.github/workflows/pr_prek.yaml
+++ b/.github/workflows/pr_prek.yaml
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - uses: stackabletech/actions/run-prek@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
+      - uses: stackabletech/actions/run-prek@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
         with:
           rust: ${{ env.RUST_TOOLCHAIN_VERSION }}
           hadolint: ${{ env.HADOLINT_VERSION }}

--- a/.github/workflows/pr_prek.yaml
+++ b/.github/workflows/pr_prek.yaml
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - uses: stackabletech/actions/run-prek@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
+      - uses: stackabletech/actions/run-prek@633678e4294785ad88ac706139e8691337eefab8 # v0.18.2
         with:
           rust: ${{ env.RUST_TOOLCHAIN_VERSION }}
           hadolint: ${{ env.HADOLINT_VERSION }}

--- a/.github/workflows/ubi-rust-builder.yml
+++ b/.github/workflows/ubi-rust-builder.yml
@@ -124,7 +124,7 @@ jobs:
     if: failure() || (github.run_attempt > 1 && !cancelled())
     steps:
       - name: Send Notification
-        uses: stackabletech/actions/send-slack-notification@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
+        uses: stackabletech/actions/send-slack-notification@633678e4294785ad88ac706139e8691337eefab8 # v0.18.2
         with:
           publish-manifests-result: ${{ needs.publish_manifests.result }}
           build-result: ${{ needs.build.result }}

--- a/.github/workflows/ubi-rust-builder.yml
+++ b/.github/workflows/ubi-rust-builder.yml
@@ -124,7 +124,7 @@ jobs:
     if: failure() || (github.run_attempt > 1 && !cancelled())
     steps:
       - name: Send Notification
-        uses: stackabletech/actions/send-slack-notification@e8aed001d347bcf693e41b61f4098b0cb94b4ab6 # v0.18.0
+        uses: stackabletech/actions/send-slack-notification@7044764f398b85cf358f6d06e605da7edc23d7ba # v0.18.1
         with:
           publish-manifests-result: ${{ needs.publish_manifests.result }}
           build-result: ${{ needs.build.result }}


### PR DESCRIPTION
Sibling PR for https://github.com/stackabletech/docker-images/pull/1631. Bumps stackabletech/actions to v0.18.2 in all other workflows.