### PR TITLE
fix: Correct the SBOM scoping follow-ups from #1630

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,21 @@ All notable changes to this project will be documented in this file.
 - kafka: Exclude the non-runtime configurations and the projects that are not shipped from the SBOM ([#1630]).
 - opensearch: Exclude the test framework, the test fixtures, the QA projects and the benchmarks from the SBOM of `3.1.0` and `3.4.0` ([#1630]).
 - opensearch: Restrict the SBOM of the Prometheus exporter to the runtime dependencies ([#1630]).
-- opensearch-dashboards: Exclude the devDependencies from the SBOM ([#1630]).
+- opensearch-dashboards: Pass `--required-only` to cdxgen ([#1630]). This turned out to have no
+  effect, see [#1635].
+- opensearch-dashboards: Pass `--type js` to cdxgen instead of the non-existing `--target` option.
+  cdxgen silently ignored it and auto-detected every ecosystem in the source tree, which added the
+  GitHub Actions workflows and the Gradle and Python files of the build tooling to the SBOM
+  ([#1635]).
+- kafka: Include the `releaseOnly` configuration in the SBOM of `4.1.1` and `4.2.1`. The `core` and
+  `tools` projects declare the Log4j runtime bindings there, so they were shipped in `libs/` without
+  being part of the SBOM ([#1635]).
+- kafka: Exclude the `generator`, integration test and Connect test plugin projects from the SBOM ([#1635]).
+- opensearch: Exclude the `build-tools` project and the remaining unshipped projects from the SBOM of `3.1.0`
+  and `3.4.0` ([#1635]).
+- airflow, superset: Add the missing purls to all packages that are installed from a local wheel or
+  a direct URL, and normalize the names in the purls as defined in the Python packaging
+  specification ([#1635]).
 - hbase: Exclude the optional npm dependencies from the web UI SBOM ([#1630]).
 - airflow, superset: Create the Python SBOM from a separate environment, so that neither cyclonedx-bom nor its dependencies end up in the SBOM and in the image ([#1630]).
 - airflow, superset: Add the missing purl to the Airflow and Superset packages in the Python SBOM. They are installed from a locally built wheel, and without a purl they show up twice in the image SBOM ([#1630]).
@@ -46,6 +60,7 @@ All notable changes to this project will be documented in this file.
 [#1620]: https://github.com/stackabletech/docker-images/pull/1620
 [#1623]: https://github.com/stackabletech/docker-images/pull/1623
 [#1630]: https://github.com/stackabletech/docker-images/pull/1630
+[#1635]: https://github.com/stackabletech/docker-images/pull/1635
 
 ## [26.7.0] - 2026-07-21
 

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -234,15 +234,25 @@ rm -rf /tmp/sbom-venv
 
 # Post-process the SBOM:
 #   * Break circular dependencies by removing the apache-airflow dependency from the providers.
-#   * Add the missing purl to the Airflow packages. They are installed from a locally built
-#     wheel, so cyclonedx-py records the file URL of that wheel instead of a purl.
-jq '.dependencies |= map(if .ref | test("^apache-airflow-providers-") then
+#   * Add the missing purls. Packages that are installed from a local wheel or a direct URL
+#     (apache-airflow, opa-auth-manager, pip) get no purl from cyclonedx-py, because it records
+#     the file URL instead. Without a purl they show up twice in the image SBOM.
+#   * Normalize the names in the purls as defined in the Python packaging specification.
+#     cyclonedx-py keeps the name as it is written in the metadata (`pkg:pypi/zope.event`),
+#     while Syft normalizes it (`pkg:pypi/zope-event`), which again results in duplicates.
+jq 'def normalize_name: ascii_downcase | gsub("[-_.]+"; "-");
+.dependencies |= map(if .ref | test("^apache-airflow-providers-") then
     .dependsOn |= map(select(. != "apache-airflow=='${PRODUCT_VERSION}'"))
 else
     .
 end)
-| .components |= map(if (.purl | not) and (.name | test("^apache[-_]airflow")) then
-    .purl = "pkg:pypi/" + (.name | ascii_downcase | gsub("[-_.]+"; "-")) + "@" + .version
+| .components |= map(if (.purl | not) and (.name != null) and (.version != null) then
+    .purl = "pkg:pypi/" + (.name | normalize_name) + "@" + .version
+else
+    .
+end
+| if (.purl // "") | startswith("pkg:pypi/") then
+    .purl |= sub("^pkg:pypi/(?<name>[^@]+)"; "pkg:pypi/" + (.name | normalize_name))
 else
     .
 end)' /tmp/sbom.json > /stackable/app/airflow-${PRODUCT_VERSION}.cdx.json

--- a/kafka/stackable/patches/3.9.1/0001-Add-CycloneDX-plugin.patch
+++ b/kafka/stackable/patches/3.9.1/0001-Add-CycloneDX-plugin.patch
@@ -1,17 +1,17 @@
-From 7e4a1e655312dd26f33bf0cb3a9e2d2b4b152f96 Mon Sep 17 00:00:00 2001
+From c7a4c4cd14dac4be0f195d2e1ff1f6e38e12758d Mon Sep 17 00:00:00 2001
 From: Lukas Voetmand <lukas.voetmand@stackable.tech>
 Date: Thu, 17 Oct 2024 11:01:40 +0200
 Subject: Add CycloneDX plugin
 
 ---
- build.gradle | 44 ++++++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 44 insertions(+)
+ build.gradle | 51 +++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 51 insertions(+)
 
 diff --git a/build.gradle b/build.gradle
-index 6b4725d542..f60df17046 100644
+index 6b4725d5429..41954b3d3a6 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -48,6 +48,50 @@ plugins {
+@@ -48,6 +48,57 @@ plugins {
    //  We are going to drop JDK8 support. Hence, the spotless is upgrade to newest version and be applied only if the build env is compatible with JDK 11.
    //  spotless 6.15.0+ has issue in runtime with JDK8 even through we define it with `apply:false`. see https://github.com/diffplug/spotless/issues/2156 for more details
    id 'com.diffplug.spotless' version "6.14.0" apply false
@@ -30,11 +30,18 @@ index 6b4725d542..f60df17046 100644
 +    // The file format generated, can be xml, json or all for generating both. Defaults to 'all'
 +    outputFormat = "json"
 +    includeConfigs = ["runtimeClasspath"]
-+    // Exclude test components. This list needs to be checked and, if it changed, updated for every new Kafka version.
-+    // The list can be obtained by running `gradle projects | grep upgrade-system-tests`
-+    // The jmh-benchmarks project is not shipped either and pulls in JMH, JUnit and Mockito.
++    // Exclude the projects that are not shipped. This list needs to be checked and, if it changed,
++    // updated for every new Kafka version. The list of projects can be obtained by running
++    // `gradle projects`.
++    //   * jmh-benchmarks pulls in JMH, JUnit and Mockito.
++    //   * generator is a build-time code generator for the message protocol. It pulls in Jackson,
++    //     but its own dependencies never reach the distribution.
++    //   * connect:test-plugins pulls in JGit, Bouncy Castle, Apache MINA sshd and commons-codec,
++    //     none of which are shipped.
 +    skipProjects = [
++      'generator',
 +      'jmh-benchmarks',
++      'test-plugins',
 +      'upgrade-system-tests-0100',
 +      'upgrade-system-tests-0101',
 +      'upgrade-system-tests-0102',

--- a/kafka/stackable/patches/3.9.1/0002-Change-Gradle-to-use-the-Nexus-Build-Repo.patch
+++ b/kafka/stackable/patches/3.9.1/0002-Change-Gradle-to-use-the-Nexus-Build-Repo.patch
@@ -1,4 +1,4 @@
-From d750e93a81170a7f762618d31627507269002c0c Mon Sep 17 00:00:00 2001
+From f0ec37c057c7c37997f4bf71f1b4e475e8621e6c Mon Sep 17 00:00:00 2001
 From: Lars Francke <git@lars-francke.de>
 Date: Thu, 12 Dec 2024 10:09:47 +0100
 Subject: Change Gradle to use the Nexus Build Repo
@@ -8,7 +8,7 @@ Subject: Change Gradle to use the Nexus Build Repo
  1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/build.gradle b/build.gradle
-index f60df17046..056088da5d 100644
+index 41954b3d3a6..6461e7cd37e 100644
 --- a/build.gradle
 +++ b/build.gradle
 @@ -20,7 +20,9 @@ import java.nio.charset.StandardCharsets
@@ -22,7 +22,7 @@ index f60df17046..056088da5d 100644
    }
    apply from: "$rootDir/gradle/dependencies.gradle"
  
-@@ -170,7 +172,9 @@ ext {
+@@ -177,7 +179,9 @@ ext {
  allprojects {
  
    repositories {

--- a/kafka/stackable/patches/3.9.1/0003-Build-custom-Stackable-version.patch
+++ b/kafka/stackable/patches/3.9.1/0003-Build-custom-Stackable-version.patch
@@ -1,4 +1,4 @@
-From 89fe680ede7726e0df32f0ba1fb90a4216af7c69 Mon Sep 17 00:00:00 2001
+From f6c5706e8ce7d409384213db19b7be96e2c84296 Mon Sep 17 00:00:00 2001
 From: dervoeti <lukas.krug@stackable.tech>
 Date: Wed, 18 Jun 2025 12:17:53 +0200
 Subject: Build custom Stackable version
@@ -15,7 +15,7 @@ Subject: Build custom Stackable version
  8 files changed, 8 insertions(+), 8 deletions(-)
 
 diff --git a/docs/configuration.html b/docs/configuration.html
-index f7c99623de..266236b54a 100644
+index f7c99623de9..266236b54aa 100644
 --- a/docs/configuration.html
 +++ b/docs/configuration.html
 @@ -296,7 +296,7 @@
@@ -28,7 +28,7 @@ index f7c99623de..266236b54a 100644
        </tbody></table>
      </li>
 diff --git a/docs/js/templateData.js b/docs/js/templateData.js
-index a1ed4601c7..57c854db36 100644
+index a1ed4601c78..57c854db36d 100644
 --- a/docs/js/templateData.js
 +++ b/docs/js/templateData.js
 @@ -19,6 +19,6 @@ limitations under the License.
@@ -40,7 +40,7 @@ index a1ed4601c7..57c854db36 100644
      "scalaVersion": "2.13"
  };
 diff --git a/gradle.properties b/gradle.properties
-index 05598137fd..3f660d4ee5 100644
+index 05598137fd5..3f660d4ee51 100644
 --- a/gradle.properties
 +++ b/gradle.properties
 @@ -23,7 +23,7 @@ group=org.apache.kafka
@@ -53,7 +53,7 @@ index 05598137fd..3f660d4ee5 100644
  # Adding swaggerVersion in gradle.properties to have a single version in place for swagger
  # New version of Swagger 2.2.14 requires minimum JDK 11.
 diff --git a/streams/quickstart/java/pom.xml b/streams/quickstart/java/pom.xml
-index 3d404de9c3..92735dffbc 100644
+index 3d404de9c37..92735dffbc8 100644
 --- a/streams/quickstart/java/pom.xml
 +++ b/streams/quickstart/java/pom.xml
 @@ -26,7 +26,7 @@
@@ -66,7 +66,7 @@ index 3d404de9c3..92735dffbc 100644
      </parent>
  
 diff --git a/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml b/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
-index 26af0e1dc3..b55640c1f0 100644
+index 26af0e1dc39..b55640c1f01 100644
 --- a/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
 +++ b/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
 @@ -29,7 +29,7 @@
@@ -79,7 +79,7 @@ index 26af0e1dc3..b55640c1f0 100644
      </properties>
  
 diff --git a/streams/quickstart/pom.xml b/streams/quickstart/pom.xml
-index f524e00445..05e8eee91a 100644
+index f524e00445f..05e8eee91a4 100644
 --- a/streams/quickstart/pom.xml
 +++ b/streams/quickstart/pom.xml
 @@ -22,7 +22,7 @@
@@ -92,7 +92,7 @@ index f524e00445..05e8eee91a 100644
      <name>Kafka Streams :: Quickstart</name>
  
 diff --git a/tests/kafkatest/__init__.py b/tests/kafkatest/__init__.py
-index a8e4d4515c..36068eeb1a 100644
+index a8e4d4515ce..36068eeb1ab 100644
 --- a/tests/kafkatest/__init__.py
 +++ b/tests/kafkatest/__init__.py
 @@ -22,4 +22,4 @@
@@ -102,7 +102,7 @@ index a8e4d4515c..36068eeb1a 100644
 -__version__ = '3.9.1'
 +__version__ = '3.9.1-stackable0.0.0-dev'
 diff --git a/tests/kafkatest/version.py b/tests/kafkatest/version.py
-index 99cb278226..cd8bcfab4b 100644
+index 99cb2782265..cd8bcfab4b9 100644
 --- a/tests/kafkatest/version.py
 +++ b/tests/kafkatest/version.py
 @@ -122,7 +122,7 @@ def get_version(node=None):

--- a/kafka/stackable/patches/3.9.2/0001-Add-CycloneDX-plugin.patch
+++ b/kafka/stackable/patches/3.9.2/0001-Add-CycloneDX-plugin.patch
@@ -1,17 +1,17 @@
-From 6264a5a1c4115a92b1fe5b9a6ca9279abd02e59e Mon Sep 17 00:00:00 2001
+From ff9091de32175669976e319117ca5b9e6271dde2 Mon Sep 17 00:00:00 2001
 From: Lukas Voetmand <lukas.voetmand@stackable.tech>
 Date: Thu, 17 Oct 2024 11:01:40 +0200
 Subject: Add CycloneDX plugin
 
 ---
- build.gradle | 44 ++++++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 44 insertions(+)
+ build.gradle | 51 +++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 51 insertions(+)
 
 diff --git a/build.gradle b/build.gradle
-index 381e964d13..38e0f7c215 100644
+index 381e964d13e..c4bbde12405 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -48,6 +48,50 @@ plugins {
+@@ -48,6 +48,57 @@ plugins {
    //  We are going to drop JDK8 support. Hence, the spotless is upgrade to newest version and be applied only if the build env is compatible with JDK 11.
    //  spotless 6.15.0+ has issue in runtime with JDK8 even through we define it with `apply:false`. see https://github.com/diffplug/spotless/issues/2156 for more details
    id 'com.diffplug.spotless' version "6.14.0" apply false
@@ -30,11 +30,18 @@ index 381e964d13..38e0f7c215 100644
 +    // The file format generated, can be xml, json or all for generating both. Defaults to 'all'
 +    outputFormat = "json"
 +    includeConfigs = ["runtimeClasspath"]
-+    // Exclude test components. This list needs to be checked and, if it changed, updated for every new Kafka version.
-+    // The list can be obtained by running `gradle projects | grep upgrade-system-tests`
-+    // The jmh-benchmarks project is not shipped either and pulls in JMH, JUnit and Mockito.
++    // Exclude the projects that are not shipped. This list needs to be checked and, if it changed,
++    // updated for every new Kafka version. The list of projects can be obtained by running
++    // `gradle projects`.
++    //   * jmh-benchmarks pulls in JMH, JUnit and Mockito.
++    //   * generator is a build-time code generator for the message protocol. It pulls in Jackson,
++    //     but its own dependencies never reach the distribution.
++    //   * connect:test-plugins pulls in JGit, Bouncy Castle, Apache MINA sshd and commons-codec,
++    //     none of which are shipped.
 +    skipProjects = [
++      'generator',
 +      'jmh-benchmarks',
++      'test-plugins',
 +      'upgrade-system-tests-0100',
 +      'upgrade-system-tests-0101',
 +      'upgrade-system-tests-0102',

--- a/kafka/stackable/patches/3.9.2/0002-Change-Gradle-to-use-the-Nexus-Build-Repo.patch
+++ b/kafka/stackable/patches/3.9.2/0002-Change-Gradle-to-use-the-Nexus-Build-Repo.patch
@@ -1,4 +1,4 @@
-From 5981533c9e29ac164ac09f9821dd99be2f411c48 Mon Sep 17 00:00:00 2001
+From f195fc9a4b3003edafc1197b421f76e5c710ab76 Mon Sep 17 00:00:00 2001
 From: Lars Francke <git@lars-francke.de>
 Date: Thu, 12 Dec 2024 10:09:47 +0100
 Subject: Change Gradle to use the Nexus Build Repo
@@ -8,7 +8,7 @@ Subject: Change Gradle to use the Nexus Build Repo
  1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/build.gradle b/build.gradle
-index 38e0f7c215..099432834c 100644
+index c4bbde12405..eee73a29454 100644
 --- a/build.gradle
 +++ b/build.gradle
 @@ -20,7 +20,9 @@ import java.nio.charset.StandardCharsets
@@ -22,7 +22,7 @@ index 38e0f7c215..099432834c 100644
    }
    apply from: "$rootDir/gradle/dependencies.gradle"
  
-@@ -170,7 +172,9 @@ ext {
+@@ -177,7 +179,9 @@ ext {
  allprojects {
  
    repositories {

--- a/kafka/stackable/patches/3.9.2/0003-Build-custom-Stackable-version.patch
+++ b/kafka/stackable/patches/3.9.2/0003-Build-custom-Stackable-version.patch
@@ -1,4 +1,4 @@
-From 944ef05a7468a0437c0da923898aecae983eb5f6 Mon Sep 17 00:00:00 2001
+From ba4b38f28330dad8a60a56698bf51c9dbd8e74bf Mon Sep 17 00:00:00 2001
 From: Razvan-Daniel Mihai <84674+razvan@users.noreply.github.com>
 Date: Mon, 1 Jun 2026 08:52:19 +0200
 Subject: Build custom Stackable version
@@ -25,7 +25,7 @@ for d in $(ls -d */); do find $d -type f -exec sed -i 's/3\.9\.2/3.9.2-stackable
  9 files changed, 9 insertions(+), 9 deletions(-)
 
 diff --git a/docs/getting-started/upgrade.md b/docs/getting-started/upgrade.md
-index d7347b3ee8..7f888fc90a 100644
+index d7347b3ee83..7f888fc90a1 100644
 --- a/docs/getting-started/upgrade.md
 +++ b/docs/getting-started/upgrade.md
 @@ -58,7 +58,7 @@ If you are upgrading from version 2.4.0 or above, and you have not overridden th
@@ -38,7 +38,7 @@ index d7347b3ee8..7f888fc90a 100644
    * There is a new server configuration, `alter.config.policy.kraft.compatibility.enable`, which ensures that an AlterConfigPolicy is invoked consistently between KRaft and ZooKeeper modes. To enable this behavior, set the property to `true` in `server.properties`. For backward compatibility, the default value is `false`. See [KIP-1252](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=399279475) for more details.
  
 diff --git a/docs/operations/kraft.md b/docs/operations/kraft.md
-index a63ce05d4e..a8caef2d2b 100644
+index a63ce05d4ed..a8caef2d2bb 100644
 --- a/docs/operations/kraft.md
 +++ b/docs/operations/kraft.md
 @@ -275,7 +275,7 @@ In general, the migration process passes through several phases.
@@ -51,7 +51,7 @@ index a63ce05d4e..a8caef2d2b 100644
  
  
 diff --git a/gradle.properties b/gradle.properties
-index 3c674c89c1..24bf3d2259 100644
+index 3c674c89c1d..24bf3d22593 100644
 --- a/gradle.properties
 +++ b/gradle.properties
 @@ -22,7 +22,7 @@ group=org.apache.kafka
@@ -64,7 +64,7 @@ index 3c674c89c1..24bf3d2259 100644
  # Adding swaggerVersion in gradle.properties to have a single version in place for swagger
  # New version of Swagger 2.2.14 requires minimum JDK 11.
 diff --git a/kafka-merge-pr.py b/kafka-merge-pr.py
-index 4ac7434065..4f5f69d872 100755
+index 4ac7434065c..4f5f69d872b 100755
 --- a/kafka-merge-pr.py
 +++ b/kafka-merge-pr.py
 @@ -70,7 +70,7 @@ TEMP_BRANCH_PREFIX = "PR_TOOL"
@@ -77,7 +77,7 @@ index 4ac7434065..4f5f69d872 100755
  ORIGINAL_HEAD = ""
  
 diff --git a/streams/quickstart/java/pom.xml b/streams/quickstart/java/pom.xml
-index f8d1bd9e54..2ee0861269 100644
+index f8d1bd9e54f..2ee08612691 100644
 --- a/streams/quickstart/java/pom.xml
 +++ b/streams/quickstart/java/pom.xml
 @@ -26,7 +26,7 @@
@@ -90,7 +90,7 @@ index f8d1bd9e54..2ee0861269 100644
      </parent>
  
 diff --git a/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml b/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
-index b62ab64acf..3d3d881096 100644
+index b62ab64acfd..3d3d8810966 100644
 --- a/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
 +++ b/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
 @@ -29,7 +29,7 @@
@@ -103,7 +103,7 @@ index b62ab64acf..3d3d881096 100644
      </properties>
  
 diff --git a/streams/quickstart/pom.xml b/streams/quickstart/pom.xml
-index ac81ea06bb..1686b2bd56 100644
+index ac81ea06bb4..1686b2bd566 100644
 --- a/streams/quickstart/pom.xml
 +++ b/streams/quickstart/pom.xml
 @@ -22,7 +22,7 @@
@@ -116,7 +116,7 @@ index ac81ea06bb..1686b2bd56 100644
      <name>Kafka Streams :: Quickstart</name>
  
 diff --git a/tests/kafkatest/__init__.py b/tests/kafkatest/__init__.py
-index 1362dad9ca..e20c655bbf 100644
+index 1362dad9ca9..e20c655bbf5 100644
 --- a/tests/kafkatest/__init__.py
 +++ b/tests/kafkatest/__init__.py
 @@ -22,4 +22,4 @@
@@ -126,7 +126,7 @@ index 1362dad9ca..e20c655bbf 100644
 -__version__ = '3.9.2'
 +__version__ = '3.9.2-stackable0.0.0-dev'
 diff --git a/tests/kafkatest/version.py b/tests/kafkatest/version.py
-index fa301e6a8d..1980c35d11 100644
+index fa301e6a8dd..1980c35d115 100644
 --- a/tests/kafkatest/version.py
 +++ b/tests/kafkatest/version.py
 @@ -122,7 +122,7 @@ def get_version(node=None):

--- a/kafka/stackable/patches/4.1.1/0001-Add-CycloneDX-plugin.patch
+++ b/kafka/stackable/patches/4.1.1/0001-Add-CycloneDX-plugin.patch
@@ -1,17 +1,17 @@
-From 0f9e14c6a625c20a80381cea71de855e4806fab0 Mon Sep 17 00:00:00 2001
+From 4e266b5eac48e4bbcbc70052f352e961eb27fa5b Mon Sep 17 00:00:00 2001
 From: Malte Sander <malte.sander.it@gmail.com>
 Date: Thu, 25 Sep 2025 10:47:57 +0200
 Subject: Add CycloneDX plugin
 
 ---
- build.gradle | 47 +++++++++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 47 insertions(+)
+ build.gradle | 60 ++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 60 insertions(+)
 
 diff --git a/build.gradle b/build.gradle
-index 97250637b7..49f691ca79 100644
+index 97250637b70..d055befd29b 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -41,6 +41,53 @@ plugins {
+@@ -41,6 +41,66 @@ plugins {
    id 'org.scoverage' version '8.0.3' apply false
    id 'com.gradleup.shadow' version '8.3.6' apply false
    id 'com.diffplug.spotless' version "6.25.0"
@@ -29,16 +29,29 @@ index 97250637b7..49f691ca79 100644
 +    outputName = "bom"
 +    // The file format generated, can be xml, json or all for generating both. Defaults to 'all'
 +    outputFormat = "json"
-+    includeConfigs = ["runtimeClasspath"]
-+    // Exclude test components. This list needs to be checked and, if it changed, updated for every new Kafka version.
-+    // The list can be obtained by running `gradle projects | grep upgrade-system-tests`
-+    // The jmh-benchmarks project is not shipped either and pulls in JMH, JUnit and Mockito,
-+    // and neither are the test-common projects, which pull in JUnit.
++    // The releaseOnly configuration is included as well, because the `core` and `tools` projects
++    // declare the Log4j runtime bindings (log4jReleaseLibs) there instead of on the
++    // runtimeClasspath. They are copied into libs/ by the releaseTarGz task, so they are shipped
++    // and must be part of the SBOM.
++    includeConfigs = ["runtimeClasspath", "releaseOnly"]
++    // Exclude the projects that are not shipped. This list needs to be checked and, if it changed,
++    // updated for every new Kafka version. The list of projects can be obtained by running
++    // `gradle projects`.
++    //   * jmh-benchmarks pulls in JMH, JUnit and Mockito.
++    //   * The test-common projects pull in JUnit.
++    //   * generator is a build-time code generator for the message protocol. It pulls in Jackson,
++    //     but its own dependencies never reach the distribution.
++    //   * The integration test projects and connect:test-plugins pull in JGit, Bouncy Castle,
++    //     Apache MINA sshd and commons-codec, none of which are shipped.
 +    skipProjects = [
++      'clients-integration-tests',
++      'generator',
++      'integration-tests',
 +      'jmh-benchmarks',
 +      'test-common-internal-api',
 +      'test-common-runtime',
 +      'test-common-util',
++      'test-plugins',
 +      'upgrade-system-tests-0110',
 +      'upgrade-system-tests-10',
 +      'upgrade-system-tests-11',

--- a/kafka/stackable/patches/4.1.1/0002-Change-Gradle-to-use-the-Nexus-Build-Repo.patch
+++ b/kafka/stackable/patches/4.1.1/0002-Change-Gradle-to-use-the-Nexus-Build-Repo.patch
@@ -1,4 +1,4 @@
-From 55362f3ede127bf2a0a70ef07a01dca0ada37481 Mon Sep 17 00:00:00 2001
+From a99ac8dcc8ef2877e9ccd5642eafc00076c5f49b Mon Sep 17 00:00:00 2001
 From: Malte Sander <malte.sander.it@gmail.com>
 Date: Thu, 25 Sep 2025 10:50:07 +0200
 Subject: Change Gradle to use the Nexus Build Repo
@@ -8,7 +8,7 @@ Subject: Change Gradle to use the Nexus Build Repo
  1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/build.gradle b/build.gradle
-index 49f691ca79..d0129928db 100644
+index d055befd29b..570da93c9ca 100644
 --- a/build.gradle
 +++ b/build.gradle
 @@ -18,7 +18,9 @@ import java.nio.charset.StandardCharsets
@@ -22,7 +22,7 @@ index 49f691ca79..d0129928db 100644
    }
    apply from: "$rootDir/gradle/dependencies.gradle"
  
-@@ -210,7 +212,9 @@ ext {
+@@ -223,7 +225,9 @@ ext {
  allprojects {
  
    repositories {

--- a/kafka/stackable/patches/4.1.1/0003-Build-custom-Stackable-version.patch
+++ b/kafka/stackable/patches/4.1.1/0003-Build-custom-Stackable-version.patch
@@ -1,4 +1,4 @@
-From a9fbe72e176442b91376cb42b2f263589db57276 Mon Sep 17 00:00:00 2001
+From bb5ffc0aff0c3fee6ba631f9ae337c42c7673fc2 Mon Sep 17 00:00:00 2001
 From: Razvan-Daniel Mihai <84674+razvan@users.noreply.github.com>
 Date: Wed, 14 Jan 2026 12:58:54 +0100
 Subject: Build custom Stackable version
@@ -14,7 +14,7 @@ Subject: Build custom Stackable version
  7 files changed, 8 insertions(+), 7 deletions(-)
 
 diff --git a/committer-tools/kafka-merge-pr.py b/committer-tools/kafka-merge-pr.py
-index 1b181ed1d6..41fac8ba68 100755
+index 1b181ed1d68..41fac8ba680 100755
 --- a/committer-tools/kafka-merge-pr.py
 +++ b/committer-tools/kafka-merge-pr.py
 @@ -70,7 +70,7 @@ TEMP_BRANCH_PREFIX = "PR_TOOL"
@@ -27,7 +27,7 @@ index 1b181ed1d6..41fac8ba68 100755
  ORIGINAL_HEAD = ""
  
 diff --git a/docs/js/templateData.js b/docs/js/templateData.js
-index d63a81b503..5b3ded927b 100644
+index d63a81b503c..5b3ded927b8 100644
 --- a/docs/js/templateData.js
 +++ b/docs/js/templateData.js
 @@ -19,6 +19,6 @@ limitations under the License.
@@ -39,7 +39,7 @@ index d63a81b503..5b3ded927b 100644
      "scalaVersion": "2.13"
  };
 diff --git a/gradle.properties b/gradle.properties
-index 005a86fa63..295ae5bc1f 100644
+index 005a86fa634..295ae5bc1f5 100644
 --- a/gradle.properties
 +++ b/gradle.properties
 @@ -23,7 +23,7 @@ group=org.apache.kafka
@@ -52,7 +52,7 @@ index 005a86fa63..295ae5bc1f 100644
  # Adding swaggerVersion in gradle.properties to have a single version in place for swagger
  swaggerVersion=2.2.25
 diff --git a/streams/quickstart/java/pom.xml b/streams/quickstart/java/pom.xml
-index fc1aad5ee4..0335ea3760 100644
+index fc1aad5ee42..0335ea37603 100644
 --- a/streams/quickstart/java/pom.xml
 +++ b/streams/quickstart/java/pom.xml
 @@ -26,7 +26,7 @@
@@ -65,7 +65,7 @@ index fc1aad5ee4..0335ea3760 100644
      </parent>
  
 diff --git a/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml b/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
-index 4cab1223a7..0688fa4ccb 100644
+index 4cab1223a71..0688fa4ccbb 100644
 --- a/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
 +++ b/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
 @@ -29,7 +29,7 @@
@@ -78,7 +78,7 @@ index 4cab1223a7..0688fa4ccb 100644
      </properties>
  
 diff --git a/streams/quickstart/pom.xml b/streams/quickstart/pom.xml
-index eef0727480..845281cce9 100644
+index eef0727480e..845281cce93 100644
 --- a/streams/quickstart/pom.xml
 +++ b/streams/quickstart/pom.xml
 @@ -22,7 +22,8 @@
@@ -92,7 +92,7 @@ index eef0727480..845281cce9 100644
      <name>Kafka Streams :: Quickstart</name>
  
 diff --git a/tests/kafkatest/__init__.py b/tests/kafkatest/__init__.py
-index 9484aec27d..213f9eb9aa 100644
+index 9484aec27d7..213f9eb9aac 100644
 --- a/tests/kafkatest/__init__.py
 +++ b/tests/kafkatest/__init__.py
 @@ -22,4 +22,4 @@

--- a/kafka/stackable/patches/4.1.1/0004-Include-jackson-dataformat-xml-dependency.patch
+++ b/kafka/stackable/patches/4.1.1/0004-Include-jackson-dataformat-xml-dependency.patch
@@ -1,4 +1,4 @@
-From 5d5829e4beb6454515eb7c7747aff508f9573028 Mon Sep 17 00:00:00 2001
+From 988f35e5eda25dd58a822b9e184c697238d495d1 Mon Sep 17 00:00:00 2001
 From: Malte Sander <malte.sander.it@gmail.com>
 Date: Thu, 25 Sep 2025 11:13:20 +0200
 Subject: Include jackson dataformat xml dependency
@@ -9,10 +9,10 @@ Subject: Include jackson dataformat xml dependency
  2 files changed, 15 insertions(+), 1 deletion(-)
 
 diff --git a/build.gradle b/build.gradle
-index d0129928db..518ab172d1 100644
+index 570da93c9ca..d99908185c9 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -186,13 +186,15 @@ ext {
+@@ -199,13 +199,15 @@ ext {
      libs.slf4jLog4j2,
      libs.junitPlatformLanucher,
      libs.jacksonDatabindYaml,
@@ -29,7 +29,7 @@ index d0129928db..518ab172d1 100644
    ]
  
    log4j2Libs = [
-@@ -1072,6 +1074,7 @@ project(':core') {
+@@ -1085,6 +1087,7 @@ project(':core') {
      implementation libs.jacksonDataformatCsv
      implementation libs.jacksonJDK8Datatypes
      implementation libs.jacksonDatabindYaml
@@ -37,7 +37,7 @@ index d0129928db..518ab172d1 100644
      implementation libs.joptSimple
      implementation libs.jose4j
      implementation libs.metrics
-@@ -1490,6 +1493,7 @@ project(':group-coordinator') {
+@@ -1503,6 +1506,7 @@ project(':group-coordinator') {
      testImplementation project(':server-common').sourceSets.test.output
      testImplementation project(':coordinator-common').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -45,7 +45,7 @@ index d0129928db..518ab172d1 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoCore
      testImplementation testLog4j2Libs
-@@ -1612,6 +1616,7 @@ project(':test-common:test-common-runtime') {
+@@ -1625,6 +1629,7 @@ project(':test-common:test-common-runtime') {
      implementation libs.junitPlatformLanucher
      implementation libs.junitJupiter
      implementation libs.jacksonDatabindYaml
@@ -53,7 +53,7 @@ index d0129928db..518ab172d1 100644
      implementation libs.slf4jApi
  
      testImplementation libs.junitJupiter
-@@ -2085,6 +2090,7 @@ project(':raft') {
+@@ -2098,6 +2103,7 @@ project(':raft') {
      testImplementation project(':clients')
      testImplementation project(':clients').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -61,7 +61,7 @@ index d0129928db..518ab172d1 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoCore
      testImplementation libs.jqwik
-@@ -2182,6 +2188,7 @@ project(':server-common') {
+@@ -2195,6 +2201,7 @@ project(':server-common') {
      testImplementation project(':clients')
      testImplementation project(':clients').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -69,7 +69,7 @@ index d0129928db..518ab172d1 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoCore
      testImplementation testLog4j2Libs
-@@ -2323,6 +2330,7 @@ project(':storage') {
+@@ -2336,6 +2343,7 @@ project(':storage') {
      testImplementation project(':transaction-coordinator')
      testImplementation libs.hamcrest
      testImplementation libs.jacksonDatabindYaml
@@ -77,7 +77,7 @@ index d0129928db..518ab172d1 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoCore
      testImplementation libs.bcpkix
-@@ -2640,6 +2648,7 @@ project(':shell') {
+@@ -2653,6 +2661,7 @@ project(':shell') {
      testImplementation project(':server-common')
      testImplementation project(':server-common').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -85,7 +85,7 @@ index d0129928db..518ab172d1 100644
      testImplementation libs.junitJupiter
      testImplementation testLog4j2Libs
  
-@@ -2689,6 +2698,7 @@ project(':streams') {
+@@ -2702,6 +2711,7 @@ project(':streams') {
  
      testImplementation project(':clients').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -93,7 +93,7 @@ index d0129928db..518ab172d1 100644
      testImplementation libs.junitJupiter
      testImplementation libs.bcpkix
      testImplementation libs.hamcrest
-@@ -2834,6 +2844,7 @@ project(':streams:streams-scala') {
+@@ -2847,6 +2857,7 @@ project(':streams:streams-scala') {
      testImplementation project(':streams:test-utils')
  
      testImplementation libs.jacksonDatabindYaml
@@ -101,7 +101,7 @@ index d0129928db..518ab172d1 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoJunitJupiter // supports MockitoExtension
      testImplementation testLog4j2Libs
-@@ -2938,6 +2949,7 @@ project(':streams:test-utils') {
+@@ -2951,6 +2962,7 @@ project(':streams:test-utils') {
  
      testImplementation project(':clients').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -109,7 +109,7 @@ index d0129928db..518ab172d1 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoCore
      testImplementation libs.hamcrest
-@@ -3616,6 +3628,7 @@ project(':connect:runtime') {
+@@ -3629,6 +3641,7 @@ project(':connect:runtime') {
      testImplementation project(':server-common').sourceSets.test.output
  
      testImplementation libs.jacksonDatabindYaml
@@ -118,7 +118,7 @@ index d0129928db..518ab172d1 100644
      testImplementation libs.mockitoCore
      testImplementation libs.mockitoJunitJupiter
 diff --git a/gradle/dependencies.gradle b/gradle/dependencies.gradle
-index 10173814e5..1a8c1bac15 100644
+index 10173814e53..1a8c1bac159 100644
 --- a/gradle/dependencies.gradle
 +++ b/gradle/dependencies.gradle
 @@ -156,6 +156,7 @@ libs += [

--- a/kafka/stackable/patches/4.2.1/0001-Add-CycloneDX-plugin.patch
+++ b/kafka/stackable/patches/4.2.1/0001-Add-CycloneDX-plugin.patch
@@ -1,17 +1,17 @@
-From 3022c3cdb6f0b0240b73618a5fa1686256222aeb Mon Sep 17 00:00:00 2001
+From e68a1a6a0930f33955bd58d4db4c918d61673d06 Mon Sep 17 00:00:00 2001
 From: Razvan-Daniel Mihai <84674+razvan@users.noreply.github.com>
 Date: Wed, 13 May 2026 16:30:33 +0300
 Subject: Add CycloneDX plugin
 
 ---
- build.gradle | 58 ++++++++++++++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 58 insertions(+)
+ build.gradle | 71 ++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 71 insertions(+)
 
 diff --git a/build.gradle b/build.gradle
-index c07cd3b047..d3f7632f56 100644
+index c07cd3b047e..59d6ba397ce 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -41,8 +41,66 @@ plugins {
+@@ -41,8 +41,79 @@ plugins {
    id 'org.scoverage' version '8.1' apply false
    id 'com.gradleup.shadow' version '8.3.9' apply false
    id 'com.diffplug.spotless' version "8.0.0"
@@ -31,18 +31,31 @@ index c07cd3b047..d3f7632f56 100644
 +// Without this the SBOM also contains the test and build tooling (JUnit, Mockito, JaCoCo,
 +// SpotBugs, Checkstyle, ...). It has to be configured on the per-project `cyclonedxDirectBom`
 +// tasks, the `cyclonedxBom` extension above only configures the aggregation.
++// The releaseOnly configuration is included as well, because the `core` and `tools` projects
++// declare the Log4j runtime bindings (log4jReleaseLibs) there instead of on the
++// runtimeClasspath. They are copied into libs/ by the releaseTarGz task, so they are shipped
++// and must be part of the SBOM.
 +allprojects {
 +  tasks.matching { it.name == 'cyclonedxDirectBom' }.configureEach {
-+    includeConfigs = ['runtimeClasspath']
++    includeConfigs = ['runtimeClasspath', 'releaseOnly']
 +  }
 +}
 +
-+// Exclude test components. This list needs to be checked and, if it changed, updated for every new Kafka version.
-+// The list can be obtained by running `gradle projects | grep upgrade-system-tests`
-+// The jmh-benchmarks project is not shipped either and pulls in JMH and the test fixtures.
-+// The same is true for the test-common projects, which pull in JUnit.
++// Exclude the projects that are not shipped. This list needs to be checked and, if it changed,
++// updated for every new Kafka version. The list of projects can be obtained by running
++// `gradle projects`.
++//   * jmh-benchmarks pulls in JMH and the test fixtures.
++//   * The test-common projects pull in JUnit.
++//   * generator is a build-time code generator for the message protocol. It pulls in Jackson,
++//     but its own dependencies never reach the distribution.
++//   * The integration test projects and connect:test-plugins pull in JGit, Bouncy Castle,
++//     Apache MINA sshd and commons-codec, none of which are shipped.
 +def skipCyclonedxProjects = [
++  ':clients:clients-integration-tests',
++  ':connect:test-plugins',
++  ':generator',
 +  ':jmh-benchmarks',
++  ':streams:integration-tests',
 +  ':streams:upgrade-system-tests-0110',
 +  ':streams:upgrade-system-tests-10',
 +  ':streams:upgrade-system-tests-11',

--- a/kafka/stackable/patches/4.2.1/0002-Change-Gradle-to-use-the-Nexus-Build-Repo.patch
+++ b/kafka/stackable/patches/4.2.1/0002-Change-Gradle-to-use-the-Nexus-Build-Repo.patch
@@ -1,4 +1,4 @@
-From 2fa68a6a66b5a415c1d3e495d5991efb79fd2254 Mon Sep 17 00:00:00 2001
+From c15728bc395dae8cde0ee9f51051aa2c7cfc805e Mon Sep 17 00:00:00 2001
 From: Razvan-Daniel Mihai <84674+razvan@users.noreply.github.com>
 Date: Wed, 13 May 2026 16:31:44 +0300
 Subject: Change Gradle to use the Nexus Build Repo
@@ -8,7 +8,7 @@ Subject: Change Gradle to use the Nexus Build Repo
  1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/build.gradle b/build.gradle
-index d3f7632f56..64334779e9 100644
+index 59d6ba397ce..4f1bed49551 100644
 --- a/build.gradle
 +++ b/build.gradle
 @@ -18,7 +18,9 @@ import java.nio.charset.StandardCharsets
@@ -22,7 +22,7 @@ index d3f7632f56..64334779e9 100644
    }
    apply from: "$rootDir/gradle/dependencies.gradle"
  
-@@ -225,7 +227,9 @@ ext {
+@@ -238,7 +240,9 @@ ext {
  allprojects {
  
    repositories {

--- a/kafka/stackable/patches/4.2.1/0003-Build-custom-Stackable-version.patch
+++ b/kafka/stackable/patches/4.2.1/0003-Build-custom-Stackable-version.patch
@@ -1,4 +1,4 @@
-From 915f1d9eb9c1fd7bf9c15a52a353c33475efa6a3 Mon Sep 17 00:00:00 2001
+From c2ff746b538ea611d8a3859e4a36d251dc38a492 Mon Sep 17 00:00:00 2001
 From: Razvan-Daniel Mihai <84674+razvan@users.noreply.github.com>
 Date: Fri, 29 May 2026 17:33:00 +0200
 Subject: Build custom Stackable version
@@ -25,7 +25,7 @@ for d in $(ls -d */); do find $d -type f -exec sed -i
  7 files changed, 7 insertions(+), 7 deletions(-)
 
 diff --git a/committer-tools/kafka-merge-pr.py b/committer-tools/kafka-merge-pr.py
-index 92dabc607c..5611a8beeb 100755
+index 92dabc607ca..5611a8beebe 100755
 --- a/committer-tools/kafka-merge-pr.py
 +++ b/committer-tools/kafka-merge-pr.py
 @@ -70,7 +70,7 @@ TEMP_BRANCH_PREFIX = "PR_TOOL"
@@ -38,7 +38,7 @@ index 92dabc607c..5611a8beeb 100755
  ORIGINAL_HEAD = ""
  
 diff --git a/gradle.properties b/gradle.properties
-index 8dad15054c..27c124ca21 100644
+index 8dad15054c0..27c124ca215 100644
 --- a/gradle.properties
 +++ b/gradle.properties
 @@ -14,7 +14,7 @@
@@ -51,7 +51,7 @@ index 8dad15054c..27c124ca21 100644
  # Adding swaggerVersion in gradle.properties to have a single version in place for swagger
  swaggerVersion=2.2.39
 diff --git a/streams/quickstart/java/pom.xml b/streams/quickstart/java/pom.xml
-index 4930378053..41b602f98e 100644
+index 4930378053d..41b602f98ef 100644
 --- a/streams/quickstart/java/pom.xml
 +++ b/streams/quickstart/java/pom.xml
 @@ -26,7 +26,7 @@
@@ -64,7 +64,7 @@ index 4930378053..41b602f98e 100644
      </parent>
  
 diff --git a/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml b/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
-index e78fa54f59..bd440c365d 100644
+index e78fa54f59e..bd440c365d8 100644
 --- a/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
 +++ b/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
 @@ -29,7 +29,7 @@
@@ -77,7 +77,7 @@ index e78fa54f59..bd440c365d 100644
      </properties>
  
 diff --git a/streams/quickstart/pom.xml b/streams/quickstart/pom.xml
-index de77049571..3964d486e1 100644
+index de770495715..3964d486e18 100644
 --- a/streams/quickstart/pom.xml
 +++ b/streams/quickstart/pom.xml
 @@ -22,7 +22,7 @@
@@ -90,7 +90,7 @@ index de77049571..3964d486e1 100644
      <name>Kafka Streams :: Quickstart</name>
  
 diff --git a/tests/kafkatest/__init__.py b/tests/kafkatest/__init__.py
-index 49861a2ef2..2f50efe072 100644
+index 49861a2ef23..2f50efe072c 100644
 --- a/tests/kafkatest/__init__.py
 +++ b/tests/kafkatest/__init__.py
 @@ -22,4 +22,4 @@
@@ -100,7 +100,7 @@ index 49861a2ef2..2f50efe072 100644
 -__version__ = '4.2.1'
 +__version__ = '4.2.1-stackable0.0.0-dev'
 diff --git a/tests/kafkatest/version.py b/tests/kafkatest/version.py
-index d0297f10f9..10474bdf43 100644
+index d0297f10f9d..10474bdf43c 100644
 --- a/tests/kafkatest/version.py
 +++ b/tests/kafkatest/version.py
 @@ -128,7 +128,7 @@ def get_version(node=None):

--- a/kafka/stackable/patches/4.2.1/0004-Include-jackson-dataformat-xml-dependency.patch
+++ b/kafka/stackable/patches/4.2.1/0004-Include-jackson-dataformat-xml-dependency.patch
@@ -1,4 +1,4 @@
-From 8bb5e2b9bb18a19b92c1f6e45571f99a8c0642f2 Mon Sep 17 00:00:00 2001
+From bfe4022af49a7c248f5f258e4bac0581c14b2691 Mon Sep 17 00:00:00 2001
 From: Razvan-Daniel Mihai <84674+razvan@users.noreply.github.com>
 Date: Fri, 29 May 2026 17:43:58 +0200
 Subject: Include jackson dataformat xml dependency
@@ -11,10 +11,10 @@ build.gradle
  2 files changed, 15 insertions(+), 1 deletion(-)
 
 diff --git a/build.gradle b/build.gradle
-index 64334779e9..bd4a2a1800 100644
+index 4f1bed49551..104f876574a 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -201,13 +201,15 @@ ext {
+@@ -214,13 +214,15 @@ ext {
      libs.slf4jLog4j2,
      libs.junitPlatformLanucher,
      libs.jacksonDatabindYaml,
@@ -31,7 +31,7 @@ index 64334779e9..bd4a2a1800 100644
    ]
  
    log4j2Libs = [
-@@ -1135,6 +1137,7 @@ project(':core') {
+@@ -1148,6 +1150,7 @@ project(':core') {
      implementation libs.jacksonDataformatCsv
      implementation libs.jacksonJDK8Datatypes
      implementation libs.jacksonDatabindYaml
@@ -39,7 +39,7 @@ index 64334779e9..bd4a2a1800 100644
      implementation libs.joptSimple
      implementation libs.jose4j
      implementation libs.metrics
-@@ -1550,6 +1553,7 @@ project(':group-coordinator') {
+@@ -1563,6 +1566,7 @@ project(':group-coordinator') {
      testImplementation project(':server-common').sourceSets.test.output
      testImplementation project(':coordinator-common').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -47,7 +47,7 @@ index 64334779e9..bd4a2a1800 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoCore
      testImplementation testLog4j2Libs
-@@ -1672,6 +1676,7 @@ project(':test-common:test-common-runtime') {
+@@ -1685,6 +1689,7 @@ project(':test-common:test-common-runtime') {
      implementation libs.junitPlatformLanucher
      implementation libs.junitJupiter
      implementation libs.jacksonDatabindYaml
@@ -55,7 +55,7 @@ index 64334779e9..bd4a2a1800 100644
      implementation libs.slf4jApi
  
      testImplementation libs.junitJupiter
-@@ -2146,6 +2151,7 @@ project(':raft') {
+@@ -2159,6 +2164,7 @@ project(':raft') {
      testImplementation project(':clients')
      testImplementation project(':clients').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -63,7 +63,7 @@ index 64334779e9..bd4a2a1800 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoCore
      testImplementation libs.jqwik
-@@ -2243,6 +2249,7 @@ project(':server-common') {
+@@ -2256,6 +2262,7 @@ project(':server-common') {
      testImplementation project(':clients')
      testImplementation project(':clients').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -71,7 +71,7 @@ index 64334779e9..bd4a2a1800 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoCore
      testImplementation testLog4j2Libs
-@@ -2384,6 +2391,7 @@ project(':storage') {
+@@ -2397,6 +2404,7 @@ project(':storage') {
      testImplementation project(':transaction-coordinator')
      testImplementation libs.hamcrest
      testImplementation libs.jacksonDatabindYaml
@@ -79,7 +79,7 @@ index 64334779e9..bd4a2a1800 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoCore
      testImplementation libs.bcpkix
-@@ -2702,6 +2710,7 @@ project(':shell') {
+@@ -2715,6 +2723,7 @@ project(':shell') {
      testImplementation project(':server-common')
      testImplementation project(':server-common').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -87,7 +87,7 @@ index 64334779e9..bd4a2a1800 100644
      testImplementation libs.junitJupiter
      testImplementation testLog4j2Libs
  
-@@ -2751,6 +2760,7 @@ project(':streams') {
+@@ -2764,6 +2773,7 @@ project(':streams') {
  
      testImplementation project(':clients').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -95,7 +95,7 @@ index 64334779e9..bd4a2a1800 100644
      testImplementation libs.junitJupiter
      testImplementation libs.bcpkix
      testImplementation libs.hamcrest
-@@ -2896,6 +2906,7 @@ project(':streams:streams-scala') {
+@@ -2909,6 +2919,7 @@ project(':streams:streams-scala') {
      testImplementation project(':streams:test-utils')
  
      testImplementation libs.jacksonDatabindYaml
@@ -103,7 +103,7 @@ index 64334779e9..bd4a2a1800 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoJunitJupiter // supports MockitoExtension
      testImplementation testLog4j2Libs
-@@ -3000,6 +3011,7 @@ project(':streams:test-utils') {
+@@ -3013,6 +3024,7 @@ project(':streams:test-utils') {
  
      testImplementation project(':clients').sourceSets.test.output
      testImplementation libs.jacksonDatabindYaml
@@ -111,7 +111,7 @@ index 64334779e9..bd4a2a1800 100644
      testImplementation libs.junitJupiter
      testImplementation libs.mockitoCore
      testImplementation libs.hamcrest
-@@ -3695,6 +3707,7 @@ project(':connect:runtime') {
+@@ -3708,6 +3720,7 @@ project(':connect:runtime') {
      testImplementation project(':server-common').sourceSets.test.output
  
      testImplementation libs.jacksonDatabindYaml
@@ -120,7 +120,7 @@ index 64334779e9..bd4a2a1800 100644
      testImplementation libs.mockitoCore
      testImplementation libs.mockitoJunitJupiter
 diff --git a/gradle/dependencies.gradle b/gradle/dependencies.gradle
-index de63116795..19d4117dca 100644
+index de631167958..19d4117dcab 100644
 --- a/gradle/dependencies.gradle
 +++ b/gradle/dependencies.gradle
 @@ -159,6 +159,7 @@ libs += [

--- a/opensearch-dashboards/Dockerfile
+++ b/opensearch-dashboards/Dockerfile
@@ -197,8 +197,16 @@ EOF
 
 # --spec-version is passed explicitly because cdxgen changes its default between
 # releases. The value is a global build argument, see boil.toml.
-# --required-only restricts the SBOM to the runtime dependencies.
-RUN PATH="/opt/node-cdxgen/bin:$PATH" cdxgen --target yarn --required-only --json-pretty --spec-version "${CDXGEN_SPEC_VERSION}"
+# --type js restricts cdxgen to the JavaScript ecosystem. Without it, cdxgen
+# auto-detects every ecosystem it finds in the source tree and also reports the
+# GitHub Actions workflows, Gradle and Python files of the build tooling.
+# --no-babel disables the Babel based usage analysis, which is not needed for a
+# dependency inventory.
+# Note: --required-only is not passed. cdxgen marks every package read from a
+# yarn.lock as "required", because the Yarn 1 lockfile does not record whether a
+# dependency is a devDependency, so the flag would have no effect here but would
+# set `compositions.aggregate` to `incomplete`.
+RUN PATH="/opt/node-cdxgen/bin:$PATH" cdxgen --type js --no-babel --json-pretty --spec-version "${CDXGEN_SPEC_VERSION}"
 
 RUN <<EOF
 # Change the group permissions already in the builder image to reduce

--- a/opensearch/stackable/patches/3.1.0/0005-Scope-CycloneDX-SBOM-to-shipped-components-only.patch
+++ b/opensearch/stackable/patches/3.1.0/0005-Scope-CycloneDX-SBOM-to-shipped-components-only.patch
@@ -1,4 +1,4 @@
-From b0fd24f0b5361718e5d479b692ba4e20e23082da Mon Sep 17 00:00:00 2001
+From 7469915d465acd03e09cc6400941b20713e4f4d2 Mon Sep 17 00:00:00 2001
 From: dervoeti <lukas.krug@stackable.tech>
 Date: Thu, 26 Mar 2026 20:51:26 +0000
 Subject: Scope CycloneDX SBOM to shipped components only
@@ -9,14 +9,14 @@ telemetry-otel are shipped from the local build. Other plugins like
 ingest-attachment (which pulls in tika-core) are not installed in the
 Stackable image and should not appear in the runtime SBOM.
 ---
- build.gradle | 17 +++++++++++++++++
- 1 file changed, 17 insertions(+)
+ build.gradle | 34 ++++++++++++++++++++++++++++++++++
+ 1 file changed, 34 insertions(+)
 
 diff --git a/build.gradle b/build.gradle
-index 78a15b418e7..b351ece8700 100644
+index 78a15b418e7..b8cbb13be3d 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -78,6 +78,23 @@ allprojects {
+@@ -78,6 +78,40 @@ allprojects {
  }
  
  cyclonedxBom {
@@ -28,14 +28,31 @@ index 78a15b418e7..b351ece8700 100644
 +  // The test framework, the test fixtures, the QA projects and the benchmarks are not
 +  // shipped either and are the only source of JUnit, Mockito, Hamcrest, randomizedtesting
 +  // and JMH in the SBOM.
++  // The build-tools project (buildSrc) is not shipped either. It resolves the Gradle build
++  // classpath, which adds Ant, Apache Rat, forbiddenapis, the Nebula and Shadow Gradle
++  // plugins and the JGit/SVNKit stack of grgit to the SBOM. Worse, it pulls in its own
++  // versions of libraries that are also shipped (for example Log4j and ASM), so the SBOM
++  // ends up asserting versions that are not in the image.
++  // Note that :distribution must not be excluded. The launchers and CLI tools under
++  // :distribution:tools are shipped in lib/tools.
 +  def shippedPlugins = ['repository-s3', 'telemetry-otel'] as Set
 +  skipProjects = subprojects.findAll { sub ->
 +    (sub.path.startsWith(':plugins:') && !(sub.name in shippedPlugins)) ||
 +    sub.path.startsWith(':example-plugins') ||
++    sub.path == ':build-tools' ||
++    sub.path.startsWith(':build-tools:') ||
++    sub.path == ':test' ||
 +    sub.path.startsWith(':test:') ||
 +    sub.path.startsWith(':qa') ||
 +    sub.path == ':benchmarks' ||
-+    sub.path == ':client:test'
++    sub.path == ':client:test' ||
++    sub.path == ':client:benchmark' ||
++    sub.path == ':client:client-benchmark-noop-api-plugin' ||
++    sub.path == ':client:sniffer' ||
++    sub.path.startsWith(':sandbox') ||
++    sub.path == ':docs' ||
++    sub.path == ':doc-tools' ||
++    sub.path == ':rest-api-spec'
 +  }.collect { it.name }
    includeConfigs = ["runtimeClasspath"]
    includeLicenseText = false

--- a/opensearch/stackable/patches/3.4.0/0005-Scope-CycloneDX-SBOM-to-shipped-components-only.patch
+++ b/opensearch/stackable/patches/3.4.0/0005-Scope-CycloneDX-SBOM-to-shipped-components-only.patch
@@ -1,4 +1,4 @@
-From d855d718ce9ff7c31ea9e7e24f167b61128aecfe Mon Sep 17 00:00:00 2001
+From bcbaaa67c14cff600128ddc5b88da30048642ca6 Mon Sep 17 00:00:00 2001
 From: dervoeti <lukas.krug@stackable.tech>
 Date: Thu, 26 Mar 2026 21:05:47 +0000
 Subject: Scope CycloneDX SBOM to shipped components only
@@ -9,14 +9,14 @@ telemetry-otel are shipped from the local build. Other plugins like
 ingest-attachment (which pulls in tika-core) are not installed in the
 Stackable image and should not appear in the runtime SBOM.
 ---
- build.gradle | 22 ++++++++++++++++++++++
- 1 file changed, 22 insertions(+)
+ build.gradle | 39 +++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 39 insertions(+)
 
 diff --git a/build.gradle b/build.gradle
-index 49d3b971efa..6763cdfee48 100644
+index 49d3b971efa..d10aa4d298f 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -82,6 +82,28 @@ allprojects {
+@@ -82,6 +82,45 @@ allprojects {
    version = VersionProperties.getOpenSearch()
    description = "OpenSearch subproject ${project.path}"
  
@@ -28,13 +28,30 @@ index 49d3b971efa..6763cdfee48 100644
 +  // The test framework, the test fixtures, the QA projects and the benchmarks are not
 +  // shipped either and are the only source of JUnit, Mockito, Hamcrest, randomizedtesting
 +  // and JMH in the SBOM.
++  // The build-tools project (buildSrc) is not shipped either. It resolves the Gradle build
++  // classpath, which adds Ant, Apache Rat, forbiddenapis, the Nebula and Shadow Gradle
++  // plugins and the JGit/SVNKit stack of grgit to the SBOM. Worse, it pulls in its own
++  // versions of libraries that are also shipped (for example Log4j and ASM), so the SBOM
++  // ends up asserting versions that are not in the image.
++  // Note that :distribution must not be excluded. The launchers and CLI tools under
++  // :distribution:tools are shipped in lib/tools.
 +  def shippedPlugins = ['repository-s3', 'telemetry-otel'] as Set
 +  def isUnshipped = (project.path.startsWith(':plugins:') && !(project.name in shippedPlugins)) ||
 +                    project.path.startsWith(':example-plugins') ||
++                    project.path == ':build-tools' ||
++                    project.path.startsWith(':build-tools:') ||
++                    project.path == ':test' ||
 +                    project.path.startsWith(':test:') ||
 +                    project.path.startsWith(':qa') ||
 +                    project.path == ':benchmarks' ||
-+                    project.path == ':client:test'
++                    project.path == ':client:test' ||
++                    project.path == ':client:benchmark' ||
++                    project.path == ':client:client-benchmark-noop-api-plugin' ||
++                    project.path == ':client:sniffer' ||
++                    project.path.startsWith(':sandbox') ||
++                    project.path == ':docs' ||
++                    project.path == ':doc-tools' ||
++                    project.path == ':rest-api-spec'
 +
 +  if (isUnshipped) {
 +    tasks.matching { it.name == 'cyclonedxDirectBom' }.configureEach {

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -237,10 +237,21 @@ uv pip install --python /tmp/sbom-venv/bin/python --no-cache-dir cyclonedx-bom==
     /stackable/app
 rm -rf /tmp/sbom-venv
 
-# Add the missing purl to the Superset package. It is installed from a locally built wheel, so
-# cyclonedx-py records the file URL of that wheel instead of a purl.
-jq '.components |= map(if (.purl | not) and (.name | test("^apache[-_]superset")) then
-    .purl = "pkg:pypi/" + (.name | ascii_downcase | gsub("[-_.]+"; "-")) + "@" + .version
+# Post-process the SBOM:
+#   * Add the missing purls. Packages that are installed from a locally built wheel
+#     (apache-superset, opa-authorizer) get no purl from cyclonedx-py, because it records the
+#     file URL of that wheel instead. Without a purl they show up twice in the image SBOM.
+#   * Normalize the names in the purls as defined in the Python packaging specification.
+#     cyclonedx-py keeps the name as it is written in the metadata (`pkg:pypi/zope.event`),
+#     while Syft normalizes it (`pkg:pypi/zope-event`), which again results in duplicates.
+jq 'def normalize_name: ascii_downcase | gsub("[-_.]+"; "-");
+.components |= map(if (.purl | not) and (.name != null) and (.version != null) then
+    .purl = "pkg:pypi/" + (.name | normalize_name) + "@" + .version
+else
+    .
+end
+| if (.purl // "") | startswith("pkg:pypi/") then
+    .purl |= sub("^pkg:pypi/(?<name>[^@]+)"; "pkg:pypi/" + (.name | normalize_name))
 else
     .
 end)' /tmp/sbom.json > /stackable/app/superset-${PRODUCT_VERSION}.cdx.json


### PR DESCRIPTION
# Description

Follow-up to #1630. While verifying the resulting image SBOMs, a few of the changes there turned out
to be incomplete, ineffective or to have removed too much.

OpenSearch Dashboards: `--target yarn` is not a cdxgen option, cdxgen silently ignored it and auto-detected every ecosystem in the source tree, so the GitHub Actions workflows and the Gradle and Python files of the build tooling ended up in the SBOM. 

Kafka `4.1.1` and `4.2.1`: `includeConfigs` now also contains `releaseOnly`, a few components were shipped without being in the SBOM.

Kafka (all versions): additionally skips `generator`, the integration test projects and `connect:test-plugins`.

OpenSearch `3.1.0` and `3.4.0`: additionally skip `build-tools` and the remaining unshipped projects (`sandbox`, `docs`, `doc-tools`, `rest-api-spec`, the client benchmarks and `client:sniffer`).

Airflow and Superset: the purl fix from #1630 only covered the Airflow and Superset packages themselves. It now applies to every package without a purl (`opa-auth-manager`, `opa-authorizer`, `pip`), and the names in all pypi purls are normalized as defined in the Python packaging specification. cyclonedx-py keeps the name as written in the metadata (`pkg:pypi/zope.event`) while Syft normalizes it (`pkg:pypi/zope-event`), which was another source of duplicates in the image SBOM.

## Definition of Done Checklist

> [!NOTE]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant.

Please make sure all these things are done and tick the boxes

- [ ] Changes are OpenShift compatible
- [ ] All added packages (via microdnf or otherwise) have a comment on why they are added
- [ ] Things not downloaded from Red Hat repositories should be mirrored in the Stackable repository and downloaded from there
- [ ] All packages should have (if available) signatures/hashes verified
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Integration tests ran successfully

<details>
<summary>TIP: Running integration tests with a new product image</summary>

The image can be built and uploaded to the kind cluster with the following commands:

```shell
boil build <IMAGE> --image-version <RELEASE_VERSION> --strip-architecture --load
kind load docker-image <MANIFEST_URI> --name=<name-of-your-test-cluster>
```

See the output of `boil` to retrieve the image manifest URI for `<MANIFEST_URI>`.
</details>
