### PR TITLE
chore(stackable-devel): Include run id+attempt in npm UA [skip ci]

### DIFF
--- a/stackable-devel/Dockerfile
+++ b/stackable-devel/Dockerfile
@@ -120,6 +120,12 @@ chown ${STACKABLE_USER_UID}:0 /stackable/patchable
 rm -rf /patchable
 EOF
 
+ARG GITHUB_RUN_ATTEMPT="<unknown>"
+ENV GITHUB_RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT}
+
+ARG GITHUB_RUN_ID="<unknown>"
+ENV GITHUB_RUN_ID=${GITHUB_RUN_ID}
+
 # Make sure NPM and YARN use our build mirror
 # In theory YARN should (I believe) fall back to the npmrc file but we want to make sure...
 COPY --chown=${STACKABLE_USER_UID}:0 stackable-devel/stackable/.npmrc /stackable/.npmrc

--- a/stackable-devel/stackable/.npmrc
+++ b/stackable-devel/stackable/.npmrc
@@ -20,3 +20,9 @@ fetch-retry-factor=1.97
 # if this needs to be tweaked in the future. This value is also used in the factor tweaking above.
 # See https://docs.npmjs.com/cli/v12/using-npm/config#fetch-timeout
 fetch-timeout=300000
+
+# By default, `npm/{npm-version} node/{node-version} {platform} {arch} workspaces/{workspaces} {ci}`
+# is used. We set a custom user-agent to more easily identify it in relevant logs. See:
+# - https://docs.npmjs.com/cli/v8/using-npm/config#user-agent
+# - https://docs.npmjs.com/cli/v8/configuring-npm/npmrc#files
+user-agent=npm (Workflow run id: ${GITHUB_RUN_ID}, Attempt: ${GITHUB_RUN_ATTEMPT})

--- a/stackable-devel/stackable/.yarnrc.yml
+++ b/stackable-devel/stackable/.yarnrc.yml
@@ -8,3 +8,6 @@ httpRetry: 50
 # By default, yarn times out after 1 minute. We increase this to 5 minutes to hopefully get less
 # failing builds in CI. See https://yarnpkg.com/configuration/yarnrc#httpTimeout
 httpTimeout: 5m
+
+# Ideally, we would want to override the user-agent string here, but yarn currently doesn't support
+# that. See https://github.com/yarnpkg/berry/issues/7146


### PR DESCRIPTION
Needs #1631.

This PR overrides the npm (pnpm) user-agent string to include the workflow run id and attempt, similar what #1631 does for maven.

> [!NOTE]
> Test runs:
>
> - https://github.com/stackabletech/docker-images/actions/runs/34233954368 (cancelled, arg/env was not set)
> - https://github.com/stackabletech/docker-images/actions/runs/34320676013 (succeeded)
